### PR TITLE
Remove carryforward flag from codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,6 @@ coverage:
 # Based on https://docs.codecov.com/docs/flags#recommended-automatic-flag-management
 flag_management:
   default_rules:
-    carryforward: true
     statuses:
       - type: project
         informational: true


### PR DESCRIPTION
## Description

Remove the [carryforward](https://docs.codecov.com/docs/carryforward-flags) flag from the [codecov](https://docs.codecov.com/docs) scan.

Fixes #33 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Results will be visible/available once pushed to _main_.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
