### PR TITLE
Write colormode to displaysettingsxml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.48.1
+      VERSION 0.48.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CziMetadata.cpp
+++ b/Src/libCZI/CziMetadata.cpp
@@ -186,7 +186,7 @@ bool IXmlNodeRead::TryGetValueAsUInt32(std::uint32_t* p)
                 throw out_of_range("value was out-of-range");
             }
 
-            return (uint32_t)v;
+            return static_cast<uint32_t>(v);
         }
     };
 

--- a/Src/libCZI/CziMetadata.h
+++ b/Src/libCZI/CziMetadata.h
@@ -15,7 +15,7 @@ class CCziMetadata : public libCZI::ICziMetadata, public std::enable_shared_from
 private:
     struct XmlNodeWrapperThrowExcp
     {
-        static void ThrowInvalidPath()
+        [[noreturn]] static void ThrowInvalidPath()
         {
             throw libCZI::LibCZIMetadataException("invalid path", libCZI::LibCZIMetadataException::ErrorType::InvalidPath);
         }

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -146,7 +146,6 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
 
 /*virtual*/std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetChildNode(const char* path)
 {
-    //return this->GetOrCreateChildNode(path, false);
     const auto child_node = this->GetChildNodePathMustExist(path);
     if (!child_node)
     {

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -141,7 +141,7 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
 
 /*virtual*/std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNode(const char* path)
 {
-    return this->GetOrCreateChildNodeInternal(path/*, true*/);
+    return this->GetOrCreateChildNodeInternal(path);
 }
 
 /*virtual*/std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetChildNode(const char* path)
@@ -339,7 +339,7 @@ pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz)
     return CNodeWrapper::GetOrCreateChildElementNode(this->node, sz);
 }
 
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs/*, bool allowCreation*/)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs)
 {
     struct find_element_node_and_attributes
     {

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -264,7 +264,7 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
 
 //--------------------------------------------------------------------------------------
 
-std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNodeInternal(const char* path/*, bool allowCreation*/)
+std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNodeInternal(const char* path)
 {
     auto p = Utilities::convertUtf8ToWchar_t(path);
 
@@ -280,7 +280,7 @@ std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNodeInternal(const cha
         throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
     }
 
-    auto node = this->GetOrCreateChildElementNodeWithAttributes(this->node, tokens[0]/*, allowCreation*/);
+    auto node = this->GetOrCreateChildElementNodeWithAttributes(this->node, tokens[0]);
     if (!node)
     {
         return nullptr;
@@ -288,7 +288,7 @@ std::shared_ptr<IXmlNodeRw> CNodeWrapper::GetOrCreateChildNodeInternal(const cha
 
     for (size_t i = 1; i < tokens.size(); ++i)
     {
-        node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i].c_str()/*, allowCreation*/);
+        node = CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(node, tokens[i]);
         if (!node)
         {
             return nullptr;
@@ -335,12 +335,7 @@ pugi::xml_node CNodeWrapper::GetOrCreatePcDataChild()
     attribute.set_value(Utilities::convertUtf8ToWchar_t(value).c_str());
 }
 
-//pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(const std::wstring& str/*, bool allowCreation*/)
-//{
-//    return CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(this->node, str/*, allowCreation*/);
-//}
-
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str/*, bool allowCreation*/)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str)
 {
     std::wregex nodenameWihtAttribregex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
     std::wsmatch pieces_match;
@@ -355,12 +350,12 @@ pugi::xml_node CNodeWrapper::GetOrCreatePcDataChild()
                 if (pieces_match[2].matched == false && pieces_match[3].matched == false)
                 {
                     // we only got a name ( not followed by [Id=abc] )
-                    return GetOrCreateChildElementNode(node, nodeName.c_str()/*, allowCreation*/);
+                    return GetOrCreateChildElementNode(node, nodeName.c_str());
                 }
                 else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
                 {
                     const auto attribValuePairs = CNodeWrapper::ParseAttributes(pieces_match[3]);
-                    return GetOrCreateChildElementNodeWithAttributes(node, nodeName, attribValuePairs/*, allowCreation*/);
+                    return GetOrCreateChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
                 }
             }
         }
@@ -369,9 +364,9 @@ pugi::xml_node CNodeWrapper::GetOrCreatePcDataChild()
     throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
 }
 
-pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz/*, bool allowCreation*/)
+pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz)
 {
-    return CNodeWrapper::GetOrCreateChildElementNode(this->node, sz/*, allowCreation*/);
+    return CNodeWrapper::GetOrCreateChildElementNode(this->node, sz);
 }
 
 /*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs/*, bool allowCreation*/)
@@ -418,11 +413,6 @@ pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz/*, bo
     auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
     if (!c)
     {
-        //if (!allowCreation)
-        //{
-        //    return xml_node();
-        //}
-
         auto newNode = node.append_child(str.c_str());
         for (auto it = attribs.cbegin(); it != attribs.cend(); ++it)
         {
@@ -435,7 +425,7 @@ pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz/*, bo
     return c;
 }
 
-/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz/*, bool allowCreation*/)
+/*static*/pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz)
 {
     struct find_element_node
     {
@@ -455,11 +445,6 @@ pugi::xml_node CNodeWrapper::GetOrCreateChildElementNode(const wchar_t* sz/*, bo
     auto c = node.find_child(find_element_node{ sz });
     if (!c)
     {
-        /*if (!allowCreation)
-        {
-            return xml_node();
-        }*/
-
         return node.append_child(sz);
     }
 
@@ -589,7 +574,7 @@ CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName, const std:
 
         s.append("]");
 
-        auto channelNode = root->GetOrCreateChildNode(s.c_str());
+        const auto channelNode = root->GetOrCreateChildNode(s.c_str());
 
         auto pxlTypeIterator = pixelTypeForChannel.GetChannelIndexPixelTypeMap().find(ch);
         if (pxlTypeIterator != pixelTypeForChannel.GetChannelIndexPixelTypeMap().end())
@@ -658,7 +643,7 @@ CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName, const std:
         break;
     default:
         return false;
-    };
+    }
 
     return true;
 }
