### PR TITLE
minor cosmetic

### DIFF
--- a/Src/libCZI/CziDisplaySettings.cpp
+++ b/Src/libCZI/CziDisplaySettings.cpp
@@ -25,7 +25,7 @@ public:
         for (; *szString != L'\0';)
         {
             double x, y;
-            x = std::stof(szString, &charsParsed);
+            x = std::stod(szString, &charsParsed);
             szString += charsParsed;
 
             // now, skip whitespace and exactly one comma
@@ -47,7 +47,7 @@ public:
                 throw std::invalid_argument("invalid syntax");
             }
 
-            y = std::stof(szString, &charsParsed);
+            y = std::stod(szString, &charsParsed);
             szString += charsParsed;
 
             splinePts.push_back({ x,y });

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -214,7 +214,7 @@ using namespace libCZI;
     }
     catch (const std::exception&)
     {
-        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", offset + sizeof(attachmentDirSegment), attachmentEntriesSize));
+        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", offset + sizeof(attachmentDirSegment), attachmentEntriesSize));
     }
 
     if (bytesRead != attachmentEntriesSize)
@@ -378,7 +378,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", offset + lengthSubblockSegmentData + sizeof(SegmentHeader), subBlckSegment.data.MetadataSize));
+            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", offset + lengthSubblockSegmentData + sizeof(SegmentHeader), subBlckSegment.data.MetadataSize));
         }
 
         if (bytesRead != subBlckSegment.data.MetadataSize)
@@ -395,7 +395,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", offset + lengthSubblockSegmentData + sizeof(SegmentHeader) + subBlckSegment.data.MetadataSize, subBlckSegment.data.DataSize));
+            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", offset + lengthSubblockSegmentData + sizeof(SegmentHeader) + subBlckSegment.data.MetadataSize, subBlckSegment.data.DataSize));
         }
 
         if (bytesRead != subBlckSegment.data.DataSize)
@@ -412,7 +412,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", offset + lengthSubblockSegmentData + sizeof(SegmentHeader) + subBlckSegment.data.MetadataSize + subBlckSegment.data.DataSize, subBlckSegment.data.AttachmentSize));
+            std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", offset + lengthSubblockSegmentData + sizeof(SegmentHeader) + subBlckSegment.data.MetadataSize + subBlckSegment.data.DataSize, subBlckSegment.data.AttachmentSize));
         }
 
         if (bytesRead != subBlckSegment.data.AttachmentSize)
@@ -467,7 +467,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading AttachmentSegement", offset + 256 + sizeof(SegmentHeader), attchmntSegment.data.DataSize));
+            std::throw_with_nested(LibCZIIOException("Error reading AttachmentSegment", offset + 256 + sizeof(SegmentHeader), attchmntSegment.data.DataSize));
         }
 
         if (bytesRead != attchmntSegment.data.DataSize)
@@ -566,7 +566,7 @@ using namespace libCZI;
     }
     catch (const std::exception&)
     {
-        std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegement", offset, sizeof(metadataSegment)));
+        std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegment", offset, sizeof(metadataSegment)));
     }
 
     if (bytesRead != sizeof(metadataSegment))
@@ -593,7 +593,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegement", offset + sizeof(metadataSegment), metadataSegment.data.XmlSize));
+            std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegment", offset + sizeof(metadataSegment), metadataSegment.data.XmlSize));
         }
 
         if (bytesRead != metadataSegment.data.XmlSize)
@@ -610,7 +610,7 @@ using namespace libCZI;
         }
         catch (const std::exception&)
         {
-            std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegement", offset + sizeof(metadataSegment) + metadataSegment.data.XmlSize, metadataSegment.data.AttachmentSize));
+            std::throw_with_nested(LibCZIIOException("Error reading MetaDataSegment", offset + sizeof(metadataSegment) + metadataSegment.data.XmlSize, metadataSegment.data.AttachmentSize));
         }
 
         if (bytesRead != metadataSegment.data.AttachmentSize)

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -33,7 +33,7 @@ struct ReplaceHelper
     int key;
     ICziReaderWriter* t;
     ReplaceHelper(int key, ICziReaderWriter* t)
