### PR TITLE
Add sortByM flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.47.2
+      VERSION 0.47.3
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -57,7 +57,7 @@ void CSingleChannelPyramidLevelTileAccessor::InternalGet(libCZI::IBitmapData* pD
     this->CheckPlaneCoordinates(planeCoordinate);
     Clear(pDest, options.backGroundColor);
     const auto sizeBitmap = pDest->GetSize();
-    const auto subSet = GetSubBlocksSubset(IntRect{ xPos,yPos,static_cast<int>(sizeBitmap.w) * sizeOfPixelOnLayer0,static_cast<int>(sizeBitmap.h) * sizeOfPixelOnLayer0 }, planeCoordinate, pyramidInfo, options.sceneFilter.get());
+    const auto subSet = GetSubBlocksSubset(IntRect{ xPos,yPos,static_cast<int>(sizeBitmap.w) * sizeOfPixelOnLayer0,static_cast<int>(sizeBitmap.h) * sizeOfPixelOnLayer0 }, planeCoordinate, pyramidInfo, options.sceneFilter.get(), options.sortByM);
     if (subSet.empty())
     {	// no subblocks were found in the requested plane/ROI, so there is nothing to do
         return;
@@ -182,7 +182,7 @@ int CSingleChannelPyramidLevelTileAccessor::CalcPyramidLayerNo(const libCZI::Int
     return layerNo;
 }
 
-std::vector<CSingleChannelPyramidLevelTileAccessor::SbInfo> CSingleChannelPyramidLevelTileAccessor::GetSubBlocksSubset(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const PyramidLayerInfo& pyramidInfo, const libCZI::IIndexSet* sceneFilter)
+std::vector<CSingleChannelPyramidLevelTileAccessor::SbInfo> CSingleChannelPyramidLevelTileAccessor::GetSubBlocksSubset(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const PyramidLayerInfo& pyramidInfo, const libCZI::IIndexSet* sceneFilter, bool sortByM)
 {
     std::vector<CSingleChannelPyramidLevelTileAccessor::SbInfo> sblks;
     this->GetAllSubBlocks(roi, planeCoordinate, sceneFilter,
@@ -190,7 +190,11 @@ std::vector<CSingleChannelPyramidLevelTileAccessor::SbInfo> CSingleChannelPyrami
         {
             sblks.emplace_back(info);
         });
-
+    if (sortByM)
+    {
+        // sort ascending-by-M-index (-> lowest M-index first, highest last)
+        std::sort(sblks.begin(), sblks.end(), [](const CSingleChannelPyramidLevelTileAccessor::SbInfo& i1, const CSingleChannelPyramidLevelTileAccessor::SbInfo& i2)->bool {return i1.mIndex < i2.mIndex; });
+    }
     return sblks;
 }
 

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.h
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.h
@@ -45,7 +45,7 @@ private:
 
     std::map<int, SbByLayer> CalcByLayer(const std::vector<SbInfo>& sbinfo, int minificationFactor);
 
-    std::vector<SbInfo> GetSubBlocksSubset(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const PyramidLayerInfo& pyramidInfo, const libCZI::IIndexSet* sceneFilter);
+    std::vector<SbInfo> GetSubBlocksSubset(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const PyramidLayerInfo& pyramidInfo, const libCZI::IIndexSet* sceneFilter, bool sortByM);
 
     void GetAllSubBlocks(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const libCZI::IIndexSet* sceneFilter, const std::function<void(const SbInfo& info)>& appender) const;
 

--- a/Src/libCZI/SingleChannelScalingTileAccessor.h
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.h
@@ -35,7 +35,7 @@ public:	// interface ISingleChannelScalingTileAccessor
 private:
     static libCZI::IntSize InternalCalcSize(const libCZI::IntRect& roi, float zoom);
 
-    std::vector<int> CreateSortByZoom(const std::vector<SbInfo>& sbBlks);
+    std::vector<int> CreateSortByZoom(const std::vector<SbInfo>& sbBlks, bool sortByM);
     std::vector<SbInfo> GetSubSet(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const std::vector<int>* allowedScenes);
     int GetIdxOf1stSubBlockWithZoomGreater(const std::vector<SbInfo>& sbBlks, const std::vector<int>& byZoom, float zoom);
     void ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo);
@@ -50,8 +50,8 @@ private:
         std::vector<int>	sortedByZoom;
     };
 
-    SubSetSortedByZoom GetSubSetFilteredBySceneSortedByZoom(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const std::vector<int>& allowedScenes);
+    SubSetSortedByZoom GetSubSetFilteredBySceneSortedByZoom(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const std::vector<int>& allowedScenes, bool sortByM);
 
-    std::vector<std::tuple<int, SubSetSortedByZoom>> GetSubSetSortedByZoomPerScene(const std::vector<int>& scenes, const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate);
+    std::vector<std::tuple<int, SubSetSortedByZoom>> GetSubSetSortedByZoomPerScene(const std::vector<int>& scenes, const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, bool sortByM);
     void Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom);
 };

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -158,6 +158,10 @@ namespace libCZI
             /// If any of R, G or B is NaN, then the background is not cleared.
             RgbFloatColor   backGroundColor;
 
+            /// If true, then the tiles are sorted by their M-index (tile with highest M-index will be 'on top').
+            /// Otherwise the Z-order is arbitrary.
+            bool sortByM;
+
             /// If true, then a one-pixel wide boundary will be drawn around 
             /// each tile (in black color).
             bool drawTileBorder;
@@ -169,6 +173,7 @@ namespace libCZI
             void Clear()
             {
                 this->drawTileBorder = false;
+                this->sortByM = true;
                 this->backGroundColor.r = this->backGroundColor.g = this->backGroundColor.b = std::numeric_limits<float>::quiet_NaN();
                 this->sceneFilter.reset();
             }
@@ -232,6 +237,10 @@ namespace libCZI
             /// If any of R, G or B is NaN, then the background is not cleared.
             RgbFloatColor   backGroundColor;
 
+            /// If true, then the tiles are sorted by their M-index (tile with highest M-index will be 'on top').
+            /// Otherwise the Z-order is arbitrary.
+            bool sortByM;
+
             /// If true, then a one-pixel wide boundary will be drawn around 
             /// each tile (in black color).
             bool drawTileBorder;
@@ -244,6 +253,7 @@ namespace libCZI
             void Clear()
             {
                 this->drawTileBorder = false;
+                this->sortByM = true;
                 this->backGroundColor.r = this->backGroundColor.g = this->backGroundColor.b = std::numeric_limits<float>::quiet_NaN();
                 this->sceneFilter.reset();
             }


### PR DESCRIPTION
## Description
This PR introduces a sortByM flag to all tile accessors and the corresponding options struct. Setting this flag makes the tile accessors sort the subblocks according to their M-Indices in ascending order.

Fixes #46 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
See the description of #46 

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
