### PR TITLE
Add ability to write DisplaySettings metadata on czi creation

### DIFF
--- a/Src/libCZI/CziAttachment.cpp
+++ b/Src/libCZI/CziAttachment.cpp
@@ -4,13 +4,15 @@
 
 #include "stdafx.h"
 #include "CziAttachment.h"
+
+#include <utility>
 #include "CziUtils.h"
 
 using namespace libCZI;
 
 CCziAttachment::CCziAttachment(const libCZI::AttachmentInfo& info, const CCZIParse::AttachmentData& data, std::function<void(void*)> deleter)
 	:	
-	spData(std::shared_ptr<const void>(data.ptrData, deleter)),
+	spData(std::shared_ptr<const void>(data.ptrData, std::move(deleter))),
 	dataSize(data.dataSize),
 	info(info)
 {

--- a/Src/libCZI/CziAttachment.cpp
+++ b/Src/libCZI/CziAttachment.cpp
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "stdafx.h"
-#include "CziAttachment.h"
-
 #include <utility>
+#include "CziAttachment.h"
 #include "CziUtils.h"
 
 using namespace libCZI;

--- a/Src/libCZI/CziAttachmentsDirectory.cpp
+++ b/Src/libCZI/CziAttachmentsDirectory.cpp
@@ -33,7 +33,7 @@ void CCziAttachmentsDirectory::AddAttachmentEntry(const AttachmentEntry& entry)
 	this->attachmentEntries.emplace_back(entry);
 }
 
-void CCziAttachmentsDirectory::EnumAttachments(std::function<bool(int index, const CCziAttachmentsDirectory::AttachmentEntry&)> func)
+void CCziAttachmentsDirectory::EnumAttachments(const std::function<bool(int index, const CCziAttachmentsDirectory::AttachmentEntry&)>& func)
 {
 	int i = 0;
 	for (const auto& ae : this->attachmentEntries)
@@ -169,7 +169,7 @@ bool CReaderWriterCziAttachmentsDirectory::TryGetAttachment(int key, AttachmentE
 
 bool CReaderWriterCziAttachmentsDirectory::TryModifyAttachment(int key, const AttachmentEntry& attchmntEntry)
 {
-	auto it = this->attchmnts.find(key);
+	const auto it = this->attchmnts.find(key);
 	if (it == this->attchmnts.end())
 	{
 		return false;
@@ -182,7 +182,7 @@ bool CReaderWriterCziAttachmentsDirectory::TryModifyAttachment(int key, const At
 
 bool CReaderWriterCziAttachmentsDirectory::TryRemoveAttachment(int key, AttachmentEntry* attchmntEntry)
 {
-	auto it = this->attchmnts.find(key);
+	const auto it = this->attchmnts.find(key);
 	if (it == this->attchmnts.end())
 	{
 		return false;

--- a/Src/libCZI/CziAttachmentsDirectory.h
+++ b/Src/libCZI/CziAttachmentsDirectory.h
@@ -38,7 +38,7 @@ public:
 	}
 
 	void AddAttachmentEntry(const AttachmentEntry& entry);
-	void EnumAttachments(std::function<bool(int index, const CCziAttachmentsDirectory::AttachmentEntry&)> func);
+	void EnumAttachments(const std::function<bool(int index, const CCziAttachmentsDirectory::AttachmentEntry&)>& func);
 	bool TryGetAttachment(int index, AttachmentEntry& entry);
 };
 

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -195,6 +195,26 @@ using namespace std;
     pcdata.set_value(ss.str().c_str());
 }
 
+/*virtual*/void CNodeWrapper::RemoveChildren()
+{
+    this->node.remove_children();
+}
+
+/*virtual*/void CNodeWrapper::RemoveAttributes()
+{
+    this->node.remove_attributes();
+}
+
+/*virtual*/bool CNodeWrapper::RemoveChild(const char* name)
+{
+    return this->node.remove_child(Utilities::convertUtf8ToWchar_t(name).c_str());
+}
+
+/*virtual*/bool CNodeWrapper::RemoveAttribute(const char* name)
+{
+    return this->node.remove_attribute(Utilities::convertUtf8ToWchar_t(name).c_str());
+}
+
 //--------------------------------------------------------------------------------------
 
 std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNode(const char* path, bool allowCreation)
@@ -966,7 +986,7 @@ static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_di
             ostringstream string_stream;
             string_stream << setprecision(numeric_limits<double>::max_digits10 + 2) << scientific;
             bool is_first_iteration = true;
-            for (auto& it = spline_control_points.cbegin(); it != spline_control_points.cend(); ++it)
+            for (auto it = spline_control_points.cbegin(); it != spline_control_points.cend(); ++it)
             {
                 if (!is_first_iteration)
                 {
@@ -985,7 +1005,12 @@ static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_di
 
 /*static*/void libCZI::MetadataUtils::WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings, int channel_count)
 {
-    auto display_settings_channel_node = builder->GetRootNode()->GetOrCreateChildNode("Metadata/DisplaySetting/Channels");
+    const auto display_settings_channel_node = builder->GetRootNode()->GetOrCreateChildNode("Metadata/DisplaySetting/Channels");
+
+    // remove existing "Channel"-nodes (if any)
+    while (display_settings_channel_node->RemoveChild("Channel"))
+    {}
+
     for (int c = 0; c < channel_count; ++c)
     {
         auto channel_display_settings = display_settings->GetChannelDisplaySettings(c);

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -918,12 +918,11 @@ bool libCZI::XmlDateTime::IsValid() const
 
 /*static*/void libCZI::MetadataUtils::WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings)
 {
-    //vector<int> channel_indices_from_display_settings;
+    // we determine the highest channel-number that we find in the display-settings object
     int max_channel_index_in_display_settings = 0;
     display_settings->EnumChannels(
         [&](int channel_index)->bool
         {
-            //channel_indices_from_display_settings.push_back(channel_index);
             if (channel_index > max_channel_index_in_display_settings)
             {
                 max_channel_index_in_display_settings = channel_index;
@@ -932,7 +931,7 @@ bool libCZI::XmlDateTime::IsValid() const
             return true;
         });
 
-    MetadataUtils::WriteDisplaySettings(builder, display_settings, max_channel_index_in_display_settings);
+    MetadataUtils::WriteDisplaySettings(builder, display_settings, 1+max_channel_index_in_display_settings);
 }
 
 static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_display_setting, IXmlNodeRw* node)

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -8,6 +8,7 @@
 #include <regex>
 #include <codecvt>
 #include <iomanip>
+#include <limits>
 #include "CziUtils.h"
 #include "XmlNodeWrapper.h"
 
@@ -956,6 +957,29 @@ static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_di
         if (channel_display_setting->TryGetGamma(&gamma))
         {
             node->GetOrCreateChildNode("Gamma")->SetValueFlt(gamma);
+        }
+    }
+    else if (gradation_curve_mode == IDisplaySettings::GradationCurveMode::Spline)
+    {
+        vector<libCZI::IDisplaySettings::SplineControlPoint> spline_control_points;
+        if (channel_display_setting->TryGetSplineControlPoints(&spline_control_points))
+        {
+            ostringstream string_stream;
+            string_stream << setprecision(numeric_limits<double>::max_digits10 + 2) << scientific;
+            bool is_first_iteration = true;
+            for (auto& it = spline_control_points.cbegin(); it != spline_control_points.cend(); ++it)
+            {
+                if (!is_first_iteration)
+                {
+                    string_stream << ' ';
+                }
+
+                string_stream << it->x << "," << it->y;
+                is_first_iteration = false;
+            }
+
+            node->GetOrCreateChildNode("Points")->SetValue(string_stream.str());
+            node->GetOrCreateChildNode("Mode")->SetValue("spline");
         }
     }
 }

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -17,963 +17,1022 @@ using namespace std;
 
 /*static*/void CNodeWrapper::MetadataBuilderXmlNodeWrapperThrowExcp::ThrowInvalidPath()
 {
-	throw libCZI::LibCZIMetadataBuilderException("invalid path", libCZI::LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    throw libCZI::LibCZIMetadataBuilderException("invalid path", libCZI::LibCZIMetadataBuilderException::ErrorType::InvalidPath);
 }
 
 /*virtual*/std::shared_ptr<libCZI::IXmlNodeRw> CNodeWrapper::AppendChildNode(const char* name)
 {
-	auto node = this->node.append_child(xml_node_type::node_element);
-	node.set_name(Utilities::convertUtf8ToWchar_t(name).c_str());
-	return make_shared<CNodeWrapper>(this->builderRef, node.internal_object());
+    auto node = this->node.append_child(xml_node_type::node_element);
+    node.set_name(Utilities::convertUtf8ToWchar_t(name).c_str());
+    return make_shared<CNodeWrapper>(this->builderRef, node.internal_object());
 }
 
 /*virtual*/bool CNodeWrapper::TryGetAttribute(const wchar_t* attributeName, std::wstring* attribValue) const
 {
-	auto attrib = this->node.find_attribute([&](const xml_attribute & a)
-	{
-		return wcscmp(a.name(), attributeName) == 0;
-	});
+    auto attrib = this->node.find_attribute([&](const xml_attribute& a)
+        {
+            return wcscmp(a.name(), attributeName) == 0;
+        });
 
-	if (!attrib)
-	{
-		return false;
-	}
+    if (!attrib)
+    {
+        return false;
+    }
 
-	if (attribValue != nullptr)
-	{
-		*attribValue = attrib.value();
-	}
+    if (attribValue != nullptr)
+    {
+        *attribValue = attrib.value();
+    }
 
-	return true;
+    return true;
 }
 
 /*virtual*/void CNodeWrapper::EnumAttributes(const std::function<bool(const std::wstring& attribName, const std::wstring& attribValue)>& enumFunc) const
 {
-	for (pugi::xml_attribute_iterator ait = this->node.attributes_begin(); ait != this->node.attributes_end(); ++ait)
-	{
-		if (!enumFunc(wstring(ait->name()), wstring(ait->value())))
-		{
-			break;
-		}
-	}
+    for (pugi::xml_attribute_iterator ait = this->node.attributes_begin(); ait != this->node.attributes_end(); ++ait)
+    {
+        if (!enumFunc(wstring(ait->name()), wstring(ait->value())))
+        {
+            break;
+        }
+    }
 }
 
 /*virtual*/bool CNodeWrapper::TryGetValue(std::wstring* value) const
 {
-	if (this->node.first_child().type() == xml_node_type::node_pcdata)
-	{
-		if (value != nullptr)
-		{
-			*value = this->node.child_value();
-		}
+    if (this->node.first_child().type() == xml_node_type::node_pcdata)
+    {
+        if (value != nullptr)
+        {
+            *value = this->node.child_value();
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 /*virtual*/std::shared_ptr<IXmlNodeRead> CNodeWrapper::GetChildNodeReadonly(const char* path)
 {
-	auto p = Utilities::convertUtf8ToWchar_t(path);
-	vector<std::wstring> tokens;
-	Utilities::Tokenize(p, tokens, L"/");
-	if (tokens.empty())
-	{
-		throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-	}
+    auto p = Utilities::convertUtf8ToWchar_t(path);
+    vector<std::wstring> tokens;
+    Utilities::Tokenize(p, tokens, L"/");
+    if (tokens.empty())
+    {
+        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    }
 
-	if (any_of(tokens.cbegin(), tokens.cend(), [](const wstring & str) {return str.empty(); }))
-	{
-		throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-	}
+    if (any_of(tokens.cbegin(), tokens.cend(), [](const wstring& str) {return str.empty(); }))
+    {
+        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    }
 
-	auto node = this->GetOrCreateChildElementNodeWithAttributes(tokens[0], false);
-	if (!node)
-	{
-		return nullptr;
-	}
+    auto node = this->GetOrCreateChildElementNodeWithAttributes(tokens[0], false);
+    if (!node)
+    {
+        return nullptr;
+    }
 
-	for (size_t i = 1; i < tokens.size(); ++i)
-	{
-		node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i].c_str(), false);
-		if (!node)
-		{
-			return nullptr;
-		}
-	}
+    for (size_t i = 1; i < tokens.size(); ++i)
+    {
+        node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i].c_str(), false);
+        if (!node)
+        {
+            return nullptr;
+        }
+    }
 
-	return std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, node.internal_object());
+    return std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, node.internal_object());
 }
 
 /*virtual*/void CNodeWrapper::EnumChildren(const std::function<bool(std::shared_ptr<IXmlNodeRead>)>& enumChildren)
 {
-	for (pugi::xml_node childNode = this->node.first_child(); childNode; childNode = childNode.next_sibling())
-	{
-		if (childNode.type() == pugi::xml_node_type::node_element)
-		{
-			bool b = enumChildren(
-				std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, childNode.internal_object()));
-			if (!b)
-			{
-				break;
-			}
-		}
-	}
+    for (pugi::xml_node childNode = this->node.first_child(); childNode; childNode = childNode.next_sibling())
+    {
+        if (childNode.type() == pugi::xml_node_type::node_element)
+        {
+            bool b = enumChildren(
+                std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, childNode.internal_object()));
+            if (!b)
+            {
+                break;
+            }
+        }
+    }
 }
 
 /*virtual*/std::wstring CNodeWrapper::Name() const
 {
-	return this->node.name();
+    return this->node.name();
 }
 
 /*virtual*/std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNode(const char* path)
 {
-	return this->GetOrCreateChildNode(path, true);
+    return this->GetOrCreateChildNode(path, true);
 }
 
 /*virtual*/std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetChildNode(const char* path)
 {
-	return this->GetOrCreateChildNode(path, false);
+    return this->GetOrCreateChildNode(path, false);
 }
 
 /*virtual*/void CNodeWrapper::SetValue(const char* str)
 {
-	this->ThrowIfCannotSetValue();
-	auto pcdata = this->GetOrCreatePcDataChild();
-	pcdata.set_value(Utilities::convertUtf8ToWchar_t(str).c_str());
+    this->ThrowIfCannotSetValue();
+    auto pcdata = this->GetOrCreatePcDataChild();
+    pcdata.set_value(Utilities::convertUtf8ToWchar_t(str).c_str());
 }
 
 /*virtual*/void CNodeWrapper::SetValue(const wchar_t* str)
 {
-	this->ThrowIfCannotSetValue();
-	auto pcdata = this->GetOrCreatePcDataChild();
-	pcdata.set_value(str);
+    this->ThrowIfCannotSetValue();
+    auto pcdata = this->GetOrCreatePcDataChild();
+    pcdata.set_value(str);
 }
 
 /*virtual*/void CNodeWrapper::SetValueI32(int value)
 {
-	this->SetValueT<int>(value);
+    this->SetValueT<int>(value);
 }
 
 /*virtual*/void CNodeWrapper::SetValueUI32(unsigned int value)
 {
-	this->SetValueT<unsigned int>(value);
+    this->SetValueT<unsigned int>(value);
 }
 
 /*virtual*/void CNodeWrapper::SetValueI64(long long value)
 {
-	this->SetValueT<long long>(value);
+    this->SetValueT<long long>(value);
 }
 
 /*virtual*/void CNodeWrapper::SetValueUI64(unsigned long long value)
 {
-	this->SetValueT<unsigned long long>(value);
+    this->SetValueT<unsigned long long>(value);
 }
 
 /*virtual*/void CNodeWrapper::SetValueBool(bool value)
 {
-	this->SetValue(value == true ? "true" : "false");
+    this->SetValue(value == true ? "true" : "false");
 }
 
 /*virtual*/void CNodeWrapper::SetValueDbl(double value)
 {
-	this->ThrowIfCannotSetValue();
-	wstringstream ss;
-	ss << std::setprecision(numeric_limits<double>::digits10) << value;
-	auto pcdata = this->GetOrCreatePcDataChild();
-	pcdata.set_value(ss.str().c_str());
+    this->ThrowIfCannotSetValue();
+    wstringstream ss;
+    ss << std::setprecision(numeric_limits<double>::digits10) << value;
+    auto pcdata = this->GetOrCreatePcDataChild();
+    pcdata.set_value(ss.str().c_str());
 }
 
 /*virtual*/void CNodeWrapper::SetValueFlt(float value)
 {
-	this->ThrowIfCannotSetValue();
-	wstringstream ss;
-	ss << std::setprecision(numeric_limits<float>::digits10) << value;
-	auto pcdata = this->GetOrCreatePcDataChild();
-	pcdata.set_value(ss.str().c_str());
+    this->ThrowIfCannotSetValue();
+    wstringstream ss;
+    ss << std::setprecision(numeric_limits<float>::digits10) << value;
+    auto pcdata = this->GetOrCreatePcDataChild();
+    pcdata.set_value(ss.str().c_str());
 }
 
 //--------------------------------------------------------------------------------------
 
 std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNode(const char* path, bool allowCreation)
 {
-	auto p = Utilities::convertUtf8ToWchar_t(path);
+    auto p = Utilities::convertUtf8ToWchar_t(path);
 
-	vector<std::wstring> tokens;
-	Utilities::Tokenize(p, tokens, L"/");
-	if (tokens.empty())
-	{
-		throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-	}
+    vector<std::wstring> tokens;
+    Utilities::Tokenize(p, tokens, L"/");
+    if (tokens.empty())
+    {
+        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    }
 
-	if (any_of(tokens.cbegin(), tokens.cend(), [](const wstring & str) {return str.empty(); }))
-	{
-		throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-	}
+    if (any_of(tokens.cbegin(), tokens.cend(), [](const wstring& str) {return str.empty(); }))
+    {
+        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    }
 
-	auto node = this->GetOrCreateChildElementNodeWithAttributes(tokens[0], allowCreation);
-	if (!node)
-	{
-		return nullptr;
-	}
+    auto node = this->GetOrCreateChildElementNodeWithAttributes(tokens[0], allowCreation);
+    if (!node)
+    {
+        return nullptr;
+    }
 
-	for (size_t i = 1; i < tokens.size(); ++i)
-	{
-		node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i].c_str(), allowCreation);
-		if (!node)
-		{
-			return nullptr;
-		}
-	}
+    for (size_t i = 1; i < tokens.size(); ++i)
+    {
+        node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i].c_str(), allowCreation);
+        if (!node)
+        {
+            return nullptr;
+        }
+    }
 
