### PR TITLE
small CZIcmd improvement

### DIFF
--- a/Src/CZICmd/CZIcmd.cpp
+++ b/Src/CZICmd/CZIcmd.cpp
@@ -92,6 +92,7 @@ int main(int argc, char** _argv)
                 }
                 else if (cmdLineParseResult == CCmdLineOptions::ParseResult::Error)
                 {
+                        log->WriteLineStdErr("");
                         log->WriteLineStdErr("There were errors parsing the arguments -> exiting.");
                         retVal = 2;
                 }

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -618,7 +618,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         "the second the pyramid-layer (starting with 0 for the layer with the highest resolution).")
         ->option_text("PYRAMIDINFO")
         ->check(pyramidinfo_validator);
-     cli_app.add_option("-z,--zoom", argument_zoom,
+    cli_app.add_option("-z,--zoom", argument_zoom,
         "The zoom-factor (which is used for the commands 'SingleChannelScalingTileAccessor' and 'ScalingChannelComposite'). "
         "It is a float between 0 and 1.")
         ->option_text("ZOOM")
@@ -703,6 +703,11 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
     try
     {
         cli_app.parse(argc, argv);
+    }
+    catch (const CLI::CallForHelp& e)
+    {
+        cli_app.exit(e);
+        return ParseResult::Exit;
     }
     catch (const CLI::ParseError& e)
     {
@@ -1894,7 +1899,7 @@ void CCmdLineOptions::PrintHelpBitmapGenerator()
         [&](int no, std::tuple<std::string, std::string, bool> name_explanation_isdefault) -> bool
         {
             maxLengthClassName = (std::max)(get<0>(name_explanation_isdefault).length(), maxLengthClassName);
-            return true;
+    return true;
         });
 
     ostringstream string_stream;
@@ -1902,9 +1907,9 @@ void CCmdLineOptions::PrintHelpBitmapGenerator()
         [&](int no, std::tuple<std::string, std::string, bool> name_explanation_isdefault) -> bool
         {
             string_stream << no + 1 << ": " << std::setw(maxLengthClassName) << std::left << get<0>(name_explanation_isdefault) << std::setw(0) <<
-                (!get<2>(name_explanation_isdefault) ? "     " : " (*) ") << "\"" <<
-                get<1>(name_explanation_isdefault) << "\"" << endl;
-            return true;
+            (!get<2>(name_explanation_isdefault) ? "     " : " (*) ") << "\"" <<
+        get<1>(name_explanation_isdefault) << "\"" << endl;
+    return true;
         });
 
     this->GetLog()->WriteLineStdOut(string_stream.str());

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -1899,7 +1899,7 @@ void CCmdLineOptions::PrintHelpBitmapGenerator()
         [&](int no, std::tuple<std::string, std::string, bool> name_explanation_isdefault) -> bool
         {
             maxLengthClassName = (std::max)(get<0>(name_explanation_isdefault).length(), maxLengthClassName);
-    return true;
+            return true;
         });
 
     ostringstream string_stream;
@@ -1907,9 +1907,9 @@ void CCmdLineOptions::PrintHelpBitmapGenerator()
         [&](int no, std::tuple<std::string, std::string, bool> name_explanation_isdefault) -> bool
         {
             string_stream << no + 1 << ": " << std::setw(maxLengthClassName) << std::left << get<0>(name_explanation_isdefault) << std::setw(0) <<
-            (!get<2>(name_explanation_isdefault) ? "     " : " (*) ") << "\"" <<
-        get<1>(name_explanation_isdefault) << "\"" << endl;
-    return true;
+                    (!get<2>(name_explanation_isdefault) ? "     " : " (*) ") << "\"" <<
+                    get<1>(name_explanation_isdefault) << "\"" << endl;
+            return true;
         });
 
     this->GetLog()->WriteLineStdOut(string_stream.str());


### PR DESCRIPTION
## Description

When CZIcmd was executed with the argument "--help", it used to print that an invalid command line was encountered (after printing help text). This is fixed with this PR.

Fixes # (issue)

N/A

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Running CZIcmd locally.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