-        :key(key), t(t) {};
+        :key(key), t(t) {}
 
     void operator()(const AddSubBlockInfo& addSbBlkInfo) const
     {

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -149,12 +149,12 @@ void CSbBlkStatisticsUpdater::UpdateStatistics(const CCziSubBlockDirectoryBase::
     auto it = this->pyramidStatistics.scenePyramidStatistics.find(sceneIndex);
     if (it != this->pyramidStatistics.scenePyramidStatistics.end())
     {
-        this->UpdatePyramidLayerStatistics(it->second, pli);
+        CSbBlkStatisticsUpdater::UpdatePyramidLayerStatistics(it->second, pli);
     }
     else
     {
         std::vector<PyramidStatistics::PyramidLayerStatistics> vecPs;
-        this->UpdatePyramidLayerStatistics(vecPs, pli);
+        CSbBlkStatisticsUpdater::UpdatePyramidLayerStatistics(vecPs, pli);
         this->pyramidStatistics.scenePyramidStatistics.insert(std::pair<int, std::vector<PyramidStatistics::PyramidLayerStatistics>>(sceneIndex, vecPs));
     }
 

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -54,7 +54,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const libCZI::AddSubBlockInfoLinewiseBi
 {
     AddSubBlockInfo addSbInfo(addSbInfoLinewise);
 
-    size_t stride = addSbInfoLinewise.physicalWidth * CziUtils::GetBytesPerPel(addSbInfoLinewise.PixelType);
+    size_t stride = addSbInfoLinewise.physicalWidth * (size_t)CziUtils::GetBytesPerPel(addSbInfoLinewise.PixelType);
     addSbInfo.sizeData = addSbInfoLinewise.physicalHeight * stride;
     auto linesCnt = addSbInfoLinewise.physicalHeight;
     addSbInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
@@ -699,7 +699,6 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     uint64_t attchmDirPos;
     // if we have already written a subblock-directory-segment (possibly a reservation), then we check here if the existing
     // segment is large enough, and if so we write our data into this segment
-    //if (this->attachmentDirectorySegment.GetAllocatedSize() >= attchmntDirSegment.header.UsedSize)
     if (int64_t(info.sizeExistingSegmentPos) >= attchmntDirSegment.header.UsedSize)
     {
         attchmDirPos = info.existingSegmentPos;// this->attachmentDirectorySegment.GetFilePos();

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -586,7 +586,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
 
     uint64_t bytesWritten;
     uint64_t totalBytesWritten = 0;
-    auto msHeaderAllocatedSize = ms.header.AllocatedSize;   // need to save this information before (potentially) changing the byte-order
+    const auto msHeaderAllocatedSize = ms.header.AllocatedSize;   // need to save this information before (potentially) changing the byte-order
 
     ConvertToHostByteOrder::Convert(&ms);
     info.writeFunc(metadataSegmentPos, &ms, sizeof(ms), &bytesWritten, "MetadataSegment");
@@ -606,7 +606,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
 
     if (totalBytesWritten < msHeaderAllocatedSize + sizeof(SegmentHeader))
     {
-        totalBytesWritten += CWriterUtils::WriteZeroes(info.writeFunc, metadataSegmentPos + totalBytesWritten, msHeaderAllocatedSize + sizeof(SegmentHeader) - totalBytesWritten);
+        CWriterUtils::WriteZeroes(info.writeFunc, metadataSegmentPos + totalBytesWritten, msHeaderAllocatedSize + sizeof(SegmentHeader) - totalBytesWritten);
     }
 
     return make_tuple(metadataSegmentPos, static_cast<std::uint64_t>(msHeaderAllocatedSize));

--- a/Src/libCZI/Doc/mainpage.markdown
+++ b/Src/libCZI/Doc/mainpage.markdown
@@ -38,8 +38,8 @@ For determining whether a change is a breaking one, the source code level is dec
 of re-compiling with the changed sources.
 A borderline case are maybe changes in the CMake-files - here the best judgement is to be applied whether a change in the compilation result will occur.
 
-Note that the number defined in the [project](https://cmake.org/cmake/help/latest/command/project.html#command:project) statement allows for four numbers: <tt><major>.<minor>.<patch>.<tweak></tt>. 
-The number for <tt><tweak></tt> has no semantic meaning.
+Note that the number defined in the [project](https://cmake.org/cmake/help/latest/command/project.html#command:project) statement allows for four numbers: <tt>\<major\>.\<minor\>.\<patch\>.\<tweak\></tt>. 
+The number for <tt>\<tweak\></tt> has no semantic meaning.
 
 
 CZI in a nutshell

--- a/Src/libCZI/libCZI_Utilities.cpp
+++ b/Src/libCZI/libCZI_Utilities.cpp
@@ -231,7 +231,7 @@ static double CalcSplineValue(double x, const std::vector<libCZI::IDisplaySettin
 /// </summary>
 /// <remarks>
 /// The Toe Slope adjustment uses a slightly adjusted version of the gamma function to evaluate the display image.
-/// The adjusted version has the advantage that its slope at the origin, i.e. for x = 0, doesn't equal infinity.
+/// The adjusted version has the advantage that its slope at the origin, i.e. for x = 0, does not equal infinity.
 /// The formula for this looks like y = ((ax + 1)**G - 1) / ((a + 1)**G - 1), where the parameter "a" depends on the gamma value.
 /// Additionally, we choose the slope of 1/(G**3) for x = 0. 
 /// This yields the iteration formula that is used in the method:
@@ -242,8 +242,8 @@ static double CalcSplineValue(double x, const std::vector<libCZI::IDisplaySettin
 template <typename tFloat>
 tFloat GetParameterForToeSlopeAdjustment(tFloat gamma)
 {
-    const double GammaTolerance = static_cast<tFloat>(0.0001);
-    if (abs(gamma - 0.5) < GammaTolerance)
+    const tFloat GammaTolerance = static_cast<tFloat>(0.0001);
+    if (abs(gamma - static_cast<tFloat>(0.5)) < GammaTolerance)
     {
         return 224;
     }

--- a/Src/libCZI/libCZI_Utilities.h
+++ b/Src/libCZI/libCZI_Utilities.h
@@ -55,7 +55,7 @@ namespace libCZI
         /// \return The count of bytes that were written to in ptrHash as the MD5SUM-hash (always 16).
         static int CalcMd5SumHash(const void* ptrData, size_t sizeData, std::uint8_t* ptrHash, int hashSize);
 
-        /// Creates an 8-bit look-up table from the specifed splines.
+        /// Creates an 8-bit look-up table from the specified splines.
         /// A spline is sampled between \c blackPoint and \c whitePoint (i. e. points left of \c blackPoint are set to 0
         /// and right of \c whitePoint are set to 1). 
         /// \param tableElementCnt Number of points to sample - the result will have as many samples as specified here.
@@ -183,7 +183,7 @@ namespace libCZI
         static std::string DimBoundsToString(const libCZI::IDimBounds* bounds);
 
         /// Create an index-set object from a string representation. The string is a list of intervals,
-        /// seperated by comma (','). It can be of the form "5", "17", "3-5", "-3-5". The string
+        /// separated by comma (','). It can be of the form "5", "17", "3-5", "-3-5". The string
         /// "inf" (meaning 'infinity') is recognized in order to express "all numbers up to" or "all numbers after"
         /// , e. g. "-inf-4" or "5-inf".
         /// In case of an invalid string, an LibCZIStringParseException exception is thrown.

--- a/Src/libCZI/splines.cpp
+++ b/Src/libCZI/splines.cpp
@@ -117,7 +117,7 @@ using namespace Eigen;
 
     // TODO: since the points are sorted for x (I'd think so...) we should be able to use a binary search here?
     int index = 0;
-    double xPos_for_foundIndex;
+    double xPos_for_foundIndex = 0;
     for (int i = 0; i < pointsCnt; i++)
     {
         double xPos_i;

--- a/Src/libCZI/splines.cpp
+++ b/Src/libCZI/splines.cpp
@@ -107,33 +107,6 @@ using namespace Eigen;
     return splineCoefficients;
 }
 
-/*static*/double CSplines::CalculateSplineValue(double xPosition, int pointsCnt, const std::function<void(int index, double* x)>& getPoint, const  std::vector<Coefficients>& coefficients)
-{
-    // the polynomial number is always 4 in our case
-    if (pointsCnt >= 4 + 2)
-    {
-        throw invalid_argument("The number of point intervals exceeds the polynomial number.");
-    }
-
-    // TODO: since the points are sorted for x (I'd think so...) we should be able to use a binary search here?
-    int index = 0;
-    double xPos_for_foundIndex = 0;
-    for (int i = 0; i < pointsCnt; i++)
-    {
-        double xPos_i;
-        getPoint(i, &xPos_i);
-        if (xPosition >= xPos_i)
-        {
-            index = i;
-            xPos_for_foundIndex = xPos_i;
-        }
-    }
-
-    xPosition -= xPos_for_foundIndex;
-
-    return CalculateSplineValue(xPosition, coefficients.at(index));
-}
-
 /*static*/double CSplines::CalculateSplineValue(double xPosition, const CSplines::Coefficients& coeffs)
 {
     constexpr int n = 4;    // cubic spline, polynomial number is 4

--- a/Src/libCZI/splines.h
+++ b/Src/libCZI/splines.h
@@ -15,7 +15,5 @@ public:
 
     static std::vector<Coefficients> GetSplineCoefficients(int pointsCnt, const std::function<void(int index, double* x, double* y)>& getPoint);
 
-    static double CalculateSplineValue(double xPosition, int pointsCnt, const std::function<void(int index, double* x)>& getPoint, const std::vector<Coefficients>& coefficients);
-
     static double CalculateSplineValue(double xPosition, const Coefficients& coeffs);
 };


### PR DESCRIPTION
## Description

Some cosmetic and fixing typos. Also, an unused (and non-exported) function was removed.

Fixes some clang-tidy findings.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

built locally and ran tests

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