-	return std::make_shared<CNodeWrapper>(this->builderRef, node.internal_object());
+    return std::make_shared<CNodeWrapper>(this->builderRef, node.internal_object());
 }
 
 void CNodeWrapper::ThrowIfCannotSetValue()
 {
-	auto node = this->node.find_child([=](const xml_node & n) {return n.type() == xml_node_type::node_element; });
-	if (!node)
-	{
-		return;
-	}
+    auto node = this->node.find_child([=](const xml_node& n) {return n.type() == xml_node_type::node_element; });
+    if (!node)
+    {
+        return;
+    }
 
-	throw LibCZIMetadataBuilderException("child-nodes present, cannot set value", LibCZIMetadataBuilderException::ErrorType::CannotSetValueToNode);
+    throw LibCZIMetadataBuilderException("child-nodes present, cannot set value", LibCZIMetadataBuilderException::ErrorType::CannotSetValueToNode);
 }
 
 pugi::xml_node CNodeWrapper::GetOrCreatePcDataChild()
 {
-	auto node = this->node.find_child([=](const xml_node & n) {return n.type() == xml_node_type::node_pcdata; });
-	if (!node)
-	{
-		node = this->node.append_child(xml_node_type::node_pcdata);
-	}
+    auto node = this->node.find_child([=](const xml_node& n) {return n.type() == xml_node_type::node_pcdata; });
+    if (!node)
+    {
+        node = this->node.append_child(xml_node_type::node_pcdata);
+    }
 
-	return node;
+    return node;
 }
 
 /*virtual*/void CNodeWrapper::SetAttribute(const char* name, const char* value)
 {
-	auto attribname = Utilities::convertUtf8ToWchar_t(name);
-	auto attribute = this->node.attribute(attribname.c_str());
+    auto attribname = Utilities::convertUtf8ToWchar_t(name);
+    auto attribute = this->node.attribute(attribname.c_str());
 
-	// if the attribute was already existing, we use (and modify) it
-	if (!attribute)
-	{
-		// otherwise, we add a new attribute
-		attribute = this->node.append_attribute(Utilities::convertUtf8ToWchar_t(name).c_str());
-	}
+    // if the attribute was already existing, we use (and modify) it
+    if (!attribute)
+    {
+        // otherwise, we add a new attribute
+        attribute = this->node.append_attribute(Utilities::convertUtf8ToWchar_t(name).c_str());
+    }
 
-	attribute.set_value(Utilities::convertUtf8ToWchar_t(value).c_str());
+    attribute.set_value(Utilities::convertUtf8ToWchar_t(value).c_str());
 }
 
-pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(const std::wstring & str, bool allowCreation)
+pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(const std::wstring& str, bool allowCreation)
 {
-	return CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(this->node, str, allowCreation);
+    return CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(this->node, str, allowCreation);
 }
 
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node & node, const std::wstring & str, bool allowCreation)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, bool allowCreation)
 {
-	std::wregex nodenameWihtAttribregex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
-	std::wsmatch pieces_match;
+    std::wregex nodenameWihtAttribregex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
+    std::wsmatch pieces_match;
 
-	if (std::regex_match(str, pieces_match, nodenameWihtAttribregex))
-	{
-		if (pieces_match.size() == 4)
-		{
-			if (pieces_match[0].matched == true && pieces_match[1].matched == true)
-			{
-				wstring nodeName = pieces_match[1];
-				if (pieces_match[2].matched == false && pieces_match[3].matched == false)
-				{
-					// we only got a name ( not followed by [Id=abc] )
-					return GetOrCreateChildElementNode(node, nodeName.c_str(), allowCreation);
-				}
-				else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
-				{
-					const auto attribValuePairs = CNodeWrapper::ParseAttributes(pieces_match[3]);
-					return GetOrCreateChildElementNodeWithAttributes(node, nodeName, attribValuePairs, allowCreation);
-				}
-			}
-		}
-	}
+    if (std::regex_match(str, pieces_match, nodenameWihtAttribregex))
+    {
+        if (pieces_match.size() == 4)
+        {
+            if (pieces_match[0].matched == true && pieces_match[1].matched == true)
+            {
+                wstring nodeName = pieces_match[1];
+                if (pieces_match[2].matched == false && pieces_match[3].matched == false)
+                {
+                    // we only got a name ( not followed by [Id=abc] )
+                    return GetOrCreateChildElementNode(node, nodeName.c_str(), allowCreation);
+                }
+                else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
+                {
+                    const auto attribValuePairs = CNodeWrapper::ParseAttributes(pieces_match[3]);
+                    return GetOrCreateChildElementNodeWithAttributes(node, nodeName, attribValuePairs, allowCreation);
+                }
+            }
+        }
+    }
 
-	throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+    throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
 }
 
 pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz, bool allowCreation)
 {
-	return CNodeWrapper::GetOrCreateChildElementNode(this->node, sz, allowCreation);
+    return CNodeWrapper::GetOrCreateChildElementNode(this->node, sz, allowCreation);
 }
 
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node & node, const std::wstring & str, const std::map<std::wstring, std::wstring> & attribs, bool allowCreation)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs, bool allowCreation)
 {
-	struct find_element_node_and_attributes
-	{
-		const wchar_t* nodeName;
-		const std::map<std::wstring, std::wstring>& attribs;
+    struct find_element_node_and_attributes
+    {
+        const wchar_t* nodeName;
+        const std::map<std::wstring, std::wstring>& attribs;
 
-		bool operator()(pugi::xml_node node) const
-		{
-			if (node.type() != xml_node_type::node_element)
-			{
-				return false;
-			}
+        bool operator()(pugi::xml_node node) const
+        {
+            if (node.type() != xml_node_type::node_element)
+            {
+                return false;
+            }
 
-			if (wcscmp(node.name(), this->nodeName) != 0)
-			{
-				return false;
-			}
+            if (wcscmp(node.name(), this->nodeName) != 0)
+            {
+                return false;
+            }
 
-			for (auto it = this->attribs.cbegin(); it != this->attribs.cend(); ++it)
-			{
-				auto attribute = node.find_attribute([&](const xml_attribute & a)
-				{
-					return wcscmp(a.name(), it->first.c_str()) == 0;
-				});
+            for (auto it = this->attribs.cbegin(); it != this->attribs.cend(); ++it)
+            {
+                auto attribute = node.find_attribute([&](const xml_attribute& a)
+                    {
+                        return wcscmp(a.name(), it->first.c_str()) == 0;
+                    });
 
-				if (!attribute)
-				{
-					return false;
-				}
+                if (!attribute)
+                {
+                    return false;
+                }
 
-				if (wcscmp(attribute.value(), it->second.c_str()) != 0)
-				{
-					return false;
-				}
-			}
+                if (wcscmp(attribute.value(), it->second.c_str()) != 0)
+                {
+                    return false;
+                }
+            }
 
-			return true;
-		}
-	};
+            return true;
+        }
+    };
 
-	auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
-	if (!c)
-	{
-		if (!allowCreation)
-		{
-			return xml_node();
-		}
+    auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
+    if (!c)
+    {
+        if (!allowCreation)
+        {
+            return xml_node();
+        }
 
-		auto newNode = node.append_child(str.c_str());
-		for (auto it = attribs.cbegin(); it != attribs.cend(); ++it)
-		{
-			newNode.append_attribute(it->first.c_str()).set_value(it->second.c_str());
-		}
+        auto newNode = node.append_child(str.c_str());
+        for (auto it = attribs.cbegin(); it != attribs.cend(); ++it)
+        {
+            newNode.append_attribute(it->first.c_str()).set_value(it->second.c_str());
+        }
 
-		return newNode;
-	}
+        return newNode;
+    }
 
-	return c;
+    return c;
 }
 
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(pugi::xml_node & node, const wchar_t* sz, bool allowCreation)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz, bool allowCreation)
 {
-	struct find_element_node
-	{
-		const wchar_t* nodeName;
+    struct find_element_node
+    {
+        const wchar_t* nodeName;
 
-		bool operator()(pugi::xml_node node) const
-		{
-			if (node.type() != xml_node_type::node_element)
-			{
-				return false;
-			}
+        bool operator()(pugi::xml_node node) const
+        {
+            if (node.type() != xml_node_type::node_element)
+            {
+                return false;
+            }
 
-			return wcscmp(node.name(), this->nodeName) == 0;
-		}
-	};
+            return wcscmp(node.name(), this->nodeName) == 0;
+        }
+    };
 
-	auto c = node.find_child(find_element_node{ sz });
-	if (!c)
-	{
-		if (!allowCreation)
-		{
-			return xml_node();
-		}
+    auto c = node.find_child(find_element_node{ sz });
+    if (!c)
+    {
+        if (!allowCreation)
+        {
+            return xml_node();
+        }
 
-		return node.append_child(sz);
-	}
+        return node.append_child(sz);
+    }
 
-	return c;
+    return c;
 }
 
