### PR TITLE
Add function to generate 16-bit LUTs from gamma

### DIFF
--- a/Src/libCZI/libCZI_Utilities.h
+++ b/Src/libCZI/libCZI_Utilities.h
@@ -67,7 +67,7 @@ namespace libCZI
 		/// \param whitePoint	   The white point.
 		/// \param gamma		   The gamma.
 		///
-		/// \return The new 8-bit look up table generated from the spline. The number is elements is as specified by <tt>tableElementCount</tt>.
+		/// \return The new 8-bit look up table generated from the gamma value. The number is elements is as specified by <tt>tableElementCount</tt>.
 		static std::vector<std::uint8_t> Create8BitLookUpTableFromGamma(int tableElementCnt, float blackPoint, float whitePoint, float gamma);
 
 		/// Creates 16-bit look-up table from the specified gamma value.

--- a/Src/libCZI/libCZI_Utilities.h
+++ b/Src/libCZI/libCZI_Utilities.h
@@ -70,6 +70,17 @@ namespace libCZI
 		/// \return The new 8-bit look up table generated from the spline. The number is elements is as specified by <tt>tableElementCount</tt>.
 		static std::vector<std::uint8_t> Create8BitLookUpTableFromGamma(int tableElementCnt, float blackPoint, float whitePoint, float gamma);
 
+		/// Creates 16-bit look-up table from the specified gamma value.
+		/// An exponential with the specified gamma is sampled between \c blackPoint and \c whitePoint (i. e. points left of \c blackPoint are set to 0
+		/// and right of \c whitePoint are set to 1).
+		/// \param tableElementCnt Number of points to sample - the result will have as many samples as specified here.
+		/// \param blackPoint	   The black point.
+		/// \param whitePoint	   The white point.
+		/// \param gamma		   The gamma.
+		///
+		/// \return The new 16-bit look up table generated from the gamma value. The number is elements is as specified by <tt>tableElementCount</tt>.
+		static std::vector<std::uint16_t> Create16BitLookUpTableFromGamma(int tableElementCnt, float blackPoint, float whitePoint, float gamma);
+
 		/// Calculates the spline coefficients from a list of control points.
 		/// \param pointCnt Number of control points.
 		/// \param getPoint A functor which will be used to retrieve the control point's coordinates.

--- a/Src/libCZI_UnitTests/test_LUT.cpp
+++ b/Src/libCZI_UnitTests/test_LUT.cpp
@@ -21,6 +21,31 @@ static bool CompareWithMargin(const std::uint8_t* p1, const std::uint8_t* p2, si
 	return true;
 }
 
+// Compares a generated 16-bit LUT to a 8-bit expected result
+static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2)
+{
+	for (size_t i = 0; i < 255 * 256; ++i)
+	{
+		const auto prev8bit = p2[i / 256];
+		const auto next8bit = p2[i / 256 + 1];
+		const auto corresponding8bit = std::round(p1[i] / 256.0);
+		if (prev8bit > next8bit)
+		{
+			return false;
+		}
+		if (corresponding8bit < prev8bit)
+		{
+			return false;
+		}
+		if (corresponding8bit > next8bit)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 TEST(LUTGeneration, Gamma1)
 {
 	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, 0.58f);
@@ -42,6 +67,11 @@ TEST(LUTGeneration, Gamma1)
 	// allow for a difference of 1 (rounding is not yet the same as in the original code, need to look into this...)
 	bool isCorrect = CompareWithMargin(&gammaLutTest[0], ExpectedResult, 256, 1);
 	EXPECT_TRUE(isCorrect) << "Incorrect result";
+
+	// test that the 16-bit result is basically the same
+	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, 0.58f);
+	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult);
+	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 }
 
 TEST(LUTGeneration, Gamma2)
@@ -66,6 +96,11 @@ TEST(LUTGeneration, Gamma2)
 	// allow for a difference of 1 (rounding is not yet the same as in the original code, need to look into this...)
 	bool isCorrect = CompareWithMargin(&gammaLutTest[0], ExpectedResult, 256, 1);
 	EXPECT_TRUE(isCorrect) << "Incorrect result";
+
+	// test that the 16-bit result is basically the same
+	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, 1.58f);
+	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult);
+	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 }
 
 TEST(LUTGeneration, Splines1)