@@ -714,7 +699,6 @@ bool libCZI::XmlDateTime::IsValid() const
 /*static*/bool libCZI::XmlDateTime::TryParse(const char* sz, libCZI::XmlDateTime* ptrDateTime)
 {
     // cf. https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html
-    //static const char* regexStr = "^(?<year>-?(?:[1-9][0-9]*)?[0-9]{4})-(?<month>1[0-2]|0[1-9])-(?<day>3[01]|0[1-9]|[12][0-9])T(?<hour>2[0-3]|[01][0-9]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9])(?<ms>\.[0-9]+)?(?<timezone>Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$";
     static const char* regexStr = R"((-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?)";
 
     auto str = Utilities::Trim(sz);

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -109,42 +109,13 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
 
 /*virtual*/std::shared_ptr<IXmlNodeRead> CNodeWrapper::GetChildNodeReadonly(const char* path)
 {
-    /*auto p = Utilities::convertUtf8ToWchar_t(path);
-    vector<std::wstring> tokens;
-    Utilities::Tokenize(p, tokens, L"/");
-    if (tokens.empty())
-    {
-        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-    }
-
-    if (any_of(tokens.cbegin(), tokens.cend(), [](const wstring& str) {return str.empty(); }))
-    {
-        throw LibCZIMetadataBuilderException("invalid path", LibCZIMetadataBuilderException::ErrorType::InvalidPath);
-    }
-
-    auto node = XmlPathSpecifierUtilities<MetadataBuilderXmlNodeWrapperThrowExcp>::GetChildElementNodeWithAttributes(this->node, tokens[0]);
-    if (!node)
-    {
-        return nullptr;
-    }
-
-    for (size_t i = 1; i < tokens.size(); ++i)
-    {
-        node = XmlPathSpecifierUtilities<MetadataBuilderXmlNodeWrapperThrowExcp>::GetChildElementNodeWithAttributes(node, tokens[i]);
-        if (!node)
-        {
-            return nullptr;
-        }
-
-    return std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, node.internal_object());
-    }*/
-    auto child_node = this->GetChildNodePathMustExist(path);
+    const auto child_node = this->GetChildNodePathMustExist(path);
     if (!child_node)
     {
         return nullptr;
     }
 
-    return std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, child_node.internal_object());
+    return std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp>>(this->builderRef, child_node.internal_object());
 }
 
 /*virtual*/void CNodeWrapper::EnumChildren(const std::function<bool(std::shared_ptr<IXmlNodeRead>)>& enumChildren)
@@ -154,7 +125,7 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
         if (childNode.type() == pugi::xml_node_type::node_element)
         {
             bool b = enumChildren(
-                std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp> >(this->builderRef, childNode.internal_object()));
+                std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp>>(this->builderRef, childNode.internal_object()));
             if (!b)
             {
                 break;

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -962,6 +962,11 @@ static void WriteChannelDisplaySettings(const IChannelDisplaySetting* channel_di
     if (channel_display_setting->TryGetTintingColorRgb8(&tinting_color))
     {
         node->GetOrCreateChildNode("Color")->SetValue(Utilities::Rgb8ColorToString(tinting_color));
+        node->GetOrCreateChildNode("ColorMode")->SetValue("Color"); // instruct to use 'tinting'
+    }
+    else
+    {
+        node->GetOrCreateChildNode("ColorMode")->SetValue("None"); // instruct to 'disable tinting'
     }
 
     float black_point, white_point;

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -120,12 +120,12 @@ pugi::xml_node CNodeWrapper::GetChildNodePathMustExist(const char* path)
 
 /*virtual*/void CNodeWrapper::EnumChildren(const std::function<bool(std::shared_ptr<IXmlNodeRead>)>& enumChildren)
 {
-    for (pugi::xml_node childNode = this->node.first_child(); childNode; childNode = childNode.next_sibling())
+    for (pugi::xml_node child_node = this->node.first_child(); child_node; child_node = child_node.next_sibling())
     {
-        if (childNode.type() == pugi::xml_node_type::node_element)
+        if (child_node.type() == pugi::xml_node_type::node_element)
         {
-            bool b = enumChildren(
-                std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp>>(this->builderRef, childNode.internal_object()));
+            const bool b = enumChildren(
+                std::make_shared<XmlNodeWrapperReadonly<CCZiMetadataBuilder, MetadataBuilderXmlNodeWrapperThrowExcp>>(this->builderRef, child_node.internal_object()));
             if (!b)
             {
                 break;

--- a/Src/libCZI/CziMetadataBuilder.h
+++ b/Src/libCZI/CziMetadataBuilder.h
@@ -73,14 +73,15 @@ public:
     bool RemoveChild(const char* name) override;
     bool RemoveAttribute(const char* name) override;
 private:
-    std::shared_ptr<IXmlNodeRw> GetOrCreateChildNode(const char* path, bool allowCreation);
-    pugi::xml_node GetOrCreateChildElementNode(const wchar_t* sz, bool allowCreation);
-    static pugi::xml_node GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz, bool allowCreation);
+    pugi::xml_node GetChildNodePathMustExist(const char* path);
+    std::shared_ptr<IXmlNodeRw> GetOrCreateChildNodeInternal(const char* path/*, bool allowCreation*/);
+    pugi::xml_node GetOrCreateChildElementNode(const wchar_t* sz/*, bool allowCreation*/);
+    static pugi::xml_node GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz/*, bool allowCreation*/);
 
-    pugi::xml_node GetOrCreateChildElementNodeWithAttributes(const std::wstring& str, bool allowCreation);
-    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, bool allowCreation);
+    //pugi::xml_node GetOrCreateChildElementNodeWithAttributes(const std::wstring& str, bool allowCreation);
+    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str/*, bool allowCreation*/);
 
-    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs, bool allowCreation);
+    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs/*, bool allowCreation*/);
 
     static std::map<std::wstring, std::wstring> ParseAttributes(const std::wstring& str);
 

--- a/Src/libCZI/CziMetadataBuilder.h
+++ b/Src/libCZI/CziMetadataBuilder.h
@@ -74,15 +74,11 @@ public:
     bool RemoveAttribute(const char* name) override;
 private:
     pugi::xml_node GetChildNodePathMustExist(const char* path);
-    std::shared_ptr<IXmlNodeRw> GetOrCreateChildNodeInternal(const char* path/*, bool allowCreation*/);
-    pugi::xml_node GetOrCreateChildElementNode(const wchar_t* sz/*, bool allowCreation*/);
-    static pugi::xml_node GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz/*, bool allowCreation*/);
-
-    //pugi::xml_node GetOrCreateChildElementNodeWithAttributes(const std::wstring& str, bool allowCreation);
-    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str/*, bool allowCreation*/);
-
-    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs/*, bool allowCreation*/);
-
+    std::shared_ptr<IXmlNodeRw> GetOrCreateChildNodeInternal(const char* path);
+    pugi::xml_node GetOrCreateChildElementNode(const wchar_t* sz);
+    static pugi::xml_node GetOrCreateChildElementNode(pugi::xml_node& node, const wchar_t* sz);
+    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str);
+    static pugi::xml_node GetOrCreateChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs);
     static std::map<std::wstring, std::wstring> ParseAttributes(const std::wstring& str);
 
     void ThrowIfCannotSetValue();