-/*static*/std::map<wstring, wstring> CNodeWrapper::ParseAttributes(const std::wstring & str)
+/*static*/std::map<wstring, wstring> CNodeWrapper::ParseAttributes(const std::wstring& str)
 {
-	map<wstring, wstring> attribMap;
+    map<wstring, wstring> attribMap;
 
-	std::wsmatch pieces_match;
+    std::wsmatch pieces_match;
 
-	// now we have string of the form Id=abc,Name=abc
-	vector<wstring> pairs;
-	Utilities::Tokenize(str, pairs, L",;");
+    // now we have string of the form Id=abc,Name=abc
+    vector<wstring> pairs;
+    Utilities::Tokenize(str, pairs, L",;");
 
-	std::wregex attribValuePairRegex(LR"(([^=]+)=([^,;]*))");
-	for (auto it = pairs.cbegin(); it != pairs.cend(); ++it)
-	{
-		bool parsedOk = false;
-		if (std::regex_match(*it, pieces_match, attribValuePairRegex))
-		{
-			if (pieces_match.size() == 3 && pieces_match[0].matched == true && pieces_match[1].matched == true && pieces_match[2].matched == true)
-			{
-				attribMap.insert(pair<wstring, wstring>(pieces_match[1], pieces_match[2]));
-				parsedOk = true;
-			}
-		}
+    std::wregex attribValuePairRegex(LR"(([^=]+)=([^,;]*))");
+    for (auto it = pairs.cbegin(); it != pairs.cend(); ++it)
+    {
+        bool parsedOk = false;
+        if (std::regex_match(*it, pieces_match, attribValuePairRegex))
+        {
+            if (pieces_match.size() == 3 && pieces_match[0].matched == true && pieces_match[1].matched == true && pieces_match[2].matched == true)
+            {
+                attribMap.insert(pair<wstring, wstring>(pieces_match[1], pieces_match[2]));
+                parsedOk = true;
+            }
+        }
 
-		if (!parsedOk)
-		{
-			throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-		}
-	}
+        if (!parsedOk)
+        {
+            throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+        }
+    }
 
-	return attribMap;
+    return attribMap;
 }
 
 //----------------------------------------------------------------------------------------------
 
 CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName)
 {
-	auto n = this->metadataDoc.append_child(xml_node_type::node_element);
-	n.set_name(rootNodeName);
-	this->rootNode = n;
+    auto n = this->metadataDoc.append_child(xml_node_type::node_element);
+    n.set_name(rootNodeName);
+    this->rootNode = n;
 }
 
 CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName, const std::string& xml)
 {
-	if (!this->metadataDoc.load_buffer(xml.c_str(), xml.size(), pugi::parse_default, encoding_utf8))
-	{
-		throw LibCZIXmlParseException("XML is not well-formed");
-	}
+    if (!this->metadataDoc.load_buffer(xml.c_str(), xml.size(), pugi::parse_default, encoding_utf8))
+    {
+        throw LibCZIXmlParseException("XML is not well-formed");
+    }
 
-	this->rootNode = this->metadataDoc.child(rootNodeName);
-	if (!this->rootNode)
-	{
-		ostringstream ss;
-		ss << "Root-node \"" << Utilities::convertWchar_tToUtf8(rootNodeName) << "\" not found.";
-		throw LibCZIXmlParseException(ss.str().c_str());
-	}
+    this->rootNode = this->metadataDoc.child(rootNodeName);
+    if (!this->rootNode)
+    {
+        ostringstream ss;
+        ss << "Root-node \"" << Utilities::convertWchar_tToUtf8(rootNodeName) << "\" not found.";
+        throw LibCZIXmlParseException(ss.str().c_str());
+    }
 }
 
 /*virtual*/std::shared_ptr<libCZI::IXmlNodeRw> CCZiMetadataBuilder::GetRootNode()
 {
-	return std::make_shared<CNodeWrapper>(this->shared_from_this(), this->rootNode.internal_object());
+    return std::make_shared<CNodeWrapper>(this->shared_from_this(), this->rootNode.internal_object());
 }
 
 /*virtual*/std::string CCZiMetadataBuilder::GetXml(bool withIndent/*=false*/)
 {
-	struct xml_string_writer : pugi::xml_writer
-	{
-		std::string result;
-		virtual void write(const void* data, size_t size) override
-		{
-			result.append(static_cast<const char*>(data), size);
-		}
-	} writer;
+    struct xml_string_writer : pugi::xml_writer
+    {
+        std::string result;
+        virtual void write(const void* data, size_t size) override
+        {
+            result.append(static_cast<const char*>(data), size);
+        }
+    } writer;
 
-	unsigned flags = format_no_declaration | (withIndent ? format_indent : format_raw);
-	this->metadataDoc.save(writer, L"  ", flags, xml_encoding::encoding_utf8);
-	return writer.result;
+    unsigned flags = format_no_declaration | (withIndent ? format_indent : format_raw);
+    this->metadataDoc.save(writer, L"  ", flags, xml_encoding::encoding_utf8);
+    return writer.result;
 }
 
 //**************************************************************************************************
 
 /*static*/void CMetadataPrepareHelper::FillDimensionChannel(
-	libCZI::ICziMetadataBuilder * builder,
-	const libCZI::SubBlockStatistics & statistics,
-	const PixelTypeForChannelIndexStatistic & pixelTypeForChannel,
-	std::function<std::tuple<std::string, std::tuple<bool, std::string>>(int channelIdx)> getIdAndName)
+    libCZI::ICziMetadataBuilder* builder,
+    const libCZI::SubBlockStatistics& statistics,
+    const PixelTypeForChannelIndexStatistic& pixelTypeForChannel,
+    std::function<std::tuple<std::string, std::tuple<bool, std::string>>(int channelIdx)> getIdAndName)
 {
-	int cStartIdx, cIdxSize;
-	if (statistics.dimBounds.TryGetInterval(DimensionIndex::C, &cStartIdx, &cIdxSize))
-	{
-		FillDimensionChannel(builder, cStartIdx, cIdxSize, pixelTypeForChannel, getIdAndName);
-	}
-	else
-	{
-		int pxlTypeInt;
-		if (pixelTypeForChannel.TryGetPixelTypeForNoChannelIndex(&pxlTypeInt))
-		{
-			FillImagePixelType(builder, CziUtils::PixelTypeFromInt(pxlTypeInt));
-		}
-	}
+    int cStartIdx, cIdxSize;
+    if (statistics.dimBounds.TryGetInterval(DimensionIndex::C, &cStartIdx, &cIdxSize))
+    {
+        FillDimensionChannel(builder, cStartIdx, cIdxSize, pixelTypeForChannel, getIdAndName);
+    }
+    else
+    {
+        int pxlTypeInt;
+        if (pixelTypeForChannel.TryGetPixelTypeForNoChannelIndex(&pxlTypeInt))
+        {
+            FillImagePixelType(builder, CziUtils::PixelTypeFromInt(pxlTypeInt));
+        }
+    }
 }
 
 /*static*/void CMetadataPrepareHelper::FillDimensionChannel(
-	libCZI::ICziMetadataBuilder * builder,
-	int channelIdxStart, int channelIdxSize,
-	const PixelTypeForChannelIndexStatistic & pixelTypeForChannel,
-	std::function<std::tuple<std::string, std::tuple<bool, std::string>>(int channelIdx)> getIdAndName)
+    libCZI::ICziMetadataBuilder* builder,
+    int channelIdxStart, int channelIdxSize,
+    const PixelTypeForChannelIndexStatistic& pixelTypeForChannel,
+    std::function<std::tuple<std::string, std::tuple<bool, std::string>>(int channelIdx)> getIdAndName)
 {
-	auto root = builder->GetRootNode();
+    auto root = builder->GetRootNode();
 
-	PixelType pxlTypeForImagePixelType = PixelType::Invalid;
-	for (int ch = channelIdxStart; ch < channelIdxStart + channelIdxSize; ++ch)
-	{
-		auto idAndOptionalName = getIdAndName(ch);
-		string s{ "Metadata/Information/Image/Dimensions/Channels/Channel[Id=" };
-		s.append(get<0>(idAndOptionalName));
-		if (get<0>(get<1>(idAndOptionalName)) == true)
-		{
-			s.append(",Name=");
-			s.append(get<1>(get<1>(idAndOptionalName)));
-		}
+    PixelType pxlTypeForImagePixelType = PixelType::Invalid;
+    for (int ch = channelIdxStart; ch < channelIdxStart + channelIdxSize; ++ch)
+    {
+        auto idAndOptionalName = getIdAndName(ch);
+        string s{ "Metadata/Information/Image/Dimensions/Channels/Channel[Id=" };
+        s.append(get<0>(idAndOptionalName));
+        if (get<0>(get<1>(idAndOptionalName)) == true)
+        {
+            s.append(",Name=");
+            s.append(get<1>(get<1>(idAndOptionalName)));
+        }
 
-		s.append("]");
+        s.append("]");
 
-		auto channelNode = root->GetOrCreateChildNode(s.c_str());
+        auto channelNode = root->GetOrCreateChildNode(s.c_str());
 
-		auto pxlTypeIterator = pixelTypeForChannel.GetChannelIndexPixelTypeMap().find(ch);
-		if (pxlTypeIterator != pixelTypeForChannel.GetChannelIndexPixelTypeMap().end())
-		{
-			int pxlTypeInt = pxlTypeIterator->second;
-			string pixelTypeString;;
-			PixelType pxlType = CziUtils::PixelTypeFromInt(pxlTypeInt);
-			if (CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(pxlType, pixelTypeString))
-			{
-				auto pixelTypeNode = channelNode->AppendChildNode("PixelType");
-				pixelTypeNode->SetValue(pixelTypeString.c_str());
-			}
+        auto pxlTypeIterator = pixelTypeForChannel.GetChannelIndexPixelTypeMap().find(ch);
+        if (pxlTypeIterator != pixelTypeForChannel.GetChannelIndexPixelTypeMap().end())
+        {
+            int pxlTypeInt = pxlTypeIterator->second;
+            string pixelTypeString;;
+            PixelType pxlType = CziUtils::PixelTypeFromInt(pxlTypeInt);
+            if (CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(pxlType, pixelTypeString))
+            {
+                auto pixelTypeNode = channelNode->AppendChildNode("PixelType");
+                pixelTypeNode->SetValue(pixelTypeString.c_str());
+            }
 
-			if (pxlType != PixelType::Invalid && pxlTypeForImagePixelType == PixelType::Invalid)
-			{
-				pxlTypeForImagePixelType = pxlType;
-			}
-		}
-	}
+            if (pxlType != PixelType::Invalid && pxlTypeForImagePixelType == PixelType::Invalid)
+            {
+                pxlTypeForImagePixelType = pxlType;
+            }
+        }
+    }
 
-	// determine what to write into Image/PixelType - which is vaguely defined, so for the time being, let's just
-	// use the first channel
-	CMetadataPrepareHelper::FillImagePixelType(builder, pxlTypeForImagePixelType);
+    // determine what to write into Image/PixelType - which is vaguely defined, so for the time being, let's just
+    // use the first channel
+    CMetadataPrepareHelper::FillImagePixelType(builder, pxlTypeForImagePixelType);
 }
 
-/*static*/void CMetadataPrepareHelper::FillImagePixelType(libCZI::ICziMetadataBuilder * builder, libCZI::PixelType pxlType)
+/*static*/void CMetadataPrepareHelper::FillImagePixelType(libCZI::ICziMetadataBuilder* builder, libCZI::PixelType pxlType)
 {
-	string pixelTypeString;;
-	if (CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(pxlType, pixelTypeString))
-	{
-		auto node = builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/PixelType");
-		node->SetValue(pixelTypeString.c_str());
-	}
+    string pixelTypeString;;
+    if (CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(pxlType, pixelTypeString))
+    {
+        auto node = builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/PixelType");
+        node->SetValue(pixelTypeString.c_str());
+    }
 }
 