--- a/Src/libCZI_UnitTests/test_LUT.cpp
+++ b/Src/libCZI_UnitTests/test_LUT.cpp
@@ -56,7 +56,9 @@ static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2, siz
 
 TEST(LUTGeneration, Gamma1)
 {
-	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, 0.58f);
+	constexpr auto gamma = 0.58f;
+
+	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, gamma);
 
 	EXPECT_EQ(gammaLutTest.size(), (size_t)256) << "Incorrect result";
 
@@ -77,19 +79,21 @@ TEST(LUTGeneration, Gamma1)
 	EXPECT_TRUE(isCorrect) << "Incorrect result";
 
 	// test that the 16-bit result is basically the same
-	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, 0.58f);
+	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, gamma);
 	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536);
 	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 
 	// note that also bit depths between 8 and 16 are supported (e.g., 12)
-	auto gammaLutTest12bit = libCZI::Utils::Create16BitLookUpTableFromGamma(4096, 0, 1, 0.58f);
+	auto gammaLutTest12bit = libCZI::Utils::Create16BitLookUpTableFromGamma(4096, 0, 1, gamma);
 	bool isCorrect12bit = Compare16bitLUT(&gammaLutTest12bit[0], ExpectedResult, 4096);
 	EXPECT_TRUE(isCorrect12bit) << "Incorrect 12-bit result";
 }
 
 TEST(LUTGeneration, Gamma2)
 {
-	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, 1.58f);
+	constexpr auto gamma = 1.58f;
+
+	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, gamma);
 
 	EXPECT_EQ(gammaLutTest.size(), (size_t)256) << "Incorrect result";
 	static std::uint8_t ExpectedResult[256] = {
@@ -111,12 +115,12 @@ TEST(LUTGeneration, Gamma2)
 	EXPECT_TRUE(isCorrect) << "Incorrect result";
 
 	// test that the 16-bit result is basically the same
-	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, 1.58f);
+	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, gamma);
 	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536);
 	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 
 	// also 10-bit LUTs, for example, can be generated
-	auto gammaLutTest10bit = libCZI::Utils::Create16BitLookUpTableFromGamma(1024, 0, 1, 1.58f);
+	auto gammaLutTest10bit = libCZI::Utils::Create16BitLookUpTableFromGamma(1024, 0, 1, gamma);
 	bool isCorrect10bit = Compare16bitLUT(&gammaLutTest10bit[0], ExpectedResult, 1024);
 	EXPECT_TRUE(isCorrect10bit) << "Incorrect 10-bit result";
 }

--- a/Src/libCZI_UnitTests/test_LUT.cpp
+++ b/Src/libCZI_UnitTests/test_LUT.cpp
@@ -32,10 +32,10 @@ static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2, siz
 
 	const auto scaler = elemCnt / 256;
 
-	for (size_t i = 0; i < 255 * scaler; ++i)
+	for (size_t i = 0; i < elemCnt; ++i)
 	{
 		const auto prev8bit = p2[i / scaler];
-		const auto next8bit = p2[i / scaler + 1];
+		const auto next8bit = i < 255 * scaler ? p2[i / scaler + 1] : 256;
 		const auto corresponding8bit = std::round(p1[i] / 256.0);
 		if (prev8bit > next8bit)
 		{

--- a/Src/libCZI_UnitTests/test_LUT.cpp
+++ b/Src/libCZI_UnitTests/test_LUT.cpp
@@ -22,7 +22,7 @@ static bool CompareWithMargin(const std::uint8_t* p1, const std::uint8_t* p2, si
 }
 
 // Compares a generated 16-bit LUT to a 8-bit expected result
-static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2, size_t elemCnt)
+static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2, size_t elemCnt, int maxAllowedDifference)
 {
 	if (elemCnt % 256 != 0)
 	{
@@ -41,11 +41,11 @@ static bool Compare16bitLUT(const std::uint16_t* p1, const std::uint8_t* p2, siz
 		{
 			return false;
 		}
-		if (corresponding8bit < prev8bit)
+		if (corresponding8bit < prev8bit - maxAllowedDifference)
 		{
 			return false;
 		}
-		if (corresponding8bit > next8bit)
+		if (corresponding8bit > next8bit + maxAllowedDifference)
 		{
 			return false;
 		}
@@ -80,12 +80,12 @@ TEST(LUTGeneration, Gamma1)
 
 	// test that the 16-bit result is basically the same
 	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, gamma);
-	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536);
+	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536, 0);
 	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 
 	// note that also bit depths between 8 and 16 are supported (e.g., 12)
 	auto gammaLutTest12bit = libCZI::Utils::Create16BitLookUpTableFromGamma(4096, 0, 1, gamma);