--- a/Src/libCZI/XmlNodeWrapper.h
+++ b/Src/libCZI/XmlNodeWrapper.h
@@ -132,7 +132,7 @@ public: // interface IXmlNodeRead
 
         for (size_t i = 1; i < tokens.size(); ++i)
         {
-            node = GetChildElementNodeWithAttributes(node, tokens[i].c_str());
+            node = GetChildElementNodeWithAttributes(node, tokens[i]);
             if (!node)
             {
                 return nullptr;

--- a/Src/libCZI/XmlNodeWrapper.h
+++ b/Src/libCZI/XmlNodeWrapper.h
@@ -16,10 +16,20 @@
 #include "pugixml.hpp"
 #include "libCZI_exceptions.h"
 
+/// A utility for parsing an "XML path specifier" (as used with IXmlNodeRead).
+///
+/// \tparam tExcp   Generic type used for throwing the appropriate exception in case of an error while parsing.
 template<typename tExcp>
 class XmlPathSpecifierUtilities
 {
 public:
+
+    /// Gets the child element node specified by the given path. This method supports node specifiers in the form of
+    /// "list of attributes" (e.g. "[Id=abc][Name=def]") and "index" (e.g. "[2]").
+    /// \param [in]     node    The node where the path is to be evaluated for.
+    /// \param          str     The path.
+    ///
+    /// \returns    The child element identified by the path.
     static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str)
     {
         // this matches one or more characters that are not square brackets, followed by an optional group that starts with a '[', 
@@ -50,7 +60,6 @@ public:
         tExcp::ThrowInvalidPath();
         throw std::logic_error("Must not get here.");
     }
-
 private:
     static pugi::xml_node GetChildElementWithSpecifier(pugi::xml_node& node, const std::wstring& nodeName, const std::wstring& specifier)
     {
@@ -78,8 +87,8 @@ private:
         }
         else
         {
-            const auto attribValuePairs = ParseAttributes(specifier);
-            return GetChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
+            const auto attribute_value_pairs = ParseAttributes(specifier);
+            return GetChildElementNodeWithAttributes(node, nodeName, attribute_value_pairs);
         }
     }
 
@@ -159,7 +168,7 @@ private:
         auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
         if (!c)
         {
-            return pugi::xml_node();
+            return {};
         }
 
         return c;
@@ -185,7 +194,7 @@ private:
         auto c = node.find_child(find_element_node{ sz });
         if (!c)
         {
-            return pugi::xml_node();
+            return {};
         }
 
         return c;
@@ -336,7 +345,6 @@ public: // interface IXmlNodeRead
             tExcp::ThrowInvalidPath();
         }
 
-        //auto node = GetChildElementNodeWithAttributes(this->node, tokens[0]);
         auto node = XmlPathSpecifierUtilities<tExcp>::GetChildElementNodeWithAttributes(this->node, tokens[0]);
         if (!node)
         {
@@ -345,7 +353,6 @@ public: // interface IXmlNodeRead
 
         for (size_t i = 1; i < tokens.size(); ++i)
         {
-            //node = GetChildElementNodeWithAttributes(node, tokens[i]);
             node = XmlPathSpecifierUtilities<tExcp>::GetChildElementNodeWithAttributes(node, tokens[i]);
             if (!node)
             {
@@ -370,211 +377,4 @@ public: // interface IXmlNodeRead
             }
         }
     }
-private:
-    /*
-    static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str)
-    {
-        // this matches one or more characters that are not square brackets, followed by an optional group that starts with a '[', 
-        // followed by zero or more of any characters that are not square brackets, and ends with a ']'
-        std::wregex node_name_with_attributes_regex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
-        std::wsmatch pieces_match;
-
-        if (std::regex_match(str, pieces_match, node_name_with_attributes_regex))
-        {
-            if (pieces_match.size() == 4)
-            {
-                if (pieces_match[0].matched == true && pieces_match[1].matched == true)
-                {
-                    const std::wstring nodeName = pieces_match[1];
-                    if (pieces_match[2].matched == false && pieces_match[3].matched == false)
-                    {
-                        // we only got a name ( not followed by [Id=abc] )
-                        return GetChildElementNode(node, nodeName.c_str());
-                    }
-                    else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
-                    {
-                        return GetChildElementWithSpecifier(node, nodeName, pieces_match[3]);
-                    }
-                }
-            }
-        }
-
-        tExcp::ThrowInvalidPath();
-        throw std::logic_error("Must not get here.");
-    }
-
-    static pugi::xml_node GetChildElementWithSpecifier(pugi::xml_node& node, const std::wstring& nodeName, const std::wstring& specifier)
-    {
-        // if the specifier contains only digits, then it is an index - otherwise it is (or has to be) a list of key-value pairs giving attributes
-        const std::wregex regex_contains_only_a_number(L"^\\s*\\d+\\s*$");
-        if (std::regex_match(specifier, regex_contains_only_a_number))
-        {
-            // we then expect the specifier to be a number
-            unsigned long num = 0;
-            try
-            {
-                num = std::stoul(specifier);
-            }
-            catch (const std::exception&)
-            {
-                tExcp::ThrowInvalidPath();
-            }
-
-            if (num > (std::numeric_limits<std::uint32_t>::max)())
-            {
-                tExcp::ThrowInvalidPath();
-            }
-
-            return GetChildElementNodeWithIndex(node, nodeName, static_cast<std::uint32_t>(num));
-        }
-        else
-        {
-            const auto attribValuePairs = ParseAttributes(specifier);
-            return GetChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
-        }
-    }
-
-    /// Gets the n-th child node with name 'node_name' from the specified node. The index is zero-based.
-    /// If this node does not exist, an exception is thrown.
-    /// \param [in]     node        The node (to get the n-th child node).
-    /// \param          node_name   Name of the child node to search for.
-    /// \param          index       Zero-based index of the child node (with the specified name) to search for.
-    /// \returns    The child node with the specified index.
-    static pugi::xml_node GetChildElementNodeWithIndex(pugi::xml_node& node, const std::wstring& node_name, std::uint32_t index)
-    {
-        auto child_node = node.child(node_name.c_str());
-        if (!child_node)
-        {
-            tExcp::ThrowInvalidPath();
-        }
-
-        for (std::uint32_t i = 0; i <= index; ++i)
-        {
-            if (i == index)
-            {
-                return child_node;
-            }
-
-            child_node = child_node.next_sibling(node_name.c_str());
-            if (!child_node)
-            {
-                tExcp::ThrowInvalidPath();
-            }
-        }
-
-        tExcp::ThrowInvalidPath();
-        throw std::logic_error("Must not get here.");
-    }
-
-    static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs)
-    {
-        struct find_element_node_and_attributes
-        {
-            const wchar_t* nodeName;
-            const std::map<std::wstring, std::wstring>& attribs;
-
-            bool operator()(pugi::xml_node node) const
-            {
-                if (node.type() != pugi::xml_node_type::node_element)
-                {
-                    return false;
-                }
-
-                if (wcscmp(node.name(), this->nodeName) != 0)
-                {
-                    return false;
-                }
-
-                for (auto it = this->attribs.cbegin(); it != this->attribs.cend(); ++it)
-                {
-                    auto attribute = node.find_attribute([&](const pugi::xml_attribute& a)
-                        {
-                            return wcscmp(a.name(), it->first.c_str()) == 0;
-                        });
-
-                    if (!attribute)
-                    {
-                        return false;
-                    }
-
-                    if (wcscmp(attribute.value(), it->second.c_str()) != 0)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        };
-
-        auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
-        if (!c)
-        {
-            return pugi::xml_node();
-        }
-
-        return c;
-    }
-
-    static pugi::xml_node GetChildElementNode(pugi::xml_node& node, const wchar_t* sz)
-    {
-        struct find_element_node
-        {
-            const wchar_t* nodeName;
-
-            bool operator()(pugi::xml_node node) const
-            {
-                if (node.type() != pugi::xml_node_type::node_element)
-                {
-                    return false;
-                }
-
-                return wcscmp(node.name(), this->nodeName) == 0;
-            }
-        };
-
-        auto c = node.find_child(find_element_node{ sz });
-        if (!c)
-        {
-            return pugi::xml_node();
-        }
-
-        return c;
-    }
-
-    /// Parse an "attributes definition string" of the form "Id=abc,Name=abc" into a map of name/value pairs.
-    /// \param  str The string to be parsed.
-    /// \returns    A std::map&lt;std::wstring,std::wstring&gt; containing the key-value pairs.
-    static std::map<std::wstring, std::wstring> ParseAttributes(const std::wstring& str)
-    {
-        std::map<std::wstring, std::wstring> attribMap;
-
-        std::wsmatch pieces_match;
-
-        // now we have string of the form Id=abc,Name=abc
-        std::vector<std::wstring> pairs;
-        Utilities::Tokenize(str, pairs, L",;");
-
-        std::wregex attribValuePairRegex(LR"(([^=]+)=([^,;]*))");
-        for (auto it = pairs.cbegin(); it != pairs.cend(); ++it)
-        {
-            bool parsedOk = false;
-            if (std::regex_match(*it, pieces_match, attribValuePairRegex))
-            {
-                if (pieces_match.size() == 3 && pieces_match[0].matched == true && pieces_match[1].matched == true && pieces_match[2].matched == true)
-                {
-                    attribMap.insert(std::pair<std::wstring, std::wstring>(pieces_match[1], pieces_match[2]));
-                    parsedOk = true;
-                }
-            }
-
-            if (!parsedOk)
-            {
-                tExcp::ThrowInvalidPath();
-            }
-        }
-
-        return attribMap;
-    }
-    */
 };