-/*static*/bool CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(libCZI::PixelType pxlType, std::string & str)
+/*static*/bool CMetadataPrepareHelper::TryConvertToXmlMetadataPixelTypeString(libCZI::PixelType pxlType, std::string& str)
 {
-	switch (pxlType)
-	{
-	case PixelType::Gray8:
-		str = "Gray8";
-		break;
-	case PixelType::Gray16:
-		str = "Gray16";
-		break;
-	case PixelType::Gray32Float:
-		str = "Gray32Float";
-		break;
-	case PixelType::Bgr24:
-		str = "Bgr24";
-		break;
-	case PixelType::Bgr48:
-		str = "Bgr48";
-		break;
-	case PixelType::Bgr96Float:
-		str = "Bgr96Float";
-		break;
-	case PixelType::Bgra32:
-		str = "Bgra32";
-		break;
-	case PixelType::Gray64ComplexFloat:
-		str = "Gray64ComplexFloat";
-		break;
-	case PixelType::Bgr192ComplexFloat:
-		str = "Bgr192ComplexFloat";
-		break;
-	default:
-		return false;
-	};
+    switch (pxlType)
+    {
+    case PixelType::Gray8:
+        str = "Gray8";
+        break;
+    case PixelType::Gray16:
+        str = "Gray16";
+        break;
+    case PixelType::Gray32Float:
+        str = "Gray32Float";
+        break;
+    case PixelType::Bgr24:
+        str = "Bgr24";
+        break;
+    case PixelType::Bgr48:
+        str = "Bgr48";
+        break;
+    case PixelType::Bgr96Float:
+        str = "Bgr96Float";
+        break;
+    case PixelType::Bgra32:
+        str = "Bgra32";
+        break;
+    case PixelType::Gray64ComplexFloat:
+        str = "Gray64ComplexFloat";
+        break;
+    case PixelType::Bgr192ComplexFloat:
+        str = "Bgr192ComplexFloat";
+        break;
+    default:
+        return false;
+    };
 
-	return true;
+    return true;
 }
 
 //**************************************************************************************************
 
 std::string libCZI::XmlDateTime::ToXmlString() const
 {
-	if (!this->IsValid())
-	{
-		throw std::invalid_argument("illegal date/time");
-	}
+    if (!this->IsValid())
+    {
+        throw std::invalid_argument("illegal date/time");
+    }
 
-	stringstream ss;
-	ss << setfill('0') << setw(4) << this->year << '-' << setw(2) << this->mon << '-' << setw(2) << this->mday << 'T'
-		<< setw(2) << this->hour << ':' << setw(2) << this->min << ':' << setw(2) << this->sec;
-	if (this->isUTC == true)
-	{
-		ss << 'Z';
-	}
-	else if (this->HasTimeZoneOffset())
-	{
-		ss << ((this->offsetHours >= 0) ? "+" : "") << setw(2) << this->offsetHours << ':' << setw(2) << this->offsetMinutes;
-	}
+    stringstream ss;
+    ss << setfill('0') << setw(4) << this->year << '-' << setw(2) << this->mon << '-' << setw(2) << this->mday << 'T'
+        << setw(2) << this->hour << ':' << setw(2) << this->min << ':' << setw(2) << this->sec;
+    if (this->isUTC == true)
+    {
+        ss << 'Z';
+    }
+    else if (this->HasTimeZoneOffset())
+    {
+        ss << ((this->offsetHours >= 0) ? "+" : "") << setw(2) << this->offsetHours << ':' << setw(2) << this->offsetMinutes;
+    }
 
-	return ss.str();
+    return ss.str();
 }
 
 std::wstring libCZI::XmlDateTime::ToXmlWstring() const
 {
-	return Utilities::convertUtf8ToWchar_t(this->ToXmlString().c_str());
+    return Utilities::convertUtf8ToWchar_t(this->ToXmlString().c_str());
 }
 
 bool libCZI::XmlDateTime::IsValid() const
 {
-	return
-		this->sec >= 0 && this->sec <= 60 &&
-		this->min >= 0 && this->min <= 59 &&
-		this->hour >= 0 && this->hour <= 23 &&
-		this->year > -10000 && this->year < 10000 &&
-		this->mon >= 1 && this->mon <= 12 &&
-		this->mday >= 1 &&
-		this->mday <= (this->mon == 2 ? (((this->year % 100 != 0 && this->year % 4 == 0) || (this->year % 400 == 0)) ? 29 : 28) :
-			this->mon == 9 || this->mon == 4 || this->mon == 6 || this->mon == 11 ? 30 : 31);
+    return
+        this->sec >= 0 && this->sec <= 60 &&
+        this->min >= 0 && this->min <= 59 &&
+        this->hour >= 0 && this->hour <= 23 &&
+        this->year > -10000 && this->year < 10000 &&
+        this->mon >= 1 && this->mon <= 12 &&
+        this->mday >= 1 &&
+        this->mday <= (this->mon == 2 ? (((this->year % 100 != 0 && this->year % 4 == 0) || (this->year % 400 == 0)) ? 29 : 28) :
+            this->mon == 9 || this->mon == 4 || this->mon == 6 || this->mon == 11 ? 30 : 31);
 }
 
 /*static*/bool libCZI::XmlDateTime::TryParse(const wchar_t* szw, libCZI::XmlDateTime* ptrDateTime)
 {
-	std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
-	return XmlDateTime::TryParse(utf8_conv.to_bytes(szw).c_str(), ptrDateTime);
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
+    return XmlDateTime::TryParse(utf8_conv.to_bytes(szw).c_str(), ptrDateTime);
 }
 
 /*static*/bool libCZI::XmlDateTime::TryParse(const char* sz, libCZI::XmlDateTime* ptrDateTime)
 {
-	// cf. https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html
-	//static const char* regexStr = "^(?<year>-?(?:[1-9][0-9]*)?[0-9]{4})-(?<month>1[0-2]|0[1-9])-(?<day>3[01]|0[1-9]|[12][0-9])T(?<hour>2[0-3]|[01][0-9]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9])(?<ms>\.[0-9]+)?(?<timezone>Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$";
-	static const char* regexStr = R"((-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?)";
+    // cf. https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html
+    //static const char* regexStr = "^(?<year>-?(?:[1-9][0-9]*)?[0-9]{4})-(?<month>1[0-2]|0[1-9])-(?<day>3[01]|0[1-9]|[12][0-9])T(?<hour>2[0-3]|[01][0-9]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9])(?<ms>\.[0-9]+)?(?<timezone>Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$";
+    static const char* regexStr = R"((-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?)";
 
-	auto str = Utilities::Trim(sz);
-	regex dateTimeRegex(regexStr);
-	smatch pieces_match;
-	if (regex_match(str, pieces_match, dateTimeRegex) && pieces_match.size() == 9)
-	{
-		XmlDateTime dateTime;
-		dateTime.Clear();
+    auto str = Utilities::Trim(sz);
+    regex dateTimeRegex(regexStr);
+    smatch pieces_match;
+    if (regex_match(str, pieces_match, dateTimeRegex) && pieces_match.size() == 9)
+    {
+        XmlDateTime dateTime;
+        dateTime.Clear();
 
-		if (pieces_match[1].matched)
-		{
-			dateTime.year = std::stoi(pieces_match[1]);
-		}
+        if (pieces_match[1].matched)
+        {
+            dateTime.year = std::stoi(pieces_match[1]);
+        }
 
-		if (pieces_match[2].matched)
-		{
-			dateTime.mon = std::stoi(pieces_match[2]);
-		}
+        if (pieces_match[2].matched)
+        {
+            dateTime.mon = std::stoi(pieces_match[2]);
+        }
 
-		if (pieces_match[3].matched)
-		{
-			dateTime.mday = std::stoi(pieces_match[3]);
-		}
+        if (pieces_match[3].matched)
+        {
+            dateTime.mday = std::stoi(pieces_match[3]);
+        }
 
-		if (pieces_match[4].matched)
-		{
-			dateTime.hour = std::stoi(pieces_match[4]);
-		}
+        if (pieces_match[4].matched)
+        {
+            dateTime.hour = std::stoi(pieces_match[4]);
+        }
 
-		if (pieces_match[5].matched)
-		{
-			dateTime.min = std::stoi(pieces_match[5]);
-		}
+        if (pieces_match[5].matched)
+        {
+            dateTime.min = std::stoi(pieces_match[5]);
+        }
 
-		if (pieces_match[6].matched)
-		{
-			dateTime.sec = std::stoi(pieces_match[6]);
-		}
+        if (pieces_match[6].matched)
+        {
+            dateTime.sec = std::stoi(pieces_match[6]);
+        }
 
-		// note that we skip the decimal places of "second"...
+        // note that we skip the decimal places of "second"...
 
-		if (pieces_match[8].matched)
-		{
-			auto strTimezone = pieces_match[8].str();
-			char _1stChar = strTimezone[0];
-			if (_1stChar == 'Z')
-			{
-				dateTime.isUTC = true;
-			}
-			else if ((_1stChar == '+' || _1stChar == '-') && strTimezone.length() >= 6)
-			{
-				dateTime.offsetHours = std::stoi(strTimezone.substr(0, 3));
-				dateTime.offsetMinutes = std::stoi(strTimezone.substr(4, 2));
-			}
-		}
+        if (pieces_match[8].matched)
+        {
+            auto strTimezone = pieces_match[8].str();
+            char _1stChar = strTimezone[0];
+            if (_1stChar == 'Z')
+            {
+                dateTime.isUTC = true;
+            }
+            else if ((_1stChar == '+' || _1stChar == '-') && strTimezone.length() >= 6)
+            {
+                dateTime.offsetHours = std::stoi(strTimezone.substr(0, 3));
+                dateTime.offsetMinutes = std::stoi(strTimezone.substr(4, 2));
+            }
+        }
 
-		if (dateTime.IsValid())
-		{
-			if (ptrDateTime != nullptr)
-			{
-				*ptrDateTime = dateTime;
-			}
+        if (dateTime.IsValid())
+        {
+            if (ptrDateTime != nullptr)
+            {
+                *ptrDateTime = dateTime;
+            }
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
-/*static*/void libCZI::MetadataUtils::WriteImageSizeInformation(libCZI::ICziMetadataBuilder * builder, int width, int height)
+/*static*/void libCZI::MetadataUtils::WriteImageSizeInformation(libCZI::ICziMetadataBuilder* builder, int width, int height)
 {
-	auto root = builder->GetRootNode();
-	root->GetOrCreateChildNode("Metadata/Information/Image/SizeX")->SetValueI32(width);
-	root->GetOrCreateChildNode("Metadata/Information/Image/SizeY")->SetValueI32(height);
+    auto root = builder->GetRootNode();
+    root->GetOrCreateChildNode("Metadata/Information/Image/SizeX")->SetValueI32(width);
+    root->GetOrCreateChildNode("Metadata/Information/Image/SizeY")->SetValueI32(height);
 }
 
-/*static*/void libCZI::MetadataUtils::WriteMIndexSizeInformation(libCZI::ICziMetadataBuilder * builder, int mSize)
+/*static*/void libCZI::MetadataUtils::WriteMIndexSizeInformation(libCZI::ICziMetadataBuilder* builder, int mSize)
 {
-	auto root = builder->GetRootNode();
-	root->GetOrCreateChildNode("Metadata/Information/Image/SizeM")->SetValueI32(mSize);
+    auto root = builder->GetRootNode();
+    root->GetOrCreateChildNode("Metadata/Information/Image/SizeM")->SetValueI32(mSize);
 }
 
-/*static*/void libCZI::MetadataUtils::WriteDimensionSize(libCZI::ICziMetadataBuilder * builder, libCZI::DimensionIndex dim, int size)
+/*static*/void libCZI::MetadataUtils::WriteDimensionSize(libCZI::ICziMetadataBuilder* builder, libCZI::DimensionIndex dim, int size)
 {
-	string s{ "Metadata/Information/Image/Size_" };
-	*(s.end() - 1) = Utils::DimensionToChar(dim);
-	auto root = builder->GetRootNode();
-	root->GetOrCreateChildNode(s.c_str())->SetValueI32(size);
+    string s{ "Metadata/Information/Image/Size_" };
+    *(s.end() - 1) = Utils::DimensionToChar(dim);
+    auto root = builder->GetRootNode();
+    root->GetOrCreateChildNode(s.c_str())->SetValueI32(size);
 }
 
-/*static*/void libCZI::MetadataUtils::WriteFillWithSubBlockStatistics(libCZI::ICziMetadataBuilder * builder, const libCZI::SubBlockStatistics & statistics)
+/*static*/void libCZI::MetadataUtils::WriteFillWithSubBlockStatistics(libCZI::ICziMetadataBuilder* builder, const libCZI::SubBlockStatistics& statistics)
 {
-	MetadataUtils::WriteImageSizeInformation(builder, statistics.boundingBox.w, statistics.boundingBox.h);
-	statistics.dimBounds.EnumValidDimensions(
-		[&](libCZI::DimensionIndex dim, int start, int size)->bool
-	{
-		MetadataUtils::WriteDimensionSize(builder, dim, size);
-		return true;
-	});
+    MetadataUtils::WriteImageSizeInformation(builder, statistics.boundingBox.w, statistics.boundingBox.h);
+    statistics.dimBounds.EnumValidDimensions(
+        [&](libCZI::DimensionIndex dim, int start, int size)->bool
+        {
+            MetadataUtils::WriteDimensionSize(builder, dim, size);
+            return true;
+        });
 
-	if (statistics.IsMIndexValid())
-	{
-		MetadataUtils::WriteMIndexSizeInformation(builder, statistics.maxMindex - statistics.minMindex + 1);
-	}
+    if (statistics.IsMIndexValid())
+    {
+        MetadataUtils::WriteMIndexSizeInformation(builder, statistics.maxMindex - statistics.minMindex + 1);
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteDimInfoT_Interval(ICziMetadataBuilder * builder, const XmlDateTime * startTime, double startOffSet, double increment)
+/*static*/void libCZI::MetadataUtils::WriteDimInfoT_Interval(ICziMetadataBuilder* builder, const XmlDateTime* startTime, double startOffSet, double increment)
 {
-	if (startTime != nullptr)
-	{
-		auto s = startTime->ToXmlString();
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValue(s.c_str());
-	}
+    if (startTime != nullptr)
+    {
+        auto s = startTime->ToXmlString();
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValue(s.c_str());
+    }
 
-	if (!isnan(startOffSet) && !isinf(startOffSet))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/Interval/Start")->SetValueDbl(startOffSet);
-	}
+    if (!isnan(startOffSet) && !isinf(startOffSet))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/Interval/Start")->SetValueDbl(startOffSet);
+    }
 
-	if (!isnan(increment) && !isinf(increment))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/Interval/Increment")->SetValueDbl(increment);
-	}
+    if (!isnan(increment) && !isinf(increment))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/Interval/Increment")->SetValueDbl(increment);
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteDimInfoT_List(ICziMetadataBuilder * builder, const XmlDateTime * startTime, const std::function<double(int)>& funcGetOffsets)
+/*static*/void libCZI::MetadataUtils::WriteDimInfoT_List(ICziMetadataBuilder* builder, const XmlDateTime* startTime, const std::function<double(int)>& funcGetOffsets)
 {
-	if (startTime != nullptr)
-	{
-		auto s = startTime->ToXmlString();
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValue(s.c_str());
-	}
+    if (startTime != nullptr)
+    {
+        auto s = startTime->ToXmlString();
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValue(s.c_str());
+    }
 
-	if (funcGetOffsets)
-	{
-		stringstream ss;
-		for (int i = 0;; ++i)
-		{
-			double v = funcGetOffsets(i);
-			if (isnan(v) || isinf(v))
-			{
-				break;
-			}
+    if (funcGetOffsets)
+    {
+        stringstream ss;
+        for (int i = 0;; ++i)
+        {
+            double v = funcGetOffsets(i);
+            if (isnan(v) || isinf(v))
+            {
+                break;
+            }
 
-			if (i > 0)
-			{
-				ss << ' ';
-			}
+            if (i > 0)
+            {
+                ss << ' ';
+            }
 
-			ss << std::setprecision(numeric_limits<double>::digits10) << v;
-		}
+            ss << std::setprecision(numeric_limits<double>::digits10) << v;
+        }
 
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/List/Offsets")->SetValue(ss.str().c_str());
-	}
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/Positions/List/Offsets")->SetValue(ss.str().c_str());
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteDimInfoZ_Interval(ICziMetadataBuilder * builder, double startPos, double startOffSet, double increment)
+/*static*/void libCZI::MetadataUtils::WriteDimInfoZ_Interval(ICziMetadataBuilder* builder, double startPos, double startOffSet, double increment)
 {
-	if (!isnan(startPos) && !isinf(startPos))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/StartPosition")->SetValueDbl(startPos);
-	}
+    if (!isnan(startPos) && !isinf(startPos))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/StartPosition")->SetValueDbl(startPos);
+    }
 
-	if (!isnan(startOffSet) && !isinf(startOffSet))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/Interval/Start")->SetValueDbl(startOffSet);
-	}
+    if (!isnan(startOffSet) && !isinf(startOffSet))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/Interval/Start")->SetValueDbl(startOffSet);
+    }
 
-	if (!isnan(increment) && !isinf(increment))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/Interval/Increment")->SetValueDbl(increment);
-	}
+    if (!isnan(increment) && !isinf(increment))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/Interval/Increment")->SetValueDbl(increment);
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteDimInfoZ_List(ICziMetadataBuilder * builder, double startPos, const std::function<double(int)>& funcGetOffsets)
+/*static*/void libCZI::MetadataUtils::WriteDimInfoZ_List(ICziMetadataBuilder* builder, double startPos, const std::function<double(int)>& funcGetOffsets)
 {
-	if (!isnan(startPos) && !isinf(startPos))
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValueDbl(startPos);
-	}
+    if (!isnan(startPos) && !isinf(startPos))
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/T/StartTime")->SetValueDbl(startPos);
+    }
 
-	if (funcGetOffsets)
-	{
-		stringstream ss;
-		for (int i = 0;; ++i)
-		{
-			double v = funcGetOffsets(i);
-			if (isnan(v) || isinf(v))
-			{
-				break;
-			}
+    if (funcGetOffsets)
+    {
+        stringstream ss;
+        for (int i = 0;; ++i)
+        {
+            double v = funcGetOffsets(i);
+            if (isnan(v) || isinf(v))
+            {
+                break;
+            }
 
-			if (i > 0)
-			{
-				ss << ' ';
-			}
+            if (i > 0)
+            {
+                ss << ' ';
+            }
 
-			ss << std::setprecision(numeric_limits<double>::digits10) << v;
-		}
+            ss << std::setprecision(numeric_limits<double>::digits10) << v;
+        }
 
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/List/Offsets")->SetValue(ss.str().c_str());
-	}
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Dimensions/Z/Positions/List/Offsets")->SetValue(ss.str().c_str());
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteGeneralDocumentInfo(ICziMetadataBuilder * builder, const libCZI::GeneralDocumentInfo & info)
+/*static*/void libCZI::MetadataUtils::WriteGeneralDocumentInfo(ICziMetadataBuilder* builder, const libCZI::GeneralDocumentInfo& info)
 {
-	const auto setField = [=](bool isValid, const char* nodeName, const wstring & s)
-	{
-		if (isValid)
-		{
-			string n("Metadata/Information/Document/");
-			n.append(nodeName);
-			builder->GetRootNode()->GetOrCreateChildNode(n.c_str())->SetValue(s.c_str());
-		}
-	};
+    const auto setField = [=](bool isValid, const char* nodeName, const wstring& s)
+    {
+        if (isValid)
+        {
+            string n("Metadata/Information/Document/");
+            n.append(nodeName);
+            builder->GetRootNode()->GetOrCreateChildNode(n.c_str())->SetValue(s.c_str());
+        }
+    };
 
-	setField(info.name_valid, "Name", info.name);
-	setField(info.title_valid, "Title", info.title);
-	setField(info.userName_valid, "UserName", info.userName);
-	setField(info.description_valid, "Description", info.description);
-	setField(info.comment_valid, "Comment", info.comment);
-	setField(info.keywords_valid, "Keywords", info.keywords);
-	setField(info.creationDateTime_valid, "CreationDate", info.creationDateTime);
+    setField(info.name_valid, "Name", info.name);
+    setField(info.title_valid, "Title", info.title);
+    setField(info.userName_valid, "UserName", info.userName);
+    setField(info.description_valid, "Description", info.description);
+    setField(info.comment_valid, "Comment", info.comment);
+    setField(info.keywords_valid, "Keywords", info.keywords);
+    setField(info.creationDateTime_valid, "CreationDate", info.creationDateTime);
 
-	if (info.rating_valid)
-	{
-		builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Document/Rating")->SetValueI32(info.rating);
-	}
+    if (info.rating_valid)
+    {
+        builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Document/Rating")->SetValueI32(info.rating);
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteScalingInfo(libCZI::ICziMetadataBuilder * builder, const libCZI::ScalingInfo & scalingInfo)
+/*static*/void libCZI::MetadataUtils::WriteScalingInfo(libCZI::ICziMetadataBuilder* builder, const libCZI::ScalingInfo& scalingInfo)
 {
-	for (char d : { 'X', 'Y', 'Z' })
-	{
-		if (scalingInfo.IsScaleValid(d))
-		{
-			stringstream ss;
-			ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/Value";
-			builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValueDbl(scalingInfo.GetScale(d));
-		}
-	}
+    for (char d : { 'X', 'Y', 'Z' })
+    {
+        if (scalingInfo.IsScaleValid(d))
+        {
+            stringstream ss;
+            ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/Value";
+            builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValueDbl(scalingInfo.GetScale(d));
+        }
+    }
 }
 
-/*static*/void libCZI::MetadataUtils::WriteScalingInfoEx(libCZI::ICziMetadataBuilder * builder, const libCZI::ScalingInfoEx & scalingInfo)
+/*static*/void libCZI::MetadataUtils::WriteScalingInfoEx(libCZI::ICziMetadataBuilder* builder, const libCZI::ScalingInfoEx& scalingInfo)
 {
-	for (char d : { 'X', 'Y', 'Z' })
-	{
-		if (scalingInfo.IsScaleValid(d) || !scalingInfo.GetDefaultUnitFormat(d).empty())
-		{
-			if (scalingInfo.IsScaleValid(d))
-			{
-				stringstream ss;
-				ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/Value";
-				builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValueDbl(scalingInfo.GetScale(d));
-			}
+    for (char d : { 'X', 'Y', 'Z' })
+    {
+        if (scalingInfo.IsScaleValid(d) || !scalingInfo.GetDefaultUnitFormat(d).empty())
+        {
+            if (scalingInfo.IsScaleValid(d))
+            {
+                stringstream ss;
+                ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/Value";
+                builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValueDbl(scalingInfo.GetScale(d));
+            }
 
-			if (!scalingInfo.GetDefaultUnitFormat(d).empty())
-			{
-				stringstream ss;
-				ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/DefaultUnitFormat";
-				builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValue(scalingInfo.GetDefaultUnitFormat(d));
-			}
-		}
-	}
+            if (!scalingInfo.GetDefaultUnitFormat(d).empty())
+            {
+                stringstream ss;
+                ss << "Metadata/Scaling/Items/Distance[Id=" << d << "]/DefaultUnitFormat";
+                builder->GetRootNode()->GetOrCreateChildNode(ss.str())->SetValue(scalingInfo.GetDefaultUnitFormat(d));
+            }
+        }
+    }
+}
+
+/*static*/void libCZI::MetadataUtils::WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings)
+{
+    //vector<int> channel_indices_from_display_settings;
+    int max_channel_index_in_display_settings = 0;
+    display_settings->EnumChannels(
+        [&](int channel_index)->bool
+        {
+            //channel_indices_from_display_settings.push_back(channel_index);
+            if (channel_index > max_channel_index_in_display_settings)
+            {
+                max_channel_index_in_display_settings = channel_index;
+            }
+
+            return true;
+        });
+
+    MetadataUtils::WriteDisplaySettings(builder, display_settings, max_channel_index_in_display_settings);
+}
+
+static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_display_setting, IXmlNodeRw* node)
+{
+    node->GetOrCreateChildNode("IsSelected")->SetValueBool(channel_display_setting->GetIsEnabled());
+
+    Rgb8Color tinting_color;
+    if (channel_display_setting->TryGetTintingColorRgb8(&tinting_color))
+    {
+        node->GetOrCreateChildNode("Color")->SetValue(Utilities::Rgb8ColorToString(tinting_color));
+    }
+
+    float black_point, white_point;
+    channel_display_setting->GetBlackWhitePoint(&black_point, &white_point);
+    node->GetOrCreateChildNode("Low")->SetValueFlt(black_point);
+    node->GetOrCreateChildNode("High")->SetValueFlt(white_point);
+
+    auto gradation_curve_mode = channel_display_setting->GetGradationCurveMode();
+    if (gradation_curve_mode == IDisplaySettings::GradationCurveMode::Gamma)
+    {
+        float gamma;
+        if (channel_display_setting->TryGetGamma(&gamma))
+        {
+            node->GetOrCreateChildNode("Gamma")->SetValueFlt(gamma);
+        }
+    }
+}
+
+/*static*/void libCZI::MetadataUtils::WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings, int channel_count)
+{
+    auto display_settings_channel_node = builder->GetRootNode()->GetOrCreateChildNode("Metadata/DisplaySetting/Channels");
+    for (int c = 0; c < channel_count; ++c)
+    {
+        auto channel_display_settings = display_settings->GetChannelDisplaySettings(c);
+        auto channel_node = display_settings_channel_node->AppendChildNode("Channel");
+        if (channel_display_settings)
+        {
+            WriteChannelDisplaySettings(channel_display_settings.get(), channel_node.get());
+        }
+    }
 }
 
 /*static*/void libCZI::MetadataUtils::SetOrAddCustomKeyValuePair(libCZI::ICziMetadataBuilder* builder, const string& key, const libCZI::CustomValueVariant& value)
 {
-	auto root = builder->GetRootNode();
-	const regex isValidNodename(R"(^([_a-z][\w]?|[a-w_yz][\w]{2,}|[_a-z][a-l_n-z\d][\w]+|[_a-z][\w][a-k_m-z\d][\w]*)$)", regex_constants::icase);
+    auto root = builder->GetRootNode();
+    const regex isValidNodename(R"(^([_a-z][\w]?|[a-w_yz][\w]{2,}|[_a-z][a-l_n-z\d][\w]+|[_a-z][\w][a-k_m-z\d][\w]*)$)", regex_constants::icase);
 
-	if (!regex_match(key, isValidNodename)) 
-	{
-		stringstream errorMessage;
-		errorMessage << "\"" << key << "\" is not a valid ElementName.";
-		throw invalid_argument(errorMessage.str());
-	}
+    if (!regex_match(key, isValidNodename))
+    {
+        stringstream errorMessage;
+        errorMessage << "\"" << key << "\" is not a valid ElementName.";
+        throw invalid_argument(errorMessage.str());
+    }
 
-	stringstream ss;
-	ss << "Metadata/Information/CustomAttributes/KeyValue/" << key;
+    stringstream ss;
+    ss << "Metadata/Information/CustomAttributes/KeyValue/" << key;
 
-	switch (value.GetType())
-	{
-		case CustomValueVariant::Type::String:
-			{
-			auto newNode = root->GetOrCreateChildNode(ss.str()); 
-			newNode->SetValue(value.GetAsStringOrThrow());
-			newNode->SetAttribute("Type", "String");
-			}
+    switch (value.GetType())
+    {
+    case CustomValueVariant::Type::String:
+    {
+        auto newNode = root->GetOrCreateChildNode(ss.str());
+        newNode->SetValue(value.GetAsStringOrThrow());
+        newNode->SetAttribute("Type", "String");
+    }
 
-			break;
-		case CustomValueVariant::Type::Boolean:
-			{
-			auto newNode = root->GetOrCreateChildNode(ss.str());
-			newNode->SetValueBool(value.GetAsBoolOrThrow());
-			newNode->SetAttribute("Type", "Boolean");
-			}
+    break;
+    case CustomValueVariant::Type::Boolean:
+    {
+        auto newNode = root->GetOrCreateChildNode(ss.str());
+        newNode->SetValueBool(value.GetAsBoolOrThrow());
+        newNode->SetAttribute("Type", "Boolean");
+    }
 
-			break;
-		case CustomValueVariant::Type::Int32:
-			{
-			auto newNode = root->GetOrCreateChildNode(ss.str());
-			newNode->SetValueI32(value.GetAsInt32OrThrow());
-			newNode->SetAttribute("Type", "Int32");
-			}
+    break;
+    case CustomValueVariant::Type::Int32:
+    {
+        auto newNode = root->GetOrCreateChildNode(ss.str());
+        newNode->SetValueI32(value.GetAsInt32OrThrow());
+        newNode->SetAttribute("Type", "Int32");
+    }
 
-			break;
-		case CustomValueVariant::Type::Double:
-			{
-			auto newNode = root->GetOrCreateChildNode(ss.str());
-			newNode->SetValueDbl(value.GetAsDoubleOrThrow());
-			newNode->SetAttribute("Type", "Double");
-			}
+    break;
+    case CustomValueVariant::Type::Double:
+    {
+        auto newNode = root->GetOrCreateChildNode(ss.str());
+        newNode->SetValueDbl(value.GetAsDoubleOrThrow());
+        newNode->SetAttribute("Type", "Double");
+    }
 
-			break;
-		case CustomValueVariant::Type::Float:
-			{
-			auto newNode = root->GetOrCreateChildNode(ss.str());
-			newNode->SetValueFlt(value.GetAsFloatOrThrow());
-			newNode->SetAttribute("Type", "Float");
-			}
+    break;
+    case CustomValueVariant::Type::Float:
+    {
+        auto newNode = root->GetOrCreateChildNode(ss.str());
+        newNode->SetValueFlt(value.GetAsFloatOrThrow());
+        newNode->SetAttribute("Type", "Float");
+    }
 
-			break;
-		default:
-			throw invalid_argument("Invalid ValueType.");
-	}
+    break;
+    default:
+        throw invalid_argument("Invalid ValueType.");
+    }
 }
 

--- a/Src/libCZI/CziMetadataBuilder.h
+++ b/Src/libCZI/CziMetadataBuilder.h
@@ -64,7 +64,10 @@ public:
 	void SetValueBool(bool value) override;
 	void SetValueI64(long long value) override;
 	void SetValueUI64(unsigned long long value) override;
-
+	void RemoveChildren() override;
+	void RemoveAttributes() override;
+    bool RemoveChild(const char* name) override;
+	bool RemoveAttribute(const char* name) override;
 private:
 	std::shared_ptr<IXmlNodeRw> GetOrCreateChildNode(const char* path, bool allowCreation);
 	pugi::xml_node GetOrCreateChildElementNode(const wchar_t* sz, bool allowCreation);

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -482,7 +482,7 @@ using namespace libCZI;
 	return ad;
 }
 
-/*static*/void CCZIParse::ParseThroughDirectoryEntries(int count, std::function<void(int, void*)> funcRead, std::function<void(const SubBlockDirectoryEntryDE*, const SubBlockDirectoryEntryDV*)> funcAddEntry)
+/*static*/void CCZIParse::ParseThroughDirectoryEntries(int count, const std::function<void(int, void*)>& funcRead, const std::function<void(const SubBlockDirectoryEntryDE*, const SubBlockDirectoryEntryDV*)>& funcAddEntry)
 {
 	for (int i = 0; i < count; ++i)
 	{

--- a/Src/libCZI/CziParse.h
+++ b/Src/libCZI/CziParse.h
@@ -13,102 +13,102 @@
 
 class CCZIParse
 {
-	friend class CCZIParseTest;	
+    friend class CCZIParseTest;
 public:
-	static const std::uint8_t FILEHDRMAGIC[16];
-	static const std::uint8_t SUBBLKDIRMAGIC[16];
-	static const std::uint8_t SUBBLKMAGIC[16];
-	static const std::uint8_t METADATASEGMENTMAGIC[16];
-	static const std::uint8_t ATTACHMENTSDIRMAGC[16];
-	static const std::uint8_t ATTACHMENTBLKMAGIC[16];
-	static const std::uint8_t DELETEDSEGMENTMAGIC[16];
+    static const std::uint8_t FILEHDRMAGIC[16];
+    static const std::uint8_t SUBBLKDIRMAGIC[16];
+    static const std::uint8_t SUBBLKMAGIC[16];
+    static const std::uint8_t METADATASEGMENTMAGIC[16];
+    static const std::uint8_t ATTACHMENTSDIRMAGC[16];
+    static const std::uint8_t ATTACHMENTBLKMAGIC[16];
+    static const std::uint8_t DELETEDSEGMENTMAGIC[16];
 public:
-	enum class SegmentType
-	{
-		SbBlkDirectory,
-		SbBlk,
-		AttchmntDirectory,
-		Attachment,
-		Metadata
-	};
-	struct SegmentSizes
-	{
-		std::int64_t AllocatedSize;
-		std::int64_t UsedSize;
-		std::int64_t GetTotalSegmentSize() const { return this->AllocatedSize + sizeof(SegmentHeader); }
-	};
+    enum class SegmentType
+    {
+        SbBlkDirectory,
+        SbBlk,
+        AttchmntDirectory,
+        Attachment,
+        Metadata
+    };
+    struct SegmentSizes
+    {
+        std::int64_t AllocatedSize;
+        std::int64_t UsedSize;
+        std::int64_t GetTotalSegmentSize() const { return this->AllocatedSize + sizeof(SegmentHeader); }
+    };
 
-	static FileHeaderSegmentData ReadFileHeaderSegment(libCZI::IStream* str);
-	static CFileHeaderSegmentData ReadFileHeaderSegmentData(libCZI::IStream* str);
+    static FileHeaderSegmentData ReadFileHeaderSegment(libCZI::IStream* str);
+    static CFileHeaderSegmentData ReadFileHeaderSegmentData(libCZI::IStream* str);
 
-	static CCziSubBlockDirectory ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset);
-	static CCziAttachmentsDirectory ReadAttachmentsDirectory(libCZI::IStream* str, std::uint64_t offset);
-	static void ReadAttachmentsDirectory(libCZI::IStream* str, std::uint64_t offset, const std::function<void(const CCziAttachmentsDirectoryBase::AttachmentEntry&)>& addFunc, SegmentSizes* segmentSizes = nullptr);
+    static CCziSubBlockDirectory ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset);
+    static CCziAttachmentsDirectory ReadAttachmentsDirectory(libCZI::IStream* str, std::uint64_t offset);
+    static void ReadAttachmentsDirectory(libCZI::IStream* str, std::uint64_t offset, const std::function<void(const CCziAttachmentsDirectoryBase::AttachmentEntry&)>& addFunc, SegmentSizes* segmentSizes = nullptr);
 
-	static void ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset, CCziSubBlockDirectory& subBlkDir);
+    static void ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset, CCziSubBlockDirectory& subBlkDir);
 
