### PR TITLE
Fix copy function. Add conversion methods for copy function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.48.2
+      VERSION 0.49.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/BitmapOperations.cpp
+++ b/Src/libCZI/BitmapOperations.cpp
@@ -89,13 +89,21 @@ using namespace std;
     case PixelType::Gray16:
         switch (dstPixelType)
         {
-        case PixelType::Gray8:break;
+        case PixelType::Gray8:
+            Copy<PixelType::Gray16, PixelType::Gray8>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
         case PixelType::Gray16:
             Copy<PixelType::Gray16, PixelType::Gray16>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
             return;
-        case PixelType::Gray32Float:break;
-        case PixelType::Bgr24:break;
-        case PixelType::Bgr48:break;
+        case PixelType::Gray32Float:
+            Copy<PixelType::Gray16, PixelType::Gray32Float>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
+        case PixelType::Bgr24:
+            Copy<PixelType::Gray16, PixelType::Bgr24>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
+        case PixelType::Bgr48:
+            Copy<PixelType::Gray16, PixelType::Bgr48>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
         default:break;
         }
         break;
@@ -139,10 +147,18 @@ using namespace std;
     case PixelType::Bgr48:
         switch (dstPixelType)
         {
-        case PixelType::Gray8:break;
-        case PixelType::Gray16:break;
-        case PixelType::Gray32Float:break;
-        case PixelType::Bgr24:break;
+        case PixelType::Gray8:
+            Copy<PixelType::Bgr48, PixelType::Gray8>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
+        case PixelType::Gray16:
+            Copy<PixelType::Bgr48, PixelType::Gray16>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
+        case PixelType::Gray32Float:
+            Copy<PixelType::Bgr48, PixelType::Gray32Float>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
+        case PixelType::Bgr24:
+            Copy<PixelType::Bgr48, PixelType::Bgr24>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+            return;
         case PixelType::Bgr48:
             Copy<PixelType::Bgr48, PixelType::Bgr48>(srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
             return;

--- a/Src/libCZI/BitmapOperations.hpp
+++ b/Src/libCZI/BitmapOperations.hpp
@@ -363,6 +363,46 @@ inline void CBitmapOperations::Copy<libCZI::PixelType::Bgr24, libCZI::PixelType:
 {
     Copy<libCZI::PixelType::Bgr24, libCZI::PixelType::Bgr48, CConvBgr24ToBgr48>(CConvBgr24ToBgr48(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
 }
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Gray8>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Gray8, CConvGray16ToGray8>(CConvGray16ToGray8(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Gray32Float>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Gray32Float, CConvGray16ToGray32Float>(CConvGray16ToGray32Float(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Bgr24>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Bgr24, CConvGray16ToBgr24>(CConvGray16ToBgr24(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Bgr48>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Gray16, libCZI::PixelType::Bgr48, CConvGray16ToBgr48>(CConvGray16ToBgr48(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray8>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray8, CConvBgr48ToGray8>(CConvBgr48ToGray8(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray16>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray16, CConvBgr48ToGray16>(CConvBgr48ToGray16(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray32Float>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Gray32Float, CConvBgr48ToGray32Float>(CConvBgr48ToGray32Float(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
+template <>
+inline void CBitmapOperations::Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Bgr24>(const void* srcPtr, int srcStride, void* dstPtr, int dstStride, int width, int height, bool drawTileBorder)
+{
+    Copy<libCZI::PixelType::Bgr48, libCZI::PixelType::Bgr24, CConvBgr48ToBgr24>(CConvBgr48ToBgr24(), srcPtr, srcStride, dstPtr, dstStride, width, height, drawTileBorder);
+}
 
 //------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
# STOP - Read this First!
Reporting a security vulnerability?  
Check out the project's [security policy](https://github.com/zeiss/libczi/security/policy).

# Fill out and Adjust this Template

## Description
For a zoom level of 1, the current implementation of SingleChannelScalingTileAccessor does not respect the provided ROI and copies the top left corner of an image instead of the provided ROI. Furthermore, for zoom=1.0, there are missing pixel type conversions that are only available for zoom!=1.0.
This PR introduces copying logic for zoom=1.0 that respects the provided ROI and adds the missing conversion functions.

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The unit tests pf pylibCZIrw fail in most cases due to the wrong RIO being copied. The introduced changes fix the test cases in pylibCZIrw.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