--- a/Src/libCZI/XmlNodeWrapper.h
+++ b/Src/libCZI/XmlNodeWrapper.h
@@ -16,6 +16,217 @@
 #include "pugixml.hpp"
 #include "libCZI_exceptions.h"
 
+template<typename tExcp>
+class XmlPathSpecifierUtilities
+{
+public:
+    static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str)
+    {
+        // this matches one or more characters that are not square brackets, followed by an optional group that starts with a '[', 
+        // followed by zero or more of any characters that are not square brackets, and ends with a ']'
+        std::wregex node_name_with_attributes_regex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
+        std::wsmatch pieces_match;
+
+        if (std::regex_match(str, pieces_match, node_name_with_attributes_regex))
+        {
+            if (pieces_match.size() == 4)
+            {
+                if (pieces_match[0].matched == true && pieces_match[1].matched == true)
+                {
+                    const std::wstring nodeName = pieces_match[1];
+                    if (pieces_match[2].matched == false && pieces_match[3].matched == false)
+                    {
+                        // we only got a name ( not followed by [Id=abc] )
+                        return GetChildElementNode(node, nodeName.c_str());
+                    }
+                    else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
+                    {
+                        return GetChildElementWithSpecifier(node, nodeName, pieces_match[3]);
+                    }
+                }
+            }
+        }
+
+        tExcp::ThrowInvalidPath();
+        throw std::logic_error("Must not get here.");
+    }
+
+private:
+    static pugi::xml_node GetChildElementWithSpecifier(pugi::xml_node& node, const std::wstring& nodeName, const std::wstring& specifier)
+    {
+        // if the specifier contains only digits, then it is an index - otherwise it is (or has to be) a list of key-value pairs giving attributes
+        const std::wregex regex_contains_only_a_number(L"^\\s*\\d+\\s*$");
+        if (std::regex_match(specifier, regex_contains_only_a_number))
+        {
+            // we then expect the specifier to be a number
+            unsigned long num = 0;
+            try
+            {
+                num = std::stoul(specifier);
+            }
+            catch (const std::exception&)
+            {
+                tExcp::ThrowInvalidPath();
+            }
+
+            if (num > (std::numeric_limits<std::uint32_t>::max)())
+            {
+                tExcp::ThrowInvalidPath();
+            }
+
+            return GetChildElementNodeWithIndex(node, nodeName, static_cast<std::uint32_t>(num));
+        }
+        else
+        {
+            const auto attribValuePairs = ParseAttributes(specifier);
+            return GetChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
+        }
+    }
+
+    /// Gets the n-th child node with name 'node_name' from the specified node. The index is zero-based.
+    /// If this node does not exist, an exception is thrown.
+    /// \param [in]     node        The node (to get the n-th child node).
+    /// \param          node_name   Name of the child node to search for.
+    /// \param          index       Zero-based index of the child node (with the specified name) to search for.
+    /// \returns    The child node with the specified index.
+    static pugi::xml_node GetChildElementNodeWithIndex(pugi::xml_node& node, const std::wstring& node_name, std::uint32_t index)
+    {
+        auto child_node = node.child(node_name.c_str());
+        if (!child_node)
+        {
+            tExcp::ThrowInvalidPath();
+        }
+
+        for (std::uint32_t i = 0; i <= index; ++i)
+        {
+            if (i == index)
+            {
+                return child_node;
+            }
+
+            child_node = child_node.next_sibling(node_name.c_str());
+            if (!child_node)
+            {
+                tExcp::ThrowInvalidPath();
+            }
+        }
+
+        tExcp::ThrowInvalidPath();
+        throw std::logic_error("Must not get here.");
+    }
+
+    static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str, const std::map<std::wstring, std::wstring>& attribs)
+    {
+        struct find_element_node_and_attributes
+        {
+            const wchar_t* nodeName;
+            const std::map<std::wstring, std::wstring>& attribs;
+
+            bool operator()(pugi::xml_node node) const
+            {
+                if (node.type() != pugi::xml_node_type::node_element)
+                {
+                    return false;
+                }
+
+                if (wcscmp(node.name(), this->nodeName) != 0)
+                {
+                    return false;
+                }
+
+                for (auto it = this->attribs.cbegin(); it != this->attribs.cend(); ++it)
+                {
+                    auto attribute = node.find_attribute([&](const pugi::xml_attribute& a)
+                        {
+                            return wcscmp(a.name(), it->first.c_str()) == 0;
+                        });
+
+                    if (!attribute)
+                    {
+                        return false;
+                    }
+
+                    if (wcscmp(attribute.value(), it->second.c_str()) != 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        };
+
+        auto c = node.find_child(find_element_node_and_attributes{ str.c_str(), attribs });
+        if (!c)
+        {
+            return pugi::xml_node();
+        }
+
+        return c;
+    }
+
+    static pugi::xml_node GetChildElementNode(pugi::xml_node& node, const wchar_t* sz)
+    {
+        struct find_element_node
+        {
+            const wchar_t* nodeName;
+
+            bool operator()(pugi::xml_node node) const
+            {
+                if (node.type() != pugi::xml_node_type::node_element)
+                {
+                    return false;
+                }
+
+                return wcscmp(node.name(), this->nodeName) == 0;
+            }
+        };
+
+        auto c = node.find_child(find_element_node{ sz });
+        if (!c)
+        {
+            return pugi::xml_node();
+        }
+
+        return c;
+    }
+
+    /// Parse an "attributes definition string" of the form "Id=abc,Name=abc" into a map of name/value pairs.
+    /// \param  str The string to be parsed.
+    /// \returns    A std::map&lt;std::wstring,std::wstring&gt; containing the key-value pairs.
+    static std::map<std::wstring, std::wstring> ParseAttributes(const std::wstring& str)
+    {
+        std::map<std::wstring, std::wstring> attribMap;
+
+        std::wsmatch pieces_match;
+
+        // now we have string of the form Id=abc,Name=abc
+        std::vector<std::wstring> pairs;
+        Utilities::Tokenize(str, pairs, L",;");
+
+        std::wregex attribValuePairRegex(LR"(([^=]+)=([^,;]*))");
+        for (auto it = pairs.cbegin(); it != pairs.cend(); ++it)
+        {
+            bool parsedOk = false;
+            if (std::regex_match(*it, pieces_match, attribValuePairRegex))
+            {
+                if (pieces_match.size() == 3 && pieces_match[0].matched == true && pieces_match[1].matched == true && pieces_match[2].matched == true)
+                {
+                    attribMap.insert(std::pair<std::wstring, std::wstring>(pieces_match[1], pieces_match[2]));
+                    parsedOk = true;
+                }
+            }
+
+            if (!parsedOk)
+            {
+                tExcp::ThrowInvalidPath();
+            }
+        }
+
+        return attribMap;
+    }
+};
+
 /// This implements a wrapper around a pugi-node struct (implementing the IXmlNodeRead-interface). It is initialized
 /// with a raw pointer (to the pugi-xml-node-structure), and we rely on that pointer being valid for the lifetime
 /// of this object. In order to achieve this, we take another shared_ptr and keep a reference to it, and this
@@ -119,12 +330,14 @@ public: // interface IXmlNodeRead
             tExcp::ThrowInvalidPath();
         }
 
+        // if any of the tokens is empty, then we have a path like "/a//b", which is invalid
         if (any_of(tokens.cbegin(), tokens.cend(), [](const std::wstring& str) {return str.empty(); }))
         {
             tExcp::ThrowInvalidPath();
         }
 
-        auto node = GetChildElementNodeWithAttributes(this->node, tokens[0]);
+        //auto node = GetChildElementNodeWithAttributes(this->node, tokens[0]);
+        auto node = XmlPathSpecifierUtilities<tExcp>::GetChildElementNodeWithAttributes(this->node, tokens[0]);
         if (!node)
         {
             return nullptr;
@@ -132,7 +345,8 @@ public: // interface IXmlNodeRead
 
         for (size_t i = 1; i < tokens.size(); ++i)
         {
-            node = GetChildElementNodeWithAttributes(node, tokens[i]);
+            //node = GetChildElementNodeWithAttributes(node, tokens[i]);
+            node = XmlPathSpecifierUtilities<tExcp>::GetChildElementNodeWithAttributes(node, tokens[i]);
             if (!node)
             {
                 return nullptr;
@@ -142,7 +356,7 @@ public: // interface IXmlNodeRead
         return std::make_shared<XmlNodeWrapperReadonly>(parentRef, node.internal_object());
     }
 
-    void EnumChildren(std::function<bool(std::shared_ptr<IXmlNodeRead>)> enumChildren, std::shared_ptr<t> parentRef)
+    void EnumChildren(const std::function<bool(std::shared_ptr<IXmlNodeRead>)>& enumChildren, std::shared_ptr<t> parentRef)
     {
         for (pugi::xml_node childNode = this->node.first_child(); childNode; childNode = childNode.next_sibling())
         {
@@ -157,12 +371,15 @@ public: // interface IXmlNodeRead
         }
     }
 private:
+    /*
     static pugi::xml_node GetChildElementNodeWithAttributes(pugi::xml_node& node, const std::wstring& str)
     {
-        std::wregex nodenameWihtAttribregex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
+        // this matches one or more characters that are not square brackets, followed by an optional group that starts with a '[', 
+        // followed by zero or more of any characters that are not square brackets, and ends with a ']'
+        std::wregex node_name_with_attributes_regex(LR"(([^\[\]]+)(\[([^\[\]]*)\])?)");
         std::wsmatch pieces_match;
 
-        if (std::regex_match(str, pieces_match, nodenameWihtAttribregex))
+        if (std::regex_match(str, pieces_match, node_name_with_attributes_regex))
         {
             if (pieces_match.size() == 4)
             {
@@ -176,10 +393,72 @@ private:
                     }
                     else if (pieces_match[2].matched == true && pieces_match[3].matched == true)
                     {
-                        const auto attribValuePairs = ParseAttributes(pieces_match[3]);
-                        return GetChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
+                        return GetChildElementWithSpecifier(node, nodeName, pieces_match[3]);
                     }
                 }
+            }
+        }
+
+        tExcp::ThrowInvalidPath();
+        throw std::logic_error("Must not get here.");
+    }
+
+    static pugi::xml_node GetChildElementWithSpecifier(pugi::xml_node& node, const std::wstring& nodeName, const std::wstring& specifier)
+    {
+        // if the specifier contains only digits, then it is an index - otherwise it is (or has to be) a list of key-value pairs giving attributes
+        const std::wregex regex_contains_only_a_number(L"^\\s*\\d+\\s*$");
+        if (std::regex_match(specifier, regex_contains_only_a_number))
+        {
+            // we then expect the specifier to be a number
+            unsigned long num = 0;
+            try
+            {
+                num = std::stoul(specifier);
+            }
+            catch (const std::exception&)
+            {
+                tExcp::ThrowInvalidPath();
+            }
+
+            if (num > (std::numeric_limits<std::uint32_t>::max)())
+            {
+                tExcp::ThrowInvalidPath();
+            }
+
+            return GetChildElementNodeWithIndex(node, nodeName, static_cast<std::uint32_t>(num));
+        }
+        else
+        {
+            const auto attribValuePairs = ParseAttributes(specifier);
+            return GetChildElementNodeWithAttributes(node, nodeName, attribValuePairs);
+        }
+    }
+
+    /// Gets the n-th child node with name 'node_name' from the specified node. The index is zero-based.
+    /// If this node does not exist, an exception is thrown.
+    /// \param [in]     node        The node (to get the n-th child node).
+    /// \param          node_name   Name of the child node to search for.
+    /// \param          index       Zero-based index of the child node (with the specified name) to search for.
+    /// \returns    The child node with the specified index.
+    static pugi::xml_node GetChildElementNodeWithIndex(pugi::xml_node& node, const std::wstring& node_name, std::uint32_t index)
+    {
+        auto child_node = node.child(node_name.c_str());
+        if (!child_node)
+        {
+            tExcp::ThrowInvalidPath();
+        }
+
+        for (std::uint32_t i = 0; i <= index; ++i)
+        {
+            if (i == index)
+            {
+                return child_node;
+            }
+
+            child_node = child_node.next_sibling(node_name.c_str());
+            if (!child_node)
+            {
+                tExcp::ThrowInvalidPath();
             }
         }
 
@@ -263,6 +542,9 @@ private:
         return c;
     }
 
+    /// Parse an "attributes definition string" of the form "Id=abc,Name=abc" into a map of name/value pairs.
+    /// \param  str The string to be parsed.
+    /// \returns    A std::map&lt;std::wstring,std::wstring&gt; containing the key-value pairs.
     static std::map<std::wstring, std::wstring> ParseAttributes(const std::wstring& str)
     {
         std::map<std::wstring, std::wstring> attribMap;
@@ -294,4 +576,5 @@ private:
 
         return attribMap;
     }
+    */
 };

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -787,7 +787,7 @@ namespace libCZI
         /// Gets a child node for the specified path/attribute specification if it
         /// exists. Otherwise, a nullptr is returned. 
         /// The path is specified as node-names separated by slashes.
-        /// At path "A/B/C" selects (or creates) a node-structure like this
+        /// At path "A/B/C" selects a node-structure like this
         /// \code{.unparsed}
         /// <A>
         ///   <B>
@@ -805,6 +805,19 @@ namespace libCZI
         ///   </B>
         /// </A>
         /// \endcode
+        /// It is also possible to specify a number inside the square brackets, which indicates that the
+        /// n-th element is to be selected. This index is zero-based.
+        /// In this example     
+        /// \code{.unparsed}
+        /// <A>
+        ///   <B Id="ab" Name="xy">
+        ///     <C Id="first"></C>
+        ///     <C Id="second"></C>
+        ///     <C Id="third"></C>
+        ///   </B>
+        /// </A>
+        /// \endcode
+        /// the path "A/B/C[1]" will select the second node of name 'C'.        
         /// \param path The path  (in UTF8-encoding).
         /// \return Either the requested node if it exists or nullptr.
         virtual std::shared_ptr<IXmlNodeRead> GetChildNodeReadonly(const char* path) = 0;
@@ -850,7 +863,7 @@ namespace libCZI
         /// \returns True if it succeeds, false if it fails.
         bool TryGetValueAsBool(bool* p);
 
-        virtual ~IXmlNodeRead() {}
+        virtual ~IXmlNodeRead() = default;
     };
 
     /// Representation of the CZI-metadata.
@@ -874,7 +887,7 @@ namespace libCZI
         /// \return The "document information".
         virtual std::shared_ptr<libCZI::ICziMultiDimensionDocumentInfo> GetDocumentInfo() = 0;
 
-        virtual ~ICziMetadata() {}
+        virtual ~ICziMetadata() = default;
     };
 
     class IXmlNodeRw;