-	static void ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc, SegmentSizes* segmentSizes=nullptr);
-	
-	struct SubBlockStorageAllocate
-	{
-		std::function<void*(size_t size)> alloc;
-		std::function<void(void*)> free;
-	};
+    static void ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc, SegmentSizes* segmentSizes = nullptr);
 
-	struct SubBlockData
-	{
-		void*			ptrData;
-		std::uint64_t	dataSize;
-		void*			ptrAttachment;
-		std::uint32_t	attachmentSize;
-		void*			ptrMetadata;
-		std::uint32_t	metaDataSize;
+    struct SubBlockStorageAllocate
+    {
+        std::function<void* (size_t size)> alloc;
+        std::function<void(void*)> free;
+    };
 
-		int						compression;
-		int						pixelType;
-		libCZI::CDimCoordinate	coordinate;
-		libCZI::IntRect			logicalRect;
-		libCZI::IntSize			physicalSize;
-		int						mIndex;			// if not present, then this is int::max
-	};
+    struct SubBlockData
+    {
+        void*           ptrData;
+        std::uint64_t	dataSize;
+        void*           ptrAttachment;
+        std::uint32_t	attachmentSize;
+        void*           ptrMetadata;
+        std::uint32_t	metaDataSize;
 
-	static SubBlockData ReadSubBlock(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
+        int						compression;
+        int						pixelType;
+        libCZI::CDimCoordinate	coordinate;
+        libCZI::IntRect			logicalRect;
+        libCZI::IntSize			physicalSize;
+        int						mIndex;			// if not present, then this is int::max
+    };
 
-	struct MetadataSegmentData
-	{
-		void*			ptrXmlData;
-		std::uint64_t	xmlDataSize;
-		void*			ptrAttachment;
-		std::uint32_t	attachmentSize;
-	};
+    static SubBlockData ReadSubBlock(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
 
-	static MetadataSegmentData ReadMetadataSegment(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
+    struct MetadataSegmentData
+    {
+        void*           ptrXmlData;
+        std::uint64_t	xmlDataSize;
+        void*           ptrAttachment;
+        std::uint32_t	attachmentSize;
+    };
 
-	struct AttachmentData
-	{
-		void*			ptrData;
-		std::uint64_t	dataSize;
-	};
+    static MetadataSegmentData ReadMetadataSegment(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
 
-	static AttachmentData ReadAttachment(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
+    struct AttachmentData
+    {
+        void*           ptrData;
+        std::uint64_t	dataSize;
+    };
 
-	static CCZIParse::SegmentSizes ReadSegmentHeader(SegmentType type, libCZI::IStream* str,std::uint64_t pos);
-	static CCZIParse::SegmentSizes ReadSegmentHeaderAny(libCZI::IStream* str, std::uint64_t pos);
+    static AttachmentData ReadAttachment(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);
+
+    static CCZIParse::SegmentSizes ReadSegmentHeader(SegmentType type, libCZI::IStream* str, std::uint64_t pos);
+    static CCZIParse::SegmentSizes ReadSegmentHeaderAny(libCZI::IStream* str, std::uint64_t pos);
 private:
-	static void ParseThroughDirectoryEntries(int count, std::function<void(int, void*)> funcRead, std::function<void(const SubBlockDirectoryEntryDE*, const SubBlockDirectoryEntryDV*)> funcAddEntry);
+    static void ParseThroughDirectoryEntries(int count, const std::function<void(int, void*)>& funcRead, const std::function<void(const SubBlockDirectoryEntryDE*, const SubBlockDirectoryEntryDV*)>& funcAddEntry);
 
-	static void AddEntryToSubBlockDirectory(const SubBlockDirectoryEntryDE* subBlkDirDE, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc/*CCziSubBlockDirectory& subBlkDir*/);
-	static void AddEntryToSubBlockDirectory(const SubBlockDirectoryEntryDV* subBlkDirDE, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc/*CCziSubBlockDirectory& subBlkDir*/);
+    static void AddEntryToSubBlockDirectory(const SubBlockDirectoryEntryDE* subBlkDirDE, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc);
+    static void AddEntryToSubBlockDirectory(const SubBlockDirectoryEntryDV* subBlkDirDE, const std::function<void(const CCziSubBlockDirectoryBase::SubBlkEntry&)>& addFunc);
 
-	static libCZI::DimensionIndex DimensionCharToDimensionIndex(const char* ptr, size_t size);
-	static bool IsMDimension(const char* ptr, size_t size);
-	static bool IsXDimension(const char* ptr, size_t size);
-	static bool IsYDimension(const char* ptr, size_t size);
-	static char ToUpperCase(char c);
+    static libCZI::DimensionIndex DimensionCharToDimensionIndex(const char* ptr, size_t size);
+    static bool IsMDimension(const char* ptr, size_t size);
+    static bool IsXDimension(const char* ptr, size_t size);
+    static bool IsYDimension(const char* ptr, size_t size);
+    static char ToUpperCase(char c);
 
-	static void ThrowNotEnoughDataRead(std::uint64_t offset, std::uint64_t bytesRequested, std::uint64_t bytesActuallyRead);
-	static void ThrowIllegalData(std::uint64_t offset, const char* sz);
-	static void ThrowIllegalData(const char* sz);
+    static void ThrowNotEnoughDataRead(std::uint64_t offset, std::uint64_t bytesRequested, std::uint64_t bytesActuallyRead);
+    static void ThrowIllegalData(std::uint64_t offset, const char* sz);
+    static void ThrowIllegalData(const char* sz);
 
-	static bool CheckAttachmentSchemaType(const char* p, size_t cnt);
+    static bool CheckAttachmentSchemaType(const char* p, size_t cnt);
 };

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -19,8 +19,8 @@ using namespace std;
 struct AddHelper
 {
     ICziReaderWriter* t;
-    AddHelper(ICziReaderWriter* t)
-        :t(t) {};
+    AddHelper(ICziReaderWriter* t) :t(t)
+    {}
 
     void operator()(const AddSubBlockInfo& addSbBlkInfo) const
     {
@@ -274,7 +274,7 @@ void CCziReaderWriter::Finish()
                 [&](size_t index, const CCziSubBlockDirectoryBase::SubBlkEntry& e)->bool
                 {
                     f(index, e);
-                    return true;
+            return true;
                 });
         };
         sbBlkDirWriteInfo.writeFunc = std::bind(&CCziReaderWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);
@@ -312,7 +312,7 @@ void CCziReaderWriter::Finish()
                 [&](size_t index, const CCziAttachmentsDirectoryBase::AttachmentEntry& e)->bool
                 {
                     f(index, e);
-                    return true;
+            return true;
                 });
         };
         attchmntDirWriteInfo.writeFunc = std::bind(&CCziReaderWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);
@@ -481,7 +481,7 @@ void CCziReaderWriter::DetermineNextSubBlockOffset()
                 lastSegmentPos = sbBlkEntry.FilePosition;
             }
 
-            return true;
+    return true;
         });
 
     this->attachmentDirectory.EnumEntries(
@@ -492,7 +492,7 @@ void CCziReaderWriter::DetermineNextSubBlockOffset()
                 lastSegmentPos = attEntry.FilePosition;
             }
 
