### PR TITLE
bytes-per-pel for pixeltype "Bgr192ComplexFloat" is 24 (not 48)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.50.0
+      VERSION 0.50.1
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CziUtils.cpp
+++ b/Src/libCZI/CziUtils.cpp
@@ -52,9 +52,9 @@ using namespace libCZI;
 {
     switch (i)
     {
-    case 0:  return CompressionMode::UnCompressed;
-    case 1:  return CompressionMode::Jpg;
-    case 4:  return CompressionMode::JpgXr;
+    case 0: return CompressionMode::UnCompressed;
+    case 1: return CompressionMode::Jpg;
+    case 4: return CompressionMode::JpgXr;
     case 5: return CompressionMode::Zstd0;
     case 6: return CompressionMode::Zstd1;
     default: return CompressionMode::Invalid;
@@ -92,7 +92,7 @@ using namespace libCZI;
     case PixelType::Bgr96Float:         return 12;
     case PixelType::Bgra32:             return 4;
     case PixelType::Gray64ComplexFloat: return 16;
-    case PixelType::Bgr192ComplexFloat: return 48;
+    case PixelType::Bgr192ComplexFloat: return 24;
     case PixelType::Gray32:             return 4;
     case PixelType::Gray64Float:        return 8;
     default: throw std::invalid_argument("illegal pixeltype");

--- a/Src/libCZI/CziUtils.h
+++ b/Src/libCZI/CziUtils.h
@@ -45,4 +45,4 @@ template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Bgra
 template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Gray32>() { return 4; }
 template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Bgr96Float>() { return 3 * 4; }
 template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Gray64ComplexFloat>() { return 2 * 8; }
-template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Bgr192ComplexFloat>() { return 48; }
+template <> constexpr std::uint8_t CziUtils::BytesPerPel<libCZI::PixelType::Bgr192ComplexFloat>() { return 24; }


### PR DESCRIPTION
## Description

The pixeltype "Bgr192ComplexFloat" has 24 bytes-per-pel (2 times 3 floats = 2*3*4 = 24), not 48.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally (with a document containing such a pixeltype)

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