@@ -925,6 +938,19 @@ namespace libCZI
         ///   </B>
         /// </A>
         /// \endcode
+        /// It is also possible to specify a number inside the square brackets, which indicates that the
+        /// n-th element is to be selected. This index is zero-based.
+        /// In this example
+        /// \code{.unparsed}
+        /// <A>
+        ///   <B Id="ab" Name="xy">
+        ///     <C Id="first"></C>
+        ///     <C Id="second"></C>
+        ///     <C Id="third"></C>
+        ///   </B>
+        /// </A>
+        /// \endcode
+        /// the path "A/B/C[1]" will select the second node of name 'C'.
         /// \param path The path (in UTF8-encoding).
         /// \return The existing node conforming to the path if it exists, null otherwise.
         virtual std::shared_ptr<IXmlNodeRw> GetChildNode(const char* path) = 0;

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -1065,7 +1065,7 @@ namespace libCZI
         /// \return The metadata (UTF8-encoded XML).
         virtual std::string GetXml(bool withIndent = false) = 0;
 
-        virtual ~ICziMetadataBuilder() {}
+        virtual ~ICziMetadataBuilder() = default;
     };
 
     /// Variant for CustomValue.

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -787,7 +787,7 @@ namespace libCZI
         /// Gets a child node for the specified path/attribute specification if it
         /// exists. Otherwise, a nullptr is returned. 
         /// The path is specified as node-names separated by slashes.