-            return true;
+    return true;
         });
 
     if (this->hdrSegmentData.GetIsSubBlockDirectoryPositionValid())
@@ -641,12 +641,12 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
         [&](int index, const CCziSubBlockDirectory::SubBlkEntry& entry)->bool
         {
             SubBlockInfo info;
-            info.coordinate = entry.coordinate;
-            info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
-            info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
-            info.mIndex = entry.mIndex;
-            info.pixelType = CziUtils::PixelTypeFromInt(entry.PixelType);
-            return funcEnum(index, info);
+    info.coordinate = entry.coordinate;
+    info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
+    info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
+    info.mIndex = entry.mIndex;
+    info.pixelType = CziUtils::PixelTypeFromInt(entry.PixelType);
+    return funcEnum(index, info);
         });
 }
 
@@ -727,11 +727,11 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
         [&](int index, const CCziAttachmentsDirectoryBase::AttachmentEntry& entry)->bool
         {
             libCZI::AttachmentInfo info;
-            info.contentGuid = entry.ContentGuid;
-            memcpy(info.contentFileType, entry.ContentFileType, sizeof(entry.ContentFileType));
-            info.name = entry.Name;
-            bool b = funcEnum(index, info);
-            return b;
+    info.contentGuid = entry.ContentGuid;
+    memcpy(info.contentFileType, entry.ContentFileType, sizeof(entry.ContentFileType));
+    info.name = entry.Name;
+    bool b = funcEnum(index, info);
+    return b;
         });
 }
 

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -369,8 +369,6 @@ void CSbBlkStatisticsUpdater::SortPyramidStatistics()
 
 CCziSubBlockDirectory::CCziSubBlockDirectory() : state(State::AddingAllowed)
 {
-	/*this->statistics.Invalidate();
-	this->statistics.subBlockCount = 0;*/
 }
 
 void CCziSubBlockDirectory::AddSubBlock(const SubBlkEntry& entry)
@@ -381,7 +379,6 @@ void CCziSubBlockDirectory::AddSubBlock(const SubBlkEntry& entry)
 	}
 
 	this->subBlks.push_back(entry);
-	//this->UpdateStatistics(entry);
 	this->sblkStatistics.UpdateStatistics(entry);
 }
 
@@ -389,12 +386,10 @@ void CCziSubBlockDirectory::AddingFinished()
 {
 	this->state = State::AddingFinished;
 	this->sblkStatistics.Consolidate();
-	//this->SortPyramidStatistics();
 }
 
 const libCZI::SubBlockStatistics& CCziSubBlockDirectory::GetStatistics() const
 {
-	//return this->statistics;
 	return this->sblkStatistics.GetStatistics();
 }
 

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -404,7 +404,7 @@ const libCZI::PyramidStatistics& CCziSubBlockDirectory::GetPyramidStatistics() c
 	return this->sblkStatistics.GetPyramidStatistics();
 }
 
-void CCziSubBlockDirectory::EnumSubBlocks(std::function<bool(int index, const SubBlkEntry&)> func)
+void CCziSubBlockDirectory::EnumSubBlocks(const std::function<bool(int index, const SubBlkEntry&)>& func)
 {
 	int i = 0;
 	for (auto it = this->subBlks.cbegin(); it != this->subBlks.cend(); ++it)

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -92,7 +92,7 @@ public:
 	void AddSubBlock(const SubBlkEntry& entry);
 	void AddingFinished();
 
-	void EnumSubBlocks(std::function<bool(int index, const SubBlkEntry&)> func);
+	void EnumSubBlocks(const std::function<bool(int index, const SubBlkEntry&)>& func);
 	bool TryGetSubBlock(int index, SubBlkEntry& entry) const;
 };
 

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -1320,6 +1320,10 @@ namespace libCZI
 		/// \param 		key         Key of the custom key-value pair.
 		/// \param 		value       Value of the custom key-value pair.                       
 		static void SetOrAddCustomKeyValuePair(libCZI::ICziMetadataBuilder* builder, const std::string& key, const libCZI::CustomValueVariant& value);
+
+		static void WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings);
+
+		static void WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings, int channel_count);
 	};
 	}
 

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -1321,8 +1321,17 @@ namespace libCZI
 		/// \param 		value       Value of the custom key-value pair.                       
 		static void SetOrAddCustomKeyValuePair(libCZI::ICziMetadataBuilder* builder, const std::string& key, const libCZI::CustomValueVariant& value);
 
+		/// Helper function which writes the specified display-settings into the specified metadata-builder. The display-settings
+		/// XML-metadata-node will have as many channel-items as the highest channel-number found in the display-settings object.
+		/// \param [in] builder             The metadata-builder object.
+		/// \param      display_settings	The display settings.
 		static void WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings);
 
+        /// Helper function which writes the specified display-settings into the specified metadata-builder. The display-settings
+        /// XML-metadata-node will have as many channel-items as specified with the argument 'channel_count'.
+        /// \param [in] builder             The metadata-builder object.
+        /// \param      display_settings	The display settings.
+        /// \param      channel_count       The number of channels (which are constructed in the display-settings XML-metadata).
 		static void WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings, int channel_count);
 	};
 	}

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -987,7 +987,25 @@ namespace libCZI
 		/// \param value The unsigned long integer to write into the node.
 		virtual void SetValueUI64(unsigned long long value) = 0;
 
-		virtual ~IXmlNodeWrite() {};
+        /// Removes all children of this node.
+		virtual void RemoveChildren() = 0;
+
+		/// Removes all attributes of this node.
+		virtual void RemoveAttributes() = 0;
+
+        /// Removes the child node with the specified name. In case that there a multiple children
+        /// with the specified name, then only the first is removed.
+        /// \param  name    The name of the node to be removed.
+        /// \returns    True if the node was found and successfully removed; false otherwise (i.e. if it did not exist).
+		virtual bool RemoveChild(const char* name) = 0;
+
+		/// Removes the attribute with the specified name. In case that there a multiple attributes
+		/// with the specified name, then only the first is removed.
+		/// \param  name    The name of the attribute to be removed.
+		/// \returns    True if the attribute was found and successfully removed; false otherwise (i.e. if it did not exist).
+		virtual bool RemoveAttribute(const char* name) = 0;
+
+		virtual ~IXmlNodeWrite() = default;
 
 		/// Sets the node value - which is specified as an UTF8-string.
 		///
@@ -1323,12 +1341,16 @@ namespace libCZI
 
 		/// Helper function which writes the specified display-settings into the specified metadata-builder. The display-settings
 		/// XML-metadata-node will have as many channel-items as the highest channel-number found in the display-settings object.
+        /// If there are nodes with name "Channel" existing (prior to calling this function) under the node
+        /// "Metadata/DisplaySetting/Channels", they are removed (before adding new content).
 		/// \param [in] builder             The metadata-builder object.
 		/// \param      display_settings	The display settings.
 		static void WriteDisplaySettings(libCZI::ICziMetadataBuilder* builder, const libCZI::IDisplaySettings* display_settings);
 
         /// Helper function which writes the specified display-settings into the specified metadata-builder. The display-settings
         /// XML-metadata-node will have as many channel-items as specified with the argument 'channel_count'.
+		/// If there are nodes with name "Channel" existing (prior to calling this function) under the node
+		/// "Metadata/DisplaySetting/Channels", they are removed (before adding new content).
         /// \param [in] builder             The metadata-builder object.
         /// \param      display_settings	The display settings.
         /// \param      channel_count       The number of channels (which are constructed in the display-settings XML-metadata).

--- a/Src/libCZI/stdAllocator.cpp
+++ b/Src/libCZI/stdAllocator.cpp
@@ -5,7 +5,7 @@
 #include "stdafx.h"
 #include "stdAllocator.h"
 #include <limits>
