### PR TITLE
add unittest exercising "sortByM"-flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,10 @@ option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3 "Prefer an Eigen3-package pres
 #  See here: https://discourse.cmake.org/t/findzstd/3506
 option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_ZSTD "Prefer a ZSTD-package present on the system" OFF)
 
-
 if (LIBCZI_BUILD_UNITTESTS)
+ include (CTest)
  enable_testing()
 endif()
 
 add_subdirectory(Src)
+

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -222,6 +222,8 @@ else()
     message(STATUS "Fetching zstd...")
     set(ZSTD_BUILD_PROGRAMS  OFF CACHE BOOL "" FORCE)
     set(ZSTD_BUILD_SHARED    OFF CACHE BOOL "" FORCE)
+    set(ZSTD_BUILD_TESTS     OFF CACHE BOOL "" FORCE)
+    set(ZSTD_BUILD_CONTRIB   OFF CACHE BOOL "" FORCE)
 
     FetchContent_Populate(zstd)
 

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -262,8 +262,8 @@ void CSingleChannelScalingTileAccessor::InternalGet(libCZI::IBitmapData* bmDest,
 
 void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom)
 {
-    const int idxOf1stSSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, zoom);
-    if (idxOf1stSSubBlockOfZoomGreater < 0)
+    const int idxOf1stSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, zoom);
+    if (idxOf1stSubBlockOfZoomGreater < 0)
     {
         // this means that we would need to overzoom (i.e. the requested zoom is less than the lowest level we find in the subblock-repository)
         // TODO: this requires special consideration, for the time being -> bail out
@@ -274,7 +274,7 @@ void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const
     }
 
     std::vector<int>::const_iterator it = sbSetSortedByZoom.sortedByZoom.cbegin();
-    std::advance(it, idxOf1stSSubBlockOfZoomGreater);
+    std::advance(it, idxOf1stSubBlockOfZoomGreater);
 
     const float startZoom = sbSetSortedByZoom.subBlocks.at(*it).GetZoom();
 

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -191,7 +191,7 @@ namespace libCZI
         };
 
         /// Gets the tile composite of the specified plane and the specified ROI and the specified pyramid-layer.
-        /// The pixeltype is determined by examing the first subblock found in the
+        /// The pixeltype is determined by examining the first subblock found in the
         /// specified plane (which is an arbitrary subblock). A newly allocated
         /// bitmap is returned.
         /// \param roi             The ROI.
@@ -267,8 +267,8 @@ namespace libCZI
         /// \return The size of the composite created by this accessor (for these parameters).
         virtual libCZI::IntSize CalcSize(const libCZI::IntRect& roi, float zoom) const = 0;
 
-        /// Gets the scaled tile composite of the specified plane and the specified ROI with the specifed zoom factor.\n
-        /// The pixeltype is determined by examing the first subblock found in the
+        /// Gets the scaled tile composite of the specified plane and the specified ROI with the specified zoom factor.\n
+        /// The pixeltype is determined by examining the first subblock found in the
         /// specified plane (which is an arbitrary subblock). A newly allocated
         /// bitmap is returned.
         /// \param roi             The ROI.
@@ -278,7 +278,7 @@ namespace libCZI
         /// \return A std::shared_ptr&lt;libCZI::IBitmapData&gt;
         virtual std::shared_ptr<libCZI::IBitmapData> Get(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options* pOptions) = 0;
 
-        /// Gets the scaled tile composite of the specified plane and the specified ROI with the specifed zoom factor.
+        /// Gets the scaled tile composite of the specified plane and the specified ROI with the specified zoom factor.
         /// \param pixeltype       The pixeltype (of the destination bitmap).
         /// \param roi             The ROI.
         /// \param planeCoordinate The plane coordinate.

