### PR TITLE
Remove succeed-for-cla

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,11 +24,3 @@ jobs:
         run: |
           echo "cla label missing. See CONTRIBUTING.md."
           exit 1
-  succeed-for-cla:
-    if: ${{contains(github.event.pull_request.labels.*.name, 'cla')}}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Succeed for present cla label
-        run: |
-          echo "cla label present. See CONTRIBUTING.md."
-          exit 0


### PR DESCRIPTION
## Description

Simplify CLA Check

It turned out that skipped checks are treated as passing. 

![image](https://github.com/ZEISS/libczi/assets/9250590/dd399b4d-a06d-4d04-a4a1-1e4dd37d8b1a)

Depending on your use case, this can also be seen as undesired behaviour - e.g. in https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt. However, in our scenario, it is as intended and therefore perfectly enough.

This change is complemented by removing the succeed-for-cla status check from the branch protection rule.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

PR Experience

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