-#include <stdlib.h>
+#include <cstdlib>
 #include "libCZI_Config.h"
 
 constexpr int ALLOC_ALIGNMENT = 32;

--- a/Src/libCZI/utilities.cpp
+++ b/Src/libCZI/utilities.cpp
@@ -11,7 +11,7 @@
 #endif
 #include "inc_libCZI_Config.h"
 #if LIBCZI_HAVE_ENDIAN_H
- #include "endian.h"
+#include "endian.h"
 #endif
 
 using namespace std;
@@ -39,6 +39,12 @@ using namespace std;
     }
 
     return 0xff;
+}
+
+/*static*/char Utilities::NibbleToHexChar(std::uint8_t nibble)
+{
+    static const char* hex_digits = "0123456789ABCDEF";
+    return hex_digits[nibble & 0x0f];
 }
 
 template <class tString>
@@ -128,8 +134,8 @@ tString trimImpl(const tString& str, const tString& whitespace)
     auto r = distu32(rng);
     g.Data2 = (uint16_t)r;
     g.Data3 = (uint16_t)(r >> 16);
-    
-	r = distu32(rng);
+
+    r = distu32(rng);
     for (int i = 0; i < 4; ++i)
     {
         g.Data4[i] = (uint8_t)r;
@@ -145,6 +151,21 @@ tString trimImpl(const tString& str, const tString& whitespace)
 
     return g;
 #endif
+}
+
+/*static*/std::string Utilities::Rgb8ColorToString(const libCZI::Rgb8Color& color)
+{
+    string color_text;
+    color_text.reserve(10);
+    color_text += '#';
+    color_text += "FF";
+    color_text += Utilities::NibbleToHexChar(color.r >> 4);
+    color_text += Utilities::NibbleToHexChar(color.r);
+    color_text += Utilities::NibbleToHexChar(color.g >> 4);
+    color_text += Utilities::NibbleToHexChar(color.g);
+    color_text += Utilities::NibbleToHexChar(color.b >> 4);
+    color_text += Utilities::NibbleToHexChar(color.b);
+    return color_text;
 }
 
 /*static*/bool Utilities::TryGetRgb8ColorFromString(const std::wstring& strXml, libCZI::Rgb8Color& color)

--- a/Src/libCZI/utilities.h
+++ b/Src/libCZI/utilities.h
@@ -90,6 +90,7 @@ public:
     }
 
     static std::uint8_t HexCharToInt(char c);
+    static char NibbleToHexChar(std::uint8_t nibble);
 
     static std::string Trim(const std::string& str, const std::string& whitespace = " \t");
     static std::wstring Trim(const std::wstring& str, const std::wstring& whitespace = L" \t");
@@ -127,6 +128,7 @@ public:
     static void ConvertGuidToHostByteOrder(GUID* p);
 
     static bool TryGetRgb8ColorFromString(const std::wstring& strXml, libCZI::Rgb8Color& color);
+    static std::string Rgb8ColorToString(const libCZI::Rgb8Color& color);
 };
 
 class LoHiBytePackUnpack

--- a/Src/libCZI_UnitTests/test_DisplaySettings.cpp
+++ b/Src/libCZI_UnitTests/test_DisplaySettings.cpp
@@ -8,82 +8,176 @@
 #include "utils.h"
 #include <codecvt>
 #include <locale>
+#include "MemOutputStream.h"
 
 using namespace libCZI;
 using namespace std;
 
 TEST(DisplaySettings, Test1)
 {
-	auto mockMdSegment = make_shared<MockMetadataSegment>();
-	auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
-	EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
-	auto docInfo = md->GetDocumentInfo();
-	auto displaySettings = docInfo->GetDisplaySettings();
+    auto mockMdSegment = make_shared<MockMetadataSegment>();
+    auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
+    EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
+    auto docInfo = md->GetDocumentInfo();
+    auto displaySettings = docInfo->GetDisplaySettings();
 
-	DisplaySettingsPOD pod;
-	IDisplaySettings::Clone(displaySettings.get(), pod);
+    DisplaySettingsPOD pod;
+    IDisplaySettings::Clone(displaySettings.get(), pod);
 
-	EXPECT_TRUE(pod.channelDisplaySettings.size() == 5) << "Expected to have a size of 5.";
+    EXPECT_TRUE(pod.channelDisplaySettings.size() == 5) << "Expected to have a size of 5.";
 
-	for (size_t i = 0; i < pod.channelDisplaySettings.size(); ++i)
-	{
-		EXPECT_TRUE(pod.channelDisplaySettings[i].isEnabled == true) << "Expected the channel to be enabled";
-		EXPECT_TRUE(pod.channelDisplaySettings[i].tintingMode == IDisplaySettings::TintingMode::Color) << "Expected the tinting mode to be 'Color'";
-		EXPECT_TRUE(pod.channelDisplaySettings[i].gradationCurveMode == IDisplaySettings::GradationCurveMode::Linear) << "Expected the gradation-curve-mode to be 'Linear'";
-	}
+    for (size_t i = 0; i < pod.channelDisplaySettings.size(); ++i)
+    {
+        EXPECT_TRUE(pod.channelDisplaySettings[i].isEnabled == true) << "Expected the channel to be enabled";
+        EXPECT_TRUE(pod.channelDisplaySettings[i].tintingMode == IDisplaySettings::TintingMode::Color) << "Expected the tinting mode to be 'Color'";
+        EXPECT_TRUE(pod.channelDisplaySettings[i].gradationCurveMode == IDisplaySettings::GradationCurveMode::Linear) << "Expected the gradation-curve-mode to be 'Linear'";
+    }
 }
 
 TEST(DisplaySettings, Test2)
 {
-	auto mockMdSegment = make_shared<MockMetadataSegment>();
-	auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
-	EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
-	auto docInfo = md->GetDocumentInfo();
-	auto displaySettings = docInfo->GetDisplaySettings();
+    auto mockMdSegment = make_shared<MockMetadataSegment>();
+    auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
+    EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
+    auto docInfo = md->GetDocumentInfo();
+    auto displaySettings = docInfo->GetDisplaySettings();
 
-	DisplaySettingsPOD pod;
-	IDisplaySettings::Clone(displaySettings.get(), pod);
+    DisplaySettingsPOD pod;
+    IDisplaySettings::Clone(displaySettings.get(), pod);
 
-	auto displaySettings2 = DisplaySettingsPOD::CreateIDisplaySettingSp(pod);
+    auto displaySettings2 = DisplaySettingsPOD::CreateIDisplaySettingSp(pod);
 
-	auto chDs1 = displaySettings->GetChannelDisplaySettings(0);
-	auto chDs2 = displaySettings2->GetChannelDisplaySettings(0);
+    auto chDs1 = displaySettings->GetChannelDisplaySettings(0);
+    auto chDs2 = displaySettings2->GetChannelDisplaySettings(0);
 
-	EXPECT_TRUE(chDs1->GetIsEnabled() == chDs2->GetIsEnabled()) << "Expected to have the same value.";
-	EXPECT_TRUE(chDs1->GetWeight() == chDs2->GetWeight()) << "Expected to have the same value.";
-	float bp1, bp2, wp1, wp2;
-	chDs1->GetBlackWhitePoint(&bp1, &wp1);
-	chDs2->GetBlackWhitePoint(&bp2, &wp2);
-	EXPECT_TRUE(bp1 == bp2 && wp1 == wp2) << "Expected to have the same value.";
+    EXPECT_TRUE(chDs1->GetIsEnabled() == chDs2->GetIsEnabled()) << "Expected to have the same value.";
+    EXPECT_TRUE(chDs1->GetWeight() == chDs2->GetWeight()) << "Expected to have the same value.";
+    float bp1, bp2, wp1, wp2;
+    chDs1->GetBlackWhitePoint(&bp1, &wp1);
+    chDs2->GetBlackWhitePoint(&bp2, &wp2);
+    EXPECT_TRUE(bp1 == bp2 && wp1 == wp2) << "Expected to have the same value.";
 }
 
 TEST(DisplaySettings, Test3)
 {
-	auto mockMdSegment = make_shared<MockMetadataSegment>(MockMetadataSegment::Type::Data2);
-	auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
-	ASSERT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
-	auto docInfo = md->GetDocumentInfo();
-	auto displaySettings = docInfo->GetDisplaySettings();
+    auto mockMdSegment = make_shared<MockMetadataSegment>(MockMetadataSegment::Type::Data2);
+    auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
+    ASSERT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
+    auto docInfo = md->GetDocumentInfo();
+    auto displaySettings = docInfo->GetDisplaySettings();
 
-	DisplaySettingsPOD pod;
-	IDisplaySettings::Clone(displaySettings.get(), pod);
+    DisplaySettingsPOD pod;
+    IDisplaySettings::Clone(displaySettings.get(), pod);
 
-	auto displaySettings2 = DisplaySettingsPOD::CreateIDisplaySettingSp(pod);
+    auto displaySettings2 = DisplaySettingsPOD::CreateIDisplaySettingSp(pod);
 
-	auto chDs1 = displaySettings->GetChannelDisplaySettings(1);
-	auto chDs2 = displaySettings2->GetChannelDisplaySettings(1);
+    auto chDs1 = displaySettings->GetChannelDisplaySettings(1);
+    auto chDs2 = displaySettings2->GetChannelDisplaySettings(1);
 
-	EXPECT_TRUE(chDs1->GetIsEnabled() == chDs2->GetIsEnabled()) << "Expected to have the same value.";
-	EXPECT_TRUE(chDs1->GetWeight() == chDs2->GetWeight()) << "Expected to have the same value.";
-	float bp1, bp2, wp1, wp2;
-	chDs1->GetBlackWhitePoint(&bp1, &wp1);
-	chDs2->GetBlackWhitePoint(&bp2, &wp2);
-	EXPECT_TRUE(bp1 == bp2 && wp1 == wp2) << "Expected to have the same value.";
+    EXPECT_TRUE(chDs1->GetIsEnabled() == chDs2->GetIsEnabled()) << "Expected to have the same value.";
+    EXPECT_TRUE(chDs1->GetWeight() == chDs2->GetWeight()) << "Expected to have the same value.";
+    float bp1, bp2, wp1, wp2;
+    chDs1->GetBlackWhitePoint(&bp1, &wp1);
+    chDs2->GetBlackWhitePoint(&bp2, &wp2);
+    EXPECT_TRUE(bp1 == bp2 && wp1 == wp2) << "Expected to have the same value.";
 
-	EXPECT_TRUE(chDs1->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Spline &&
-				chDs2->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Spline) << "Expected to have the same value (=Spline).";
+    EXPECT_TRUE(chDs1->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Spline &&
+        chDs2->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Spline) << "Expected to have the same value (=Spline).";
 
-	vector< IDisplaySettings::SplineControlPoint> splineCtrlPts1, splineCtrlPts2;
-	ASSERT_TRUE(chDs1->TryGetSplineControlPoints(&splineCtrlPts1) && chDs1->TryGetSplineControlPoints(&splineCtrlPts2)) << "Expected to find spline-control-points";
-	EXPECT_THAT(splineCtrlPts1, ::testing::ContainerEq(splineCtrlPts2)) << "The data should have been equal";
+    vector< IDisplaySettings::SplineControlPoint> splineCtrlPts1, splineCtrlPts2;
+    ASSERT_TRUE(chDs1->TryGetSplineControlPoints(&splineCtrlPts1) && chDs1->TryGetSplineControlPoints(&splineCtrlPts2)) << "Expected to find spline-control-points";
+    EXPECT_THAT(splineCtrlPts1, ::testing::ContainerEq(splineCtrlPts2)) << "The data should have been equal";
+}
+
+TEST(DisplaySettings, WriteToDocumentAndReadFromThereAndCompare)
+{
+    auto writer = CreateCZIWriter();
+    auto outStream = make_shared<CMemOutputStream>(0);
+    //auto outStream = CreateOutputStreamForFile(L"D:\\libczi_displaysettings.czi", true);
+
+    auto spWriterInfo = make_shared<CCziWriterInfo >(
+        GUID{ 0x1234567,0x89ab,0xcdef,{ 1,2,3,4,5,6,7,8 } },
+        CDimBounds{ { { DimensionIndex::C,0,2 } } });	// set a bounds for  C
+
+    writer->Create(outStream, spWriterInfo);
+
+    auto bitmap = CreateTestBitmap(PixelType::Gray8, 400, 400);
+
+    ScopedBitmapLockerSP lockBm{ bitmap };
+    AddSubBlockInfoStridedBitmap addSbBlkInfo;
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C0");
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = 0;
+    addSbBlkInfo.x = 0;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    addSbBlkInfo.ptrBitmap = lockBm.ptrDataRoi;
+    addSbBlkInfo.strideBitmap = lockBm.stride;
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C1");
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    auto metadata_to_be_written = writer->GetPreparedMetadata(PrepareMetadataInfo{});
+
+    DisplaySettingsPOD display_settings;
+    ChannelDisplaySettingsPOD channel_display_settings;
+    channel_display_settings.Clear();
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::Color;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    display_settings.channelDisplaySettings[0] = channel_display_settings;
+    channel_display_settings.tintingColor = Rgb8Color{ 0,0xff,0 };
+    channel_display_settings.blackPoint = 0.1f;
+    channel_display_settings.whitePoint = 0.4f;
+    display_settings.channelDisplaySettings[1] = channel_display_settings;
+    MetadataUtils::WriteDisplaySettings(metadata_to_be_written.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 2);
+
+    string xml = metadata_to_be_written->GetXml(true);
+    WriteMetadataInfo writerMdInfo = { 0 };
+    writerMdInfo.szMetadata = xml.c_str();
+    writerMdInfo.szMetadataSize = xml.size();
+    writer->SyncWriteMetadata(writerMdInfo);
+
+    writer->Close();
+    writer.reset();
+
+    size_t cziData_Size;
+    auto cziData = outStream->GetCopy(&cziData_Size);
+    outStream.reset();	// not needed anymore
+
+    auto inputStream = CreateStreamFromMemory(cziData, cziData_Size);
+    auto spReader = libCZI::CreateCZIReader();
+    spReader->Open(inputStream);
+
+    auto metadata = spReader->ReadMetadataSegment()->CreateMetaFromMetadataSegment();
+
+    auto display_settings_from_document = metadata->GetDocumentInfo()->GetDisplaySettings();
+
+    auto channel_display_settings_from_document = display_settings_from_document->GetChannelDisplaySettings(0);
+    ASSERT_TRUE(channel_display_settings_from_document);
+    EXPECT_TRUE(channel_display_settings_from_document->GetIsEnabled());
+    Rgb8Color tinting_color_from_document;
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetTintingColorRgb8(&tinting_color_from_document));
+    EXPECT_TRUE(tinting_color_from_document.r == 0xff && tinting_color_from_document.g == 0 && tinting_color_from_document.b == 0);
+    float black_point_from_document, white_point_from_document;
+    channel_display_settings_from_document->GetBlackWhitePoint(&black_point_from_document, &white_point_from_document);
+    EXPECT_NEAR(black_point_from_document, 0.3f, 1e-8f);
+    EXPECT_NEAR(white_point_from_document, 0.8f, 1e-8f);
+
+    channel_display_settings_from_document = display_settings_from_document->GetChannelDisplaySettings(1);
+    ASSERT_TRUE(channel_display_settings_from_document);
+    EXPECT_TRUE(channel_display_settings_from_document->GetIsEnabled());
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetTintingColorRgb8(&tinting_color_from_document));
+    EXPECT_TRUE(tinting_color_from_document.r == 0 && tinting_color_from_document.g == 0xff && tinting_color_from_document.b == 0);
+    channel_display_settings_from_document->GetBlackWhitePoint(&black_point_from_document, &white_point_from_document);
+    EXPECT_NEAR(black_point_from_document, 0.1f, 1e-8f);
+    EXPECT_NEAR(white_point_from_document, 0.4f, 1e-8f);
 }