--- a/Src/libCZI_UnitTests/CMakeLists.txt
+++ b/Src/libCZI_UnitTests/CMakeLists.txt
@@ -67,7 +67,8 @@ ADD_EXECUTABLE(libCZI_UnitTests
 										pch.cpp                   
 										testImage.cpp                  
 										test_reader.cpp                 
-										utils.h)
+										utils.h 
+										test_Accessors.cpp)
 
 # Now simply link against gtest or gtest_main as needed. Eg
 TARGET_LINK_LIBRARIES(libCZI_UnitTests

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -108,7 +108,7 @@ static tuple<shared_ptr<void>, size_t> CreateTestCziDocumentAndGetAsBlob(const a
 
 struct ZOrderAndResultGray8Fixture : public testing::TestWithParam<tuple<int, int, int, array<uint8_t, 4>>> { };
 
-TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelScalingTileAccessorAndCheckResult)
+TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelScalingTileAccessorWithSortByMAndCheckResult)
 {
     // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
     // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
@@ -142,7 +142,7 @@ TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelScalingTile
     EXPECT_EQ(p[3], expected[3]);
 }
 
-TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelTileAccessorAndCheckResult)
+TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelTileAccessorWithSortByMAndCheckResult)
 {
     // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
     // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
@@ -176,7 +176,7 @@ TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelTileAccesso
     EXPECT_EQ(p[3], expected[3]);
 }
 
-TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelPyramidLayerTileAccessorAndCheckResult)
+TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelPyramidLayerTileAccessorWithSortByMAndCheckResult)
 {
     // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
     // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
@@ -226,3 +226,111 @@ INSTANTIATE_TEST_SUITE_P(
     make_tuple(1, 0, 2, array<uint8_t, 4>{ 42, 42, 47, 47 }),
     // second tile on top, first tile in the middle, third tile at the bottom
     make_tuple(1, 2, 0, array<uint8_t, 4>{ 42, 45, 45, 47 })));