-        /// At path "A/B/C" selects a node-structure like this
+        /// A path "A/B/C" selects a node-structure like this
         /// \code{.unparsed}
         /// <A>
         ///   <B>
@@ -897,7 +897,7 @@ namespace libCZI
     {
     public:
         /// Gets or create a child node. The path is specified as node-names separated by slashes.
-        /// At path "A/B/C" selects (or creates) a node-structure like this
+        /// A path "A/B/C" selects (or creates) a node-structure like this
         /// \code{.unparsed}
         /// <A>
         ///   <B>
@@ -920,7 +920,7 @@ namespace libCZI
         virtual std::shared_ptr<IXmlNodeRw> GetOrCreateChildNode(const char* path) = 0;
 
         /// Gets an existing child node. The path is specified as node-names separated by slashes.
-        /// At path "A/B/C" selects (or creates) a node-structure like this
+        /// A path "A/B/C" selects (or creates) a node-structure like this
         /// \code{.unparsed}
         /// <A>
         ///   <B>

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -743,7 +743,7 @@ namespace libCZI
         /// \return The display settings object.
         virtual std::shared_ptr<IDisplaySettings> GetDisplaySettings() const = 0;
 
-        virtual ~ICziMultiDimensionDocumentInfo() {}
+        virtual ~ICziMultiDimensionDocumentInfo() = default;
 
         /// Gets a vector with all dimensions (found in metadata).
         /// \return The vector containing all dimensions.

--- a/Src/libCZI/libCZI_Metadata.h
+++ b/Src/libCZI/libCZI_Metadata.h
@@ -583,7 +583,7 @@ namespace libCZI
         /// \param [out] gamma If non-null and applicable, the gamma will be returned.
         ///
         /// \return True if the corresponding channel uses gradation curve mode <tt>Gamma</tt> (and a value for gamma is available), false otherwise.
-        virtual bool    TryGetGamma(float* gamma)const = 0;
+        virtual bool    TryGetGamma(float* gamma) const = 0;
 
         /// Attempts to get spline control points - this will only be available if gradation curve mode is <tt>Spline</tt>.
         /// \remark

--- a/Src/libCZI_UnitTests/test_DisplaySettings.cpp
+++ b/Src/libCZI_UnitTests/test_DisplaySettings.cpp
@@ -196,7 +196,7 @@ TEST(DisplaySettings, WriteDisplaySettingsToDocumentAndReadFromThereAndCompare)
     EXPECT_NEAR(white_point_from_document, 0.4f, 1e-8f);
 }
 
