### PR TITLE
fix for "not-pixel-exact result with scaling-accessor if zoom is exactly 1"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.48.0
+      VERSION 0.48.1
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -427,7 +427,7 @@ TEST(Accessor, CreateDocumentAndEnsurePixelAccuracyWithScalingAccessor)
             const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + y * lock_info_bitmap.stride + x;
             if (*p != expected_value)
             {
-                FAIL() << "resulting bitmap is incorrect (at x=" << x << " y=" << y << '.';
+                FAIL() << "resulting bitmap is incorrect (at x=" << x << " y=" << y << ").";
             }
         }
     }

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -419,11 +419,11 @@ TEST(Accessor, CreateDocumentAndEnsurePixelAccuracyWithScalingAccessor)
     
     // ok, we now expect that composite-bitmap is all black, except for a rectangle of size 761x2449 at (0,2671) which has the pixel-value 0x2a
     const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
-    for (int y = 0; y < 5121; ++y)
+    for (size_t y = 0; y < 5121; ++y)
     {
-        for (int x = 0; x < 5121; ++x)
+        for (size_t x = 0; x < 5121; ++x)
         {
-            uint8_t expected_value = (x >= 0 && x < 761 && y >= 2671 && y < 2671 + 2449) ? 0x2a : 0;
+            uint8_t expected_value = (x < 761 && y >= 2671 && y < 2671 + 2449) ? 0x2a : 0;
             const uint8_t* p = static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + y * lock_info_bitmap.stride + x;
             if (*p != expected_value)
             {

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -465,7 +465,7 @@ TEST(Accessor, CreateDocumentAndExerciseScalingAccessorAllowingForInaccuracy)
         PixelType::Gray8,
         IntRect{ 0,0,5121,5121 },
         &plane_coordinate,
-        1 - numeric_limits<float>::epsilon(),
+        zoom,
         &options);
 
     // assert

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -393,7 +393,7 @@ TEST(Accessor, CreateDocumentAndEnsurePixelAccuracyWithScalingAccessor)
 {
     // arrange
 
-    // we now create a document which characteristics which have been "problematic" - in this case the composition
+    // we now create a document with characteristics which have been "problematic" - in this case the composition
     //  result was not pixel-accurate (despite the zoom being exactly 1)
     auto czi_document_as_blob = CreateCziWhichWasFoundProblematicWrtPixelAccuracyAndGetAsBlob();
 


### PR DESCRIPTION
## Description

When using the scaling-accessor, in some cases not pixel-accurate compositions have been found.
This PR avoids using the scaling-blit-operation if zoom is exactly 1, and therefore is giving pixel-accurate results in this case.
A unit-test which exercises on of the problematic cases is added.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

running unit-tests locally, testing with CZIcmd

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