+
+TEST(Accessor, CreateDocumentAndUseSingleChannelScalingTileAccessorAndCheckResult)
+{
+    // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
+    // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
+    // 1st subblock is at (0,0), 2nd at (0,1) and 3rd at (0,2).
+    // Then we use a single-channel scaling tile accessor to get the tile composite of size 4x1 pixels at (0,0) and check the result.
+    // When doing the tile composite, we instruct NOT to sort by M-index, so the order is undefined and we therefore check that the
+    // result is one of four possible results.
+
+    // arrange
+    auto czi_document_as_blob = CreateTestCziDocumentAndGetAsBlob(array<int, 3>{ 0, 1, 2 });
+    const auto memory_stream = make_shared<CMemInputOutputStream>(get<0>(czi_document_as_blob).get(), get<1>(czi_document_as_blob));
+    const auto reader = CreateCZIReader();
+    reader->Open(memory_stream);
+    const auto accessor = reader->CreateSingleChannelScalingTileAccessor();
+    const CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    ISingleChannelScalingTileAccessor::Options options;
+    options.Clear();
+    options.sortByM = false;
+
+    // act
+    const auto composite_bitmap = accessor->Get(PixelType::Gray8, IntRect{ 0,0,4,1 }, &plane_coordinate, 1.f, &options);
+
+    // assert
+    const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+    const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi);
+    const auto& expected_variant1 = array<uint8_t, 4>{ 42, 45, 47, 47};
+    const auto& expected_variant2 = array<uint8_t, 4>{ 42, 42, 45, 47};
+    const auto& expected_variant3 = array<uint8_t, 4>{ 42, 42, 47, 47};
+    const auto& expected_variant4 = array<uint8_t, 4>{ 42, 45, 45, 47};
+    EXPECT_TRUE(memcmp(p, &expected_variant1, sizeof(expected_variant1)) == 0 ||
+                memcmp(p, &expected_variant2, sizeof(expected_variant2)) == 0 ||
+                memcmp(p, &expected_variant3, sizeof(expected_variant3)) == 0 ||
+                memcmp(p, &expected_variant4, sizeof(expected_variant4)) == 0);
+}
+
+TEST(Accessor, CreateDocumentAndUseSingleChannelTileAccessorAndCheckResult)
+{
+    // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
+    // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
+    // 1st subblock is at (0,0), 2nd at (0,1) and 3rd at (0,2).
+    // Then we use a single-channel tile accessor to get the tile composite of size 4x1 pixels at (0,0) and check the result.
+    // When doing the tile composite, we instruct NOT to sort by M-index, so the order is undefined and we therefore check that the
+    // result is one of four possible results.
+
+    // arrange
+    auto czi_document_as_blob = CreateTestCziDocumentAndGetAsBlob(array<int, 3>{ 0, 1, 2 });
+    const auto memory_stream = make_shared<CMemInputOutputStream>(get<0>(czi_document_as_blob).get(), get<1>(czi_document_as_blob));
+    const auto reader = CreateCZIReader();
+    reader->Open(memory_stream);
+    const auto accessor = reader->CreateSingleChannelTileAccessor();
+    const CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    ISingleChannelTileAccessor::Options options;
+    options.Clear();
+    options.sortByM = false;
+
+    // act
+    const auto composite_bitmap = accessor->Get(PixelType::Gray8, IntRect{ 0,0,4,1 }, &plane_coordinate, &options);
+
+    // assert
+    const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+    const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi);
+    const auto& expected_variant1 = array<uint8_t, 4>{ 42, 45, 47, 47};
+    const auto& expected_variant2 = array<uint8_t, 4>{ 42, 42, 45, 47};
+    const auto& expected_variant3 = array<uint8_t, 4>{ 42, 42, 47, 47};
+    const auto& expected_variant4 = array<uint8_t, 4>{ 42, 45, 45, 47};
+    EXPECT_TRUE(memcmp(p, &expected_variant1, sizeof(expected_variant1)) == 0 ||
+                memcmp(p, &expected_variant2, sizeof(expected_variant2)) == 0 ||
+                memcmp(p, &expected_variant3, sizeof(expected_variant3)) == 0 ||
+                memcmp(p, &expected_variant4, sizeof(expected_variant4)) == 0);
+}
+
+TEST(Accessor, CreateDocumentAndUseSingleChannelPyramidLayerTileAccessorWithAndCheckResult)
+{
+    // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
+    // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
+    // 1st subblock is at (0,0), 2nd at (0,1) and 3rd at (0,2).
+    // Then we use a pyramid-layer tile accessor to get the tile composite of size 4x1 pixels at (0,0) and check the result.
+    // When doing the tile composite, we instruct NOT to sort by M-index, so the order is undefined and we therefore check that the
+    // result is one of four possible results.
+
+    // arrange
+    auto czi_document_as_blob = CreateTestCziDocumentAndGetAsBlob(array<int, 3>{ 0, 1, 2 });
+    const auto memory_stream = make_shared<CMemInputOutputStream>(get<0>(czi_document_as_blob).get(), get<1>(czi_document_as_blob));
+    const auto reader = CreateCZIReader();
+    reader->Open(memory_stream);
+    const auto accessor = reader->CreateSingleChannelPyramidLayerTileAccessor();
+    CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    ISingleChannelPyramidLayerTileAccessor::Options options;
+    options.Clear();
+    options.sortByM = false;
+
+    // act
+    const auto composite_bitmap = accessor->Get(PixelType::Gray8, IntRect{ 0,0,4,1 }, &plane_coordinate, ISingleChannelPyramidLayerTileAccessor::PyramidLayerInfo{ 2,0 }, &options);
+
+    // assert
+    const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+    const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi);
+    const auto& expected_variant1 = array<uint8_t, 4>{ 42, 45, 47, 47};
+    const auto& expected_variant2 = array<uint8_t, 4>{ 42, 42, 45, 47};
+    const auto& expected_variant3 = array<uint8_t, 4>{ 42, 42, 47, 47};
+    const auto& expected_variant4 = array<uint8_t, 4>{ 42, 45, 45, 47};
+    EXPECT_TRUE(memcmp(p, &expected_variant1, sizeof(expected_variant1)) == 0 ||
+                memcmp(p, &expected_variant2, sizeof(expected_variant2)) == 0 ||
+                memcmp(p, &expected_variant3, sizeof(expected_variant3)) == 0 ||
+                memcmp(p, &expected_variant4, sizeof(expected_variant4)) == 0);
+}

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2017-2022 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "pch.h"
+#include <array>
+#include "inc_libCZI.h"
+#include "MemOutputStream.h"
+#include "utils.h"
+#include "MemInputOutputStream.h"
+
+using namespace libCZI;
+using namespace std;
+
+struct ZOrderAndResultGray8Fixture : public testing::TestWithParam<tuple<int, int, int, array<uint8_t, 4>>> { };
+
+TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelScalingTileAccessorAndCheckResult)
+{
+    // We create a document with 3 subblocks, where the M-index (of each subblock) is given by the test parameters.
+    // The subblocks are 2x1 pixels, and the pixel values are 42 for the 1st, 45 for the second, and 47 for the third
+    // 1st subblock is at (0,0), 2nd at (0,1) and 3rd at (0,2).
+    // Then we use a single-channel scaling tile accessor to get the tile composite of size 4x1 pixels at (0,0) and check the result.
+    // When doing the tile composite, the M-index is to give the z-order - so depending on the M-index, we expect a different result,
+    // which is then checked.
+
+    const auto parameters = GetParam();
+
+    // arrange
+    auto writer = CreateCZIWriter();
+    auto outStream = make_shared<CMemOutputStream>(0);
+
+    auto spWriterInfo = make_shared<CCziWriterInfo >(
+        GUID{ 0x1234567,0x89ab,0xcdef,{ 1,2,3,4,5,6,7,8 } },
+        CDimBounds{ { DimensionIndex::C,0,1 } },	// set a bounds C
+        0, 2);	// set a bounds M : 0<=m<=2
+    writer->Create(outStream, spWriterInfo);
+
+    auto bitmap = CreateGray8BitmapAndFill(2, 1, 42);
+    AddSubBlockInfoStridedBitmap addSbBlkInfo;
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate.Set(DimensionIndex::C, 0);
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = get<0>(parameters);
+    addSbBlkInfo.x = 0;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    {
+        ScopedBitmapLockerSP lock_info_bitmap{ bitmap };
+        addSbBlkInfo.ptrBitmap = lock_info_bitmap.ptrDataRoi;
+        addSbBlkInfo.strideBitmap = lock_info_bitmap.stride;
+        writer->SyncAddSubBlock(addSbBlkInfo);
+    }
+
+    bitmap = CreateGray8BitmapAndFill(2, 1, 45);
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate.Set(DimensionIndex::C, 0);
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = get<1>(parameters);
+    addSbBlkInfo.x = 1;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    {
+        ScopedBitmapLockerSP lock_info_bitmap{ bitmap };
+        addSbBlkInfo.ptrBitmap = lock_info_bitmap.ptrDataRoi;
+        addSbBlkInfo.strideBitmap = lock_info_bitmap.stride;
+        writer->SyncAddSubBlock(addSbBlkInfo);
+    }
+
+    bitmap = CreateGray8BitmapAndFill(2, 1, 47);
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate.Set(DimensionIndex::C, 0);
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = get<2>(parameters);
+    addSbBlkInfo.x = 2;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    {
+        ScopedBitmapLockerSP lock_info_bitmap{ bitmap };
+        addSbBlkInfo.ptrBitmap = lock_info_bitmap.ptrDataRoi;
+        addSbBlkInfo.strideBitmap = lock_info_bitmap.stride;
+        writer->SyncAddSubBlock(addSbBlkInfo);
+    }
+
+    PrepareMetadataInfo prepare_metadata_info;
+    auto metaDataBuilder = writer->GetPreparedMetadata(prepare_metadata_info);
+    WriteMetadataInfo write_metadata_info;
+    write_metadata_info.Clear();
+    const auto& strMetadata = metaDataBuilder->GetXml();
+    write_metadata_info.szMetadata = strMetadata.c_str();
+    write_metadata_info.szMetadataSize = strMetadata.size() + 1;
+    write_metadata_info.ptrAttachment = nullptr;
+    write_metadata_info.attachmentSize = 0;
+    writer->SyncWriteMetadata(write_metadata_info);
+    writer->Close();
+    writer.reset();
+
+    size_t czi_document_size;
+    shared_ptr<void> czi_document_data = outStream->GetCopy(&czi_document_size);
+    outStream.reset();
+
+    auto memory_stream = make_shared<CMemInputOutputStream>(czi_document_data.get(), czi_document_size);
+    auto reader = CreateCZIReader();
+    reader->Open(memory_stream);
+    auto accessor = reader->CreateSingleChannelScalingTileAccessor();
+    CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    ISingleChannelScalingTileAccessor::Options options;
+    options.Clear();
+
+    // act
+    auto composite_bitmap = accessor->Get(PixelType::Gray8, IntRect{ 0,0,4,1 }, &plane_coordinate, 1.f, &options);
+
+    // assert
+    ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+    const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi);
+    const auto& expected = get<3>(parameters);
+    EXPECT_EQ(p[0], expected[0]);
+    EXPECT_EQ(p[1], expected[1]);
+    EXPECT_EQ(p[2], expected[2]);
+    EXPECT_EQ(p[3], expected[3]);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Accessor,
+    ZOrderAndResultGray8Fixture,
+    testing::Values(
+    // third tile on top, second tile in the middle, first tile at the bottom
+    make_tuple(0, 1, 2, array<uint8_t, 4>{ 42, 45, 47, 47 }),
+    // first tile on top, second tile in the middle, third tile at the bottom
+    make_tuple(2, 1, 0, array<uint8_t, 4>{ 42, 42, 45, 47 }),
+    // second tile on top, third tile in the middle, first tile at the bottom
+    make_tuple(0, 2, 1, array<uint8_t, 4>{ 42, 45, 45, 47 }),
+    // first tile on top, third tile in the middle, first tile at the bottom
+    make_tuple(2, 0, 1, array<uint8_t, 4>{ 42, 42, 47, 47 }),
+    // third tile on top, first tile in the middle, second tile at the bottom
+    make_tuple(1, 0, 2, array<uint8_t, 4>{ 42, 42, 47, 47 }),
+    // second tile on top, first tile in the middle, third tile at the bottom
+    make_tuple(1, 2, 0, array<uint8_t, 4>{ 42, 45, 45, 47 })));

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -26,7 +26,7 @@ static tuple<shared_ptr<void>, size_t> CreateTestCziDocumentAndGetAsBlob(const a
 
     auto spWriterInfo = make_shared<CCziWriterInfo >(
         GUID{ 0x1234567,0x89ab,0xcdef,{ 1,2,3,4,5,6,7,8 } },
-        CDimBounds{ { DimensionIndex::C,0,1 } },	// set a bounds C
+        CDimBounds{ { DimensionIndex::C, 0, 1 } },	// set a bounds C
         0, 2);	// set a bounds M : 0<=m<=2
     writer->Create(outStream, spWriterInfo);
 
@@ -193,7 +193,7 @@ TEST_P(ZOrderAndResultGray8Fixture, CreateDocumentAndUseSingleChannelPyramidLaye
     const auto reader = CreateCZIReader();
     reader->Open(memory_stream);
     const auto accessor = reader->CreateSingleChannelPyramidLayerTileAccessor();
-    CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    const CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
     ISingleChannelPyramidLayerTileAccessor::Options options;
     options.Clear();
 
@@ -314,7 +314,7 @@ TEST(Accessor, CreateDocumentAndUseSingleChannelPyramidLayerTileAccessorWithAndC
     const auto reader = CreateCZIReader();
     reader->Open(memory_stream);
     const auto accessor = reader->CreateSingleChannelPyramidLayerTileAccessor();
-    CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    const CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
     ISingleChannelPyramidLayerTileAccessor::Options options;
     options.Clear();
     options.sortByM = false;

--- a/Src/libCZI_UnitTests/test_readerwriter.cpp
+++ b/Src/libCZI_UnitTests/test_readerwriter.cpp
@@ -277,7 +277,7 @@ TEST(CziReaderWriter, ReaderWriter1)
                 indexOfModifiedSbBlk = index;
                 ++callCnt;
             }
-    return true;
+            return true;
         });
 
     EXPECT_TRUE(callCnt == 1 && indexOfModifiedSbBlk >= 0) << "not the expected result";