-TEST(DisplaySettings, WriteDisplaySettingsWithGradionCurveGammaAndSplineToDocumentAndReadFromThereAndCompare)
+TEST(DisplaySettings, WriteDisplaySettingsWithGradationCurveGammaAndSplineToDocumentAndReadFromThereAndCompare)
 {
     // what happens here:
     // - we are creating a simple 2-channel-CZI-document, add two subblocks 

--- a/Src/libCZI_UnitTests/test_metadatabuilder.cpp
+++ b/Src/libCZI_UnitTests/test_metadatabuilder.cpp
@@ -300,7 +300,7 @@ TEST(MetadataBuilder, MetadataUtils3)
                 return offsets[i];
             }
 
-    return std::numeric_limits<double>::quiet_NaN();
+            return std::numeric_limits<double>::quiet_NaN();
         });
 
     auto xml = mdBldr->GetXml(true);
@@ -466,8 +466,8 @@ TEST(MetadataBuilder, MetadataUtils7)
                 wasOk = true;
             }
 
-    callCnt++;
-    return true;
+            callCnt++;
+            return true;
         });
 
     EXPECT_TRUE(wasOk && callCnt == 1) << "Incorrect result";
@@ -849,4 +849,62 @@ TEST(MetadataBuilder, RemoveAttribute)
         u8"  </Metadata>\n"
         u8"</ImageDocument>\n";
     EXPECT_STREQ(expected_result2, xml.c_str()) << "Incorrect result";
+}
+
+TEST(MetadataBuilder, WriteDisplaySettingsWithTintingModeNoneAndCheckResult)
+{
+    // set tinting mode to none and expect to find <ColorMode>None</ColorMode> in the xml
+    const auto metadata_builder = libCZI::CreateMetadataBuilder();
+
+    DisplaySettingsPOD display_settings;
+    ChannelDisplaySettingsPOD channel_display_settings;
+    channel_display_settings.Clear();
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::None;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    display_settings.channelDisplaySettings[0] = channel_display_settings;  // set the channel-display-settings for channel 0
+
+    MetadataUtils::WriteDisplaySettings(metadata_builder.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 1);
+
+    auto xml = metadata_builder->GetXml(true);
+
+    const auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/ColorMode");
+    ASSERT_TRUE(node != nullptr);
+    wstring color_mode_element;
+    EXPECT_TRUE(node->TryGetValue(&color_mode_element));
+    EXPECT_STREQ(L"None", color_mode_element.c_str()) << "Incorrect result";
+}
+
+TEST(MetadataBuilder, WriteDisplaySettingsWithTintingModeColorAndCheckResult)
+{
+    // set tinting mode to "color" and expect to find <ColorMode>Color</ColorMode> in the xml (and the specified color)
+    const auto metadata_builder = libCZI::CreateMetadataBuilder();
+
+    DisplaySettingsPOD display_settings;
+    ChannelDisplaySettingsPOD channel_display_settings;
+    channel_display_settings.Clear();
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::Color;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    display_settings.channelDisplaySettings[0] = channel_display_settings;  // set the channel-display-settings for channel 0
+
+    MetadataUtils::WriteDisplaySettings(metadata_builder.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 1);
+
+    auto xml = metadata_builder->GetXml(true);
+
+    auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/ColorMode");
+    ASSERT_TRUE(node != nullptr);
+    wstring color_mode_element;
+    EXPECT_TRUE(node->TryGetValue(&color_mode_element));
+    EXPECT_STREQ(L"Color", color_mode_element.c_str()) << "Incorrect result";
+
+    node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/Color");
+    ASSERT_TRUE(node != nullptr);
+    wstring color_element;
+    EXPECT_TRUE(node->TryGetValue(&color_element));
+    EXPECT_STREQ(L"#FFFF0000", color_element.c_str()) << "Incorrect result";
 }

--- a/Src/libCZI_UnitTests/test_metadatabuilder.cpp
+++ b/Src/libCZI_UnitTests/test_metadatabuilder.cpp
@@ -870,7 +870,7 @@ TEST(MetadataBuilder, WriteDisplaySettingsWithTintingModeNoneAndCheckResult)
 
     auto xml = metadata_builder->GetXml(true);
 
-    const auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/ColorMode");
+    const auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[0]/ColorMode");
     ASSERT_TRUE(node != nullptr);
     wstring color_mode_element;
     EXPECT_TRUE(node->TryGetValue(&color_mode_element));
@@ -896,15 +896,58 @@ TEST(MetadataBuilder, WriteDisplaySettingsWithTintingModeColorAndCheckResult)
 
     auto xml = metadata_builder->GetXml(true);
 