--- a/Src/libCZI_UnitTests/test_DisplaySettings.cpp
+++ b/Src/libCZI_UnitTests/test_DisplaySettings.cpp
@@ -263,7 +263,7 @@ TEST(DisplaySettings, WriteDisplaySettingsWithGradionCurveGammaAndSplineToDocume
     display_settings.channelDisplaySettings[1] = channel_display_settings;  // set the channel-display-settings for channel 1
 
     // and now, write those display-settings into the metadata-builder-object
-    MetadataUtils::WriteDisplaySettings(metadata_to_be_written.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 2);
+    MetadataUtils::WriteDisplaySettings(metadata_to_be_written.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get());
 
     // then, get the XML-string containing the metadata, and put this into the CZI-file
     string xml = metadata_to_be_written->GetXml(true);

--- a/Src/libCZI_UnitTests/test_DisplaySettings.cpp
+++ b/Src/libCZI_UnitTests/test_DisplaySettings.cpp
@@ -195,3 +195,133 @@ TEST(DisplaySettings, WriteDisplaySettingsToDocumentAndReadFromThereAndCompare)
     EXPECT_NEAR(black_point_from_document, 0.1f, 1e-8f);
     EXPECT_NEAR(white_point_from_document, 0.4f, 1e-8f);
 }
+
+TEST(DisplaySettings, WriteDisplaySettingsWithGradionCurveGammaAndSplineToDocumentAndReadFromThereAndCompare)
+{
+    // what happens here:
+    // - we are creating a simple 2-channel-CZI-document, add two subblocks 
+    // - and, we construct "display-settings" for the document, write them into the CZI-document
+    // - then we open the CZI-document
+    // - and read the display-settings from it
+    // - and, finally, compare them to what we put into
+    auto writer = CreateCZIWriter();
+    auto outStream = make_shared<CMemOutputStream>(0);
+    //auto outStream = CreateOutputStreamForFile(L"D:\\libczi_displaysettings.czi", true);
+
+    auto spWriterInfo = make_shared<CCziWriterInfo >(
+        GUID{ 0x1234567,0x89ab,0xcdef,{ 1,2,3,4,5,6,7,8 } },
+        CDimBounds{ { { DimensionIndex::C,0,2 } } });	// set a bounds for  C
+
+    writer->Create(outStream, spWriterInfo);
+
+    // now add two subblocks (does not really matter, though)
+    auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
+
+    ScopedBitmapLockerSP lockBm{ bitmap };
+    AddSubBlockInfoStridedBitmap addSbBlkInfo;
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C0");
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = 0;
+    addSbBlkInfo.x = 0;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    addSbBlkInfo.ptrBitmap = lockBm.ptrDataRoi;
+    addSbBlkInfo.strideBitmap = lockBm.stride;
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C1");
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    // the writer-object can give us a "partially filled out metadata-object"
+    auto metadata_to_be_written = writer->GetPreparedMetadata(PrepareMetadataInfo{});
+
+    // ...to which we add here some display-settings
+    DisplaySettingsPOD display_settings;
+    ChannelDisplaySettingsPOD channel_display_settings;
+    channel_display_settings.Clear();
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::Color;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    channel_display_settings.gradationCurveMode = IDisplaySettings::GradationCurveMode::Gamma;
+    channel_display_settings.gamma = 0.83f;
+    display_settings.channelDisplaySettings[0] = channel_display_settings;  // set the channel-display-settings for channel 0
+    channel_display_settings.tintingColor = Rgb8Color{ 0,0xff,0 };
+    channel_display_settings.blackPoint = 0.1f;
+    channel_display_settings.whitePoint = 0.4f;
+    channel_display_settings.gradationCurveMode = IDisplaySettings::GradationCurveMode::Spline;
+    channel_display_settings.splineCtrlPoints.push_back(IDisplaySettings::SplineControlPoint{ 0.155251141552511,0.428571428571429 });
+    channel_display_settings.splineCtrlPoints.push_back(IDisplaySettings::SplineControlPoint{ 0.468036529680365,0.171428571428571 });
+    channel_display_settings.splineCtrlPoints.push_back(IDisplaySettings::SplineControlPoint{ 0.58675799086758,0.657142857142857 });
+    channel_display_settings.splineCtrlPoints.push_back(IDisplaySettings::SplineControlPoint{ 0.840182648401826,0.2 });
+    display_settings.channelDisplaySettings[1] = channel_display_settings;  // set the channel-display-settings for channel 1
+
+    // and now, write those display-settings into the metadata-builder-object
+    MetadataUtils::WriteDisplaySettings(metadata_to_be_written.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 2);
+
+    // then, get the XML-string containing the metadata, and put this into the CZI-file
+    string xml = metadata_to_be_written->GetXml(true);
+    WriteMetadataInfo writerMdInfo = { 0 };
+    writerMdInfo.szMetadata = xml.c_str();
+    writerMdInfo.szMetadataSize = xml.size();
+    writer->SyncWriteMetadata(writerMdInfo);
+
+    writer->Close();
+    writer.reset();
+
+    size_t cziData_Size;
+    auto cziData = outStream->GetCopy(&cziData_Size);
+    outStream.reset();	// not needed anymore
+
+    // now, we open the CZI-document (note: this is "in-memory")
+    auto inputStream = CreateStreamFromMemory(cziData, cziData_Size);
+    auto spReader = libCZI::CreateCZIReader();
+    spReader->Open(inputStream);
+
+    // read the metadata-segment, get the document-info-object, and from it the display-settings
+    auto metadata = spReader->ReadMetadataSegment()->CreateMetaFromMetadataSegment();
+    auto display_settings_from_document = metadata->GetDocumentInfo()->GetDisplaySettings();
+
+    // and here, compare those display-settings we got from the document to the information we put in before
+    auto channel_display_settings_from_document = display_settings_from_document->GetChannelDisplaySettings(0);
+    ASSERT_TRUE(channel_display_settings_from_document);
+    EXPECT_TRUE(channel_display_settings_from_document->GetIsEnabled());
+    Rgb8Color tinting_color_from_document;
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetTintingColorRgb8(&tinting_color_from_document));
+    EXPECT_TRUE(tinting_color_from_document.r == 0xff && tinting_color_from_document.g == 0 && tinting_color_from_document.b == 0);
+    float black_point_from_document, white_point_from_document;
+    channel_display_settings_from_document->GetBlackWhitePoint(&black_point_from_document, &white_point_from_document);
+    EXPECT_NEAR(black_point_from_document, 0.3f, 1e-8f);
+    EXPECT_NEAR(white_point_from_document, 0.8f, 1e-8f);
+    EXPECT_TRUE(channel_display_settings_from_document->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Gamma);
+    float gamma__from_document;
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetGamma(&gamma__from_document));
+    EXPECT_NEAR(gamma__from_document, 0.83f, 1e-8f);
+
+    channel_display_settings_from_document = display_settings_from_document->GetChannelDisplaySettings(1);
+    ASSERT_TRUE(channel_display_settings_from_document);
+    EXPECT_TRUE(channel_display_settings_from_document->GetIsEnabled());
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetTintingColorRgb8(&tinting_color_from_document));
+    EXPECT_TRUE(tinting_color_from_document.r == 0 && tinting_color_from_document.g == 0xff && tinting_color_from_document.b == 0);
+    channel_display_settings_from_document->GetBlackWhitePoint(&black_point_from_document, &white_point_from_document);
+    EXPECT_NEAR(black_point_from_document, 0.1f, 1e-8f);
+    EXPECT_NEAR(white_point_from_document, 0.4f, 1e-8f);
+    EXPECT_TRUE(channel_display_settings_from_document->GetGradationCurveMode() == IDisplaySettings::GradationCurveMode::Spline);
+    vector<libCZI::IDisplaySettings::SplineControlPoint> spline_control_points_from_document;
+    EXPECT_TRUE(channel_display_settings_from_document->TryGetSplineControlPoints(&spline_control_points_from_document));
+    ASSERT_EQ(spline_control_points_from_document.size(), 4);
+    EXPECT_NEAR(spline_control_points_from_document[0].x, 0.155251141552511, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[0].y, 0.428571428571429, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[1].x, 0.468036529680365, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[1].y, 0.171428571428571, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[2].x, 0.58675799086758, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[2].y, 0.657142857142857, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[3].x, 0.840182648401826, 1e-7);
+    EXPECT_NEAR(spline_control_points_from_document[3].y, 0.2, 1e-7);
+}

--- a/Src/libCZI_UnitTests/test_DisplaySettings.cpp
+++ b/Src/libCZI_UnitTests/test_DisplaySettings.cpp
@@ -108,7 +108,7 @@ TEST(DisplaySettings, WriteDisplaySettingsToDocumentAndReadFromThereAndCompare)
     writer->Create(outStream, spWriterInfo);
 
     // now add two subblocks (does not really matter, though)
-    auto bitmap = CreateTestBitmap(PixelType::Gray8, 400, 400);
+    auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
 
     ScopedBitmapLockerSP lockBm{ bitmap };
     AddSubBlockInfoStridedBitmap addSbBlkInfo;

--- a/Src/libCZI_UnitTests/test_metadatabuilder.cpp
+++ b/Src/libCZI_UnitTests/test_metadatabuilder.cpp
@@ -618,3 +618,235 @@ TEST(MetadataBuilder, MetadataBuilderFromXml2)
 
 	EXPECT_ANY_THROW(CreateMetadataBuilderFromXml(xml_document)) << "Expected to throw because no ImageDocument-root-node present";
 }
+
+TEST(MetadataBuilder, RemoveChildren)
+{
+	static const char* xml_document =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"X\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"        <Distance Id=\"Y\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"        <Distance Id=\"Z\">\n"
+		u8"          <Value>5e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	const auto metadata_builder = CreateMetadataBuilderFromXml(xml_document);
+	const auto items_node = metadata_builder->GetRootNode()->GetChildNode("Metadata/Scaling/Items");
+	items_node->RemoveChildren();
+
+	const auto xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items />\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	EXPECT_STREQ(expected_result, xml.c_str()) << "Incorrect result";
+}
+
+TEST(MetadataBuilder, RemoveChild)
+{
+	static const char* xml_document =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"X\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"        <Distance Id=\"Y\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"        <Distance Id=\"Z\">\n"
+		u8"          <Value>5e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	const auto metadata_builder = CreateMetadataBuilderFromXml(xml_document);
+	const auto items_node = metadata_builder->GetRootNode()->GetChildNode("Metadata/Scaling/Items");
+	bool b = items_node->RemoveChild("Distance");
+	EXPECT_TRUE(b);
+
+	auto xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result1 =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"Y\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"        <Distance Id=\"Z\">\n"
+		u8"          <Value>5e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+	EXPECT_STREQ(expected_result1, xml.c_str()) << "Incorrect result";
+
+	b = items_node->RemoveChild("Distance");
+	EXPECT_TRUE(b);
+
+	xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result2 =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"Z\">\n"
+		u8"          <Value>5e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+	EXPECT_STREQ(expected_result2, xml.c_str()) << "Incorrect result";
+
+	b = items_node->RemoveChild("Distance");
+	EXPECT_TRUE(b);
+	xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result3 =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items />\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+	EXPECT_STREQ(expected_result3, xml.c_str()) << "Incorrect result";
+
+	b = items_node->RemoveChild("Distance");
+	EXPECT_FALSE(b);
+}
+
+TEST(MetadataBuilder, RemoveAttributes)
+{
+	static const char* xml_document =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"X\" Attr1=\"a\" Attr2=\"b\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	const auto metadata_builder = CreateMetadataBuilderFromXml(xml_document);
+	const auto distance_node = metadata_builder->GetRootNode()->GetChildNode("Metadata/Scaling/Items/Distance");
+	distance_node->RemoveAttributes();
+
+	const auto xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance>\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	EXPECT_STREQ(expected_result, xml.c_str()) << "Incorrect result";
+}
+
+TEST(MetadataBuilder, RemoveAttribute)
+{
+	static const char* xml_document =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Id=\"X\" Attr1=\"a\" Attr2=\"b\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+
+	const auto metadata_builder = CreateMetadataBuilderFromXml(xml_document);
+	const auto distance_node = metadata_builder->GetRootNode()->GetChildNode("Metadata/Scaling/Items/Distance");
+	bool b = distance_node->RemoveAttribute("Id");
+	EXPECT_TRUE(b);
+
+	auto xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result1 =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance Attr1=\"a\" Attr2=\"b\">\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+	EXPECT_STREQ(expected_result1, xml.c_str()) << "Incorrect result";
+
+	b = distance_node->RemoveAttribute("Attr1");
+	EXPECT_TRUE(b);
+	b = distance_node->RemoveAttribute("Attr2");
+	EXPECT_TRUE(b);
+	b = distance_node->RemoveAttribute("Attr2");
+	EXPECT_FALSE(b);
+
+	xml = metadata_builder->GetXml(true);
+
+	static const char* expected_result2 =
+		u8"<ImageDocument>\n"
+		u8"  <Metadata>\n"
+		u8"    <Scaling>\n"
+		u8"      <Items>\n"
+		u8"        <Distance>\n"
+		u8"          <Value>1.06822e-07</Value>\n"
+		u8"          <DefaultUnitFormat>µm</DefaultUnitFormat>\n"
+		u8"        </Distance>\n"
+		u8"      </Items>\n"
+		u8"    </Scaling>\n"
+		u8"  </Metadata>\n"
+		u8"</ImageDocument>\n";
+	EXPECT_STREQ(expected_result2, xml.c_str()) << "Incorrect result";
+}


### PR DESCRIPTION
## Description

Summary of the change(s) and which issue(s) is/are fixed  
Relevant motivation and context  
Dependencies required for this change  

This is adding support for Writing display settings when creating a CZI

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

build runs locally (Linux and Windows)
Tests run successfully

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