@@ -408,8 +408,8 @@ TEST(CziReaderWriter, ReaderWriter2)
                 return true;
             }
 
-    success = false;
-    return false;
+            success = false;
+            return false;
         });
 
     EXPECT_TRUE(success && allReceived) << "did not behave as expected";
@@ -434,7 +434,7 @@ TEST(CziReaderWriter, ReaderWriter3)
                 return false;
             }
 
-    return true;
+            return true;
         });
 
     EXPECT_TRUE(idxAttachment >= 0) << "did not behave as expected";
@@ -534,8 +534,8 @@ TEST(CziReaderWriter, ReaderWriter3)
                 return true;
             }
 
-    success = false;
-    return false;
+            success = false;
+            return false;
         });
 
     allReceived = true;
@@ -564,7 +564,7 @@ TEST(CziReaderWriter, ReaderWriter4)
                 return false;
             }
 
-    return true;
+            return true;
         });
 
     EXPECT_TRUE(idxAttachment >= 0) << "did not behave as expected";
@@ -616,7 +616,7 @@ TEST(CziReaderWriter, ReaderWriter4)
                 indexOfModifiedAttchmnt = index;
             }
 
-    return true;
+            return true;
         });
 
     EXPECT_TRUE(indexOfModifiedAttchmnt >= 0) << "not the expected result";