-	bool isCorrect12bit = Compare16bitLUT(&gammaLutTest12bit[0], ExpectedResult, 4096);
+	bool isCorrect12bit = Compare16bitLUT(&gammaLutTest12bit[0], ExpectedResult, 4096, 0);
 	EXPECT_TRUE(isCorrect12bit) << "Incorrect 12-bit result";
 }
 
@@ -116,12 +116,12 @@ TEST(LUTGeneration, Gamma2)
 
 	// test that the 16-bit result is basically the same
 	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, gamma);
-	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536);
+	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536, 0);
 	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
 
 	// also 10-bit LUTs, for example, can be generated
 	auto gammaLutTest10bit = libCZI::Utils::Create16BitLookUpTableFromGamma(1024, 0, 1, gamma);
-	bool isCorrect10bit = Compare16bitLUT(&gammaLutTest10bit[0], ExpectedResult, 1024);
+	bool isCorrect10bit = Compare16bitLUT(&gammaLutTest10bit[0], ExpectedResult, 1024, 0);
 	EXPECT_TRUE(isCorrect10bit) << "Incorrect 10-bit result";
 }
 
@@ -172,7 +172,9 @@ TEST(LUTGeneration, Splines1)
 
 TEST(LUTGeneration, Gamma3)
 {
-	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, 0.28218746779620463f);
+	constexpr auto gamma = 0.28218746779620463f;
+
+	auto gammaLutTest = libCZI::Utils::Create8BitLookUpTableFromGamma(256, 0, 1, gamma);
 
 	EXPECT_EQ(gammaLutTest.size(), (size_t)256) << "Incorrect result";
 
@@ -189,7 +191,17 @@ TEST(LUTGeneration, Gamma3)
 		246, 246, 246, 247, 247, 247, 248, 248, 249, 249, 249, 250, 250, 250, 251, 251, 251, 252, 252, 252, 253, 253, 253, 254,
 		254, 254, 255, 255, 255, 255 };
 
-	// allow for a difference of 1 (rounding is not yet the same as in the original code, need to look into this...)
+	// allow for a difference of 2 (rounding is not yet the same as in the original code, need to look into this...)
 	bool isCorrect = CompareWithMargin(&gammaLutTest[0], ExpectedResult, 256, 2);
 	EXPECT_TRUE(isCorrect) << "Incorrect result";
+
+	// test that the 16-bit result is basically the same
+	auto gammaLutTest16bit = libCZI::Utils::Create16BitLookUpTableFromGamma(65536, 0, 1, gamma);
+	bool isCorrect16bit = Compare16bitLUT(&gammaLutTest16bit[0], ExpectedResult, 65536, 1);
+	EXPECT_TRUE(isCorrect16bit) << "Incorrect 16-bit result";
+
+	// also 14-bit LUTs, for example, can be generated
+	auto gammaLutTest14bit = libCZI::Utils::Create16BitLookUpTableFromGamma(16384, 0, 1, gamma);
+	bool isCorrect14bit = Compare16bitLUT(&gammaLutTest14bit[0], ExpectedResult, 16384, 1);
+	EXPECT_TRUE(isCorrect14bit) << "Incorrect 14-bit result";
 }


### PR DESCRIPTION
## Description

* Add new function `Create16BitLookUpTableFromGamma` that works similarly to the previously existing `Create8BitLookUpTableFromGamma`.
* Rename `InternalCreate8BitLookUpTableFromGamma` -> `InternalCreateLookUpTableFromGamma`, and generalize the already-templated function so that it is easy to produce LUTs having different types (and then just use the updated function).
* Fix a trivial copy-paste error.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not really tested just yet. Can look into adding some test automation, if this addition can otherwise be considered? Am new to libCZI, and haven't so far even looked into how the current test suite has been set up.

## Checklist:

- [ ] I followed the [Contributing Guidelines](https://github.com/FelixS90/libCZIrw_Demo/CONTRIBUTING.md).
  - The link appears to be dead.
- [X] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