-    auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/ColorMode");
+    auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[0]/ColorMode");
     ASSERT_TRUE(node != nullptr);
     wstring color_mode_element;
     EXPECT_TRUE(node->TryGetValue(&color_mode_element));
     EXPECT_STREQ(L"Color", color_mode_element.c_str()) << "Incorrect result";
 
-    node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel/Color");
+    node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[0]/Color");
     ASSERT_TRUE(node != nullptr);
     wstring color_element;
     EXPECT_TRUE(node->TryGetValue(&color_element));
     EXPECT_STREQ(L"#FFFF0000", color_element.c_str()) << "Incorrect result";
+}
+
+TEST(MetadataBuilder, WriteDisplaySettingsForTwoChannelsWithDifferentTintingModesAndCheckResult)
+{
+    // set tinting mode to "color" and expect to find <ColorMode>Color</ColorMode> in the xml (and the specified color)
+    const auto metadata_builder = libCZI::CreateMetadataBuilder();
+
+    DisplaySettingsPOD display_settings;
+    ChannelDisplaySettingsPOD channel_display_settings;
+    channel_display_settings.Clear();
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::Color;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    display_settings.channelDisplaySettings[0] = channel_display_settings;  // set the channel-display-settings for channel 0
+    channel_display_settings.isEnabled = true;
+    channel_display_settings.tintingMode = IDisplaySettings::TintingMode::None;
+    channel_display_settings.tintingColor = Rgb8Color{ 0xff,0,0 };
+    channel_display_settings.blackPoint = 0.3f;
+    channel_display_settings.whitePoint = 0.8f;
+    display_settings.channelDisplaySettings[1] = channel_display_settings;  // set the channel-display-settings for channel 1
+    
+    MetadataUtils::WriteDisplaySettings(metadata_builder.get(), DisplaySettingsPOD::CreateIDisplaySettingSp(display_settings).get(), 2);
+
+    auto xml = metadata_builder->GetXml(true);
+
+    auto node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[0]/ColorMode");
+    ASSERT_TRUE(node != nullptr);
+    wstring color_mode_element;
+    EXPECT_TRUE(node->TryGetValue(&color_mode_element));
+    EXPECT_STREQ(L"Color", color_mode_element.c_str()) << "Incorrect result";
+
+    node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[0]/Color");
+    ASSERT_TRUE(node != nullptr);
+    wstring color_element;
+    EXPECT_TRUE(node->TryGetValue(&color_element));
+    EXPECT_STREQ(L"#FFFF0000", color_element.c_str()) << "Incorrect result";
+
+    node = metadata_builder->GetRootNode()->GetChildNodeReadonly("Metadata/DisplaySetting/Channels/Channel[1]/ColorMode");
+    ASSERT_TRUE(node != nullptr);
+    EXPECT_TRUE(node->TryGetValue(&color_mode_element));
+    EXPECT_STREQ(L"None", color_mode_element.c_str()) << "Incorrect result";
 }

--- a/Src/libCZI_UnitTests/test_metadatareading.cpp
+++ b/Src/libCZI_UnitTests/test_metadatareading.cpp
@@ -663,3 +663,75 @@ TEST(MetadataReading, DimensionInfoAtrribute1Test)
     ASSERT_TRUE(b);
     EXPECT_EQ(id.compare(L"Channel:1"), 0);
 }
+
+TEST(MetadataReading, AccessNodeWithIndexTest)
+{
+    auto mockMdSegment = make_shared<MockMetadataSegment>();
+    auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
+
+    EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
+
+    auto node = md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[0]");
+    ASSERT_TRUE(node);
+    wstring id;
+    wstring name;
+    EXPECT_TRUE(node->TryGetAttribute(L"Id", &id));
+    EXPECT_TRUE(node->TryGetAttribute(L"Name", &name));
+    EXPECT_EQ(id.compare(L"Channel:1"), 0);
+    EXPECT_EQ(name.compare(L"DAPI"), 0);
+
+    node = md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[1]");
+    ASSERT_TRUE(node);
+    EXPECT_TRUE(node->TryGetAttribute(L"Id", &id));
+    EXPECT_TRUE(node->TryGetAttribute(L"Name", &name));
+    EXPECT_EQ(id.compare(L"Channel:2"), 0);
+    EXPECT_EQ(name.compare(L"QD655"), 0);
+
+    node = md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[2]");
+    ASSERT_TRUE(node);
+    EXPECT_TRUE(node->TryGetAttribute(L"Id", &id));
+    EXPECT_TRUE(node->TryGetAttribute(L"Name", &name));
+    EXPECT_EQ(id.compare(L"Channel:3"), 0);
+    EXPECT_EQ(name.compare(L"QD605"), 0);
+
+    node = md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[3]");
+    ASSERT_TRUE(node);
+    EXPECT_TRUE(node->TryGetAttribute(L"Id", &id));
+    EXPECT_TRUE(node->TryGetAttribute(L"Name", &name));
+    EXPECT_EQ(id.compare(L"Channel:4"), 0);
+    EXPECT_EQ(name.compare(L"QD705"), 0);
+
+    node = md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[4]");
+    ASSERT_TRUE(node);
+    EXPECT_TRUE(node->TryGetAttribute(L"Id", &id));
+    EXPECT_TRUE(node->TryGetAttribute(L"Name", &name));
+    EXPECT_EQ(id.compare(L"Channel:5"), 0);
+    EXPECT_EQ(name.compare(L"QD565"), 0);
+}
+
+TEST(MetadataReading, AccessNodeWithInvalidIndexAndExpectExceptionTest)
+{
+    auto mockMdSegment = make_shared<MockMetadataSegment>();
+    auto md = CreateMetaFromMetadataSegment(mockMdSegment.get());
+
+    EXPECT_TRUE(md->IsXmlValid()) << "Expected valid XML.";
+
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[5]"),
+        libCZI::LibCZIMetadataException);
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[4958123987]"),
+        libCZI::LibCZIMetadataException);
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[495812394234234587]"),
+        libCZI::LibCZIMetadataException);
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[2 3]"),
+        libCZI::LibCZIMetadataException);
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[+3]"),
+        libCZI::LibCZIMetadataException);
+    EXPECT_THROW(
+        md->GetChildNodeReadonly("ImageDocument/Metadata/DisplaySetting/Channels/Channel[-3]"),
+        libCZI::LibCZIMetadataException);
+}


### PR DESCRIPTION
## Description

When serializing display-settings to CZI-XML, it was found that we better write the element "ColorMode", which explicitly states whether "tinting-mode" is to be used or not.
While at it, I did also some cosmetic and refactoring, and added a feature for the IXmlNodeRead::GetChildNodeReadonly-function: ability to select a specific node by index.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