--- a/Src/libCZI_UnitTests/utils.cpp
+++ b/Src/libCZI_UnitTests/utils.cpp
@@ -306,6 +306,20 @@ std::shared_ptr<libCZI::IBitmapData> CreateTestBitmap(libCZI::PixelType pixeltyp
     return bm;
 }
 
+std::shared_ptr<libCZI::IBitmapData> CreateGray8BitmapAndFill(std::uint32_t width, std::uint32_t height, uint8_t value)
+{
+    auto bm = make_shared<CMemBitmapWrapper>(PixelType::Gray8, width, height);
+    ScopedBitmapLockerSP lckBm{ bm };
+    uint8_t* data = reinterpret_cast<uint8_t*>(lckBm.ptrDataRoi);
+    for (uint32_t y = 0; y < height; ++y)
+    {
+        uint8_t* dst = data + (static_cast<size_t>(lckBm.stride) * y);
+        memset(dst, value, width);
+    }
+
+    return bm;
+}
+
 std::shared_ptr<libCZI::IBitmapData> CreateRandomBitmap(libCZI::PixelType pixeltype, std::uint32_t width, std::uint32_t height)
 {
     ::srand(::time(nullptr));

--- a/Src/libCZI_UnitTests/utils.h
+++ b/Src/libCZI_UnitTests/utils.h
@@ -10,7 +10,7 @@
 /**
  * \brief	Creates a testing bitmap with the given width, height and the pixel type.
  *			The function throws exception if unsupported pixel type is selected.
- * \param	pixelType	The pixel type. Supports either PixelType::Gray8, PixelType::Gray16,
+ * \param	pixeltype	The pixel type. Supports either PixelType::Gray8, PixelType::Gray16,
  *						PixelType::Bgr24 or PixelType::Bgr48. All other types are not supported.
  *						The function throws exception if other pixel type is selected.
  * \param	width		The width of bitmap image in pixels.
@@ -23,7 +23,7 @@ std::shared_ptr<libCZI::IBitmapData> CreateTestBitmap(libCZI::PixelType pixeltyp
 /**
  * \brief	Creates a testing bitmap with random pixel values. The image has given width, height and the pixel type.
  *			The function throws exception if unsupported pixel type is selected.
- * \param	pixelType	The pixel type. Supports either PixelType::Gray8, PixelType::Gray16,
+ * \param	pixeltype	The pixel type. Supports either PixelType::Gray8, PixelType::Gray16,
  *						PixelType::Bgr24 or PixelType::Bgr48. All other types are not supported.
  *						The function throws exception if other pixel type is selected.
  * \param	width		The width of bitmap image in pixels.
@@ -33,6 +33,9 @@ std::shared_ptr<libCZI::IBitmapData> CreateTestBitmap(libCZI::PixelType pixeltyp
  *			failed to allocated memory for the image.
  */
 std::shared_ptr<libCZI::IBitmapData> CreateRandomBitmap(libCZI::PixelType pixeltype, std::uint32_t width, std::uint32_t height);
+
+
+std::shared_ptr<libCZI::IBitmapData> CreateGray8BitmapAndFill(std::uint32_t width, std::uint32_t height, uint8_t value);
 
 /**
  * \brief	Creates an object with Zeiss logo bitmap image, which has fixed size of image width, height and pixel types


### PR DESCRIPTION
## Description

This is adding unit-tests coverage in the area changed with #48 .

Fixes #49 .

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

CI/CD on fork

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
