### PR TITLE
Write colormode to displaysettingsxml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.48.1
+      VERSION 0.48.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -962,6 +962,11 @@ static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_di
     if (channel_display_setting->TryGetTintingColorRgb8(&tinting_color))
     {
         node->GetOrCreateChildNode("Color")->SetValue(Utilities::Rgb8ColorToString(tinting_color));
+        node->GetOrCreateChildNode("ColorMode")->SetValue("Color"); // instruct to use 'tinting'
+    }
+    else
+    {
+        node->GetOrCreateChildNode("ColorMode")->SetValue("None"); // instruct to 'disable tinting'
     }
 
     float black_point, white_point;

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -583,7 +583,7 @@ namespace libCZI
         /// \param [out] gamma If non-null and applicable, the gamma will be returned.
         ///
         /// \return True if the corresponding channel uses gradation curve mode <tt>Gamma</tt> (and a value for gamma is available), false otherwise.
-        virtual bool    TryGetGamma(float* gamma)const = 0;
+        virtual bool    TryGetGamma(float* gamma) const = 0;
 
         /// Attempts to get spline control points - this will only be available if gradation curve mode is <tt>Spline</tt>.
         /// \remark


### PR DESCRIPTION
## Description

When serializing display-settings to CZI-XML, it was found that we better write the element "ColorMode", which explicitly states whether "tinting-mode" is to be used or not.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
