### PR TITLE
Jbl/lax parsing special case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.51.0
+      VERSION 0.51.1
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -24,9 +24,12 @@ static CCZIParse::SubblockDirectoryParseOptions GetParseOptionsFromOpenOptions(c
     }
     else
     {
-        parse_options.SetDimensionXyMustBePresent(true);
-        parse_options.SetDimensionOtherThanMMustHaveSizeOne(true);
-        parse_options.SetDimensionMMustHaveSizeOne(options.ignore_sizem_for_pyramid_subblocks);
+        parse_options.SetStrictParsing();
+        if (options.ignore_sizem_for_pyramid_subblocks)
+        {
+            parse_options.SetDimensionOtherThanMMustHaveSizeOne(false);
+            parse_options.SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(true);
+        }
     }
 }
 

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -23,7 +23,8 @@ static CCZIParse::SubblockDirectoryParseOptions GetParseOptionsFromOpenOptions(c
         parse_options.SetStrictParsing();
         if (options.ignore_sizem_for_pyramid_subblocks)
         {
-            parse_options.SetDimensionOtherThanMMustHaveSizeOne(false);
+            // in this case we require only that non-pyramid-subblocks have a SizeM=1
+            parse_options.SetDimensionMMustHaveSizeOne(false);
             parse_options.SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(true);
         }
     }

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -18,11 +18,7 @@ using namespace libCZI;
 static CCZIParse::SubblockDirectoryParseOptions GetParseOptionsFromOpenOptions(const ICZIReader::OpenOptions& options)
 {
     CCZIParse::SubblockDirectoryParseOptions parse_options;
-    if (options.lax_subblock_coordinate_checks == true)
-    {
-        return parse_options;
-    }
-    else
+    if (options.lax_subblock_coordinate_checks == false)
     {
         parse_options.SetStrictParsing();
         if (options.ignore_sizem_for_pyramid_subblocks)
@@ -31,6 +27,8 @@ static CCZIParse::SubblockDirectoryParseOptions GetParseOptionsFromOpenOptions(c
             parse_options.SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(true);
         }
     }
+
+    return parse_options;
 }
 
 CCZIReader::CCZIReader() : isOperational(false)

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -6,7 +6,7 @@
 #include "libCZI.h"
 #include "CziParse.h"
 #include "CziStructs.h"
-#include <assert.h>
+#include <cassert>
 #include <cstddef>
 #include "Site.h"
 
@@ -32,7 +32,7 @@ using namespace libCZI;
     }
     catch (const std::exception&)
     {
-        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", 0, sizeof(fileHeaderSegment)));
+        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", 0, sizeof(fileHeaderSegment)));
     }
 
     if (bytesRead != sizeof(fileHeaderSegment))
@@ -75,7 +75,7 @@ using namespace libCZI;
     }
     catch (const std::exception&)
     {
-        std::throw_with_nested(LibCZIIOException("Error reading SubBlkDirectorySegement", offset, sizeof(subBlckDirSegment)));
+        std::throw_with_nested(LibCZIIOException("Error reading SubBlkDirectorySegment", offset, sizeof(subBlckDirSegment)));
     }
 
     if (bytesRead != sizeof(subBlckDirSegment))
@@ -121,7 +121,7 @@ using namespace libCZI;
     }
     catch (const std::exception&)
     {
-        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegement", offset + sizeof(subBlckDirSegment), subBlkDirSize));
+        std::throw_with_nested(LibCZIIOException("Error reading FileHeaderSegment", offset + sizeof(subBlckDirSegment), subBlkDirSize));
     }
 
     if (bytesRead != subBlkDirSize)
@@ -365,7 +365,7 @@ using namespace libCZI;
     // TODO: if subBlckSegment.data.DataSize > size_t (=4GB for 32Bit) then bail out gracefully
     auto deleter = [&](void* ptr) -> void {allocateInfo.free(ptr); };
     std::unique_ptr<void, decltype(deleter)> pMetadataBuffer(subBlckSegment.data.MetadataSize > 0 ? allocateInfo.alloc(subBlckSegment.data.MetadataSize) : nullptr, deleter);
-    std::unique_ptr<void, decltype(deleter)> pDataBuffer(subBlckSegment.data.DataSize > 0 ? allocateInfo.alloc((size_t)subBlckSegment.data.DataSize) : nullptr, deleter);
+    std::unique_ptr<void, decltype(deleter)> pDataBuffer(subBlckSegment.data.DataSize > 0 ? allocateInfo.alloc(static_cast<size_t>(subBlckSegment.data.DataSize)) : nullptr, deleter);
     std::unique_ptr<void, decltype(deleter)> pAttachmentBuffer(subBlckSegment.data.AttachmentSize > 0 ? allocateInfo.alloc(subBlckSegment.data.AttachmentSize) : nullptr, deleter);
 
     // TODO: now get the information from the SubBlockDirectoryEntryDV/DE structure, and figure out their size
@@ -457,7 +457,7 @@ using namespace libCZI;
 
     // TODO: if subBlckSegment.data.DataSize > size_t (=4GB for 32Bit) then bail out gracefully
     auto deleter = [&](void* ptr) -> void {allocateInfo.free(ptr); };
-    std::unique_ptr<void, decltype(deleter)> pAttchmntBuffer(attchmntSegment.data.DataSize > 0 ? allocateInfo.alloc((size_t)attchmntSegment.data.DataSize) : nullptr, deleter);
+    std::unique_ptr<void, decltype(deleter)> pAttchmntBuffer(attchmntSegment.data.DataSize > 0 ? allocateInfo.alloc(static_cast<size_t>(attchmntSegment.data.DataSize)) : nullptr, deleter);
 
     if (pAttchmntBuffer)
     {
@@ -648,7 +648,7 @@ using namespace libCZI;
     // TODO: perform consistency checks...
     auto deleter = [&](void* ptr) -> void {allocateInfo.free(ptr); };
     std::unique_ptr<void, decltype(deleter)> pXmlBuffer(metadataSegment.data.XmlSize > 0 ? allocateInfo.alloc(metadataSegment.data.XmlSize) : nullptr, deleter);
-    std::unique_ptr<void, decltype(deleter)> pAttachmentBuffer(metadataSegment.data.AttachmentSize > 0 ? allocateInfo.alloc((size_t)metadataSegment.data.AttachmentSize) : nullptr, deleter);
+    std::unique_ptr<void, decltype(deleter)> pAttachmentBuffer(metadataSegment.data.AttachmentSize > 0 ? allocateInfo.alloc(static_cast<size_t>(metadataSegment.data.AttachmentSize)) : nullptr, deleter);
     if (pXmlBuffer)
     {
         try

--- a/Src/libCZI/CziParse.h
+++ b/Src/libCZI/CziParse.h
@@ -36,7 +36,7 @@ public:
             kDimensionMMustHaveSizeOneExceptForPyramidSubblocks,
             kDimensionMMustHaveSizeOne,
 
-            kParseFlagsCount
+            kParseFlagsCount    ///< The number of flags - this is not a flag itself, and it must be the last entry in the enum.
         };
         std::bitset<static_cast<std::underlying_type<ParseFlags>::type>(ParseFlags::kParseFlagsCount)> flags;
     public:
@@ -60,16 +60,36 @@ public:
         /// \param  enable  True to enable, false to disable.
         void SetDimensionMMustHaveSizeOne(bool enable) { return this->SetFlag(ParseFlags::kDimensionMMustHaveSizeOne, enable); }
 
+        /// Gets a boolean indicating whether to check that the dimensions X and Y are be present for each subblock.
+        ///
+        /// \returns    True if it is to be checked whether all subblocks have an X and Y dimension specified; false otherwise.
         bool GetDimensionXyMustBePresent() const { return this->GetFlag(ParseFlags::kDimensionXyMustBePresent); }
+
+        /// Gets a boolean indicating whether to check that the size of all dimensions other than X, Y and M is "1" for each subblock.
+        ///
+        /// \returns    True if it is to be checked that the size of all dimensions other than X, Y and M is "1" for each subblock; false otherwise.
         bool GetDimensionOtherThanMMustHaveSizeOne() const { return this->GetFlag(ParseFlags::kDimensionOtherThanMMustHaveSizeOne); }
+
+        /// Gets a boolean indicating whether to check that the size is "1" for dimension M for all non-pyramid-subblocks.
+        /// This flag is more specific than the flag "DimensionMMustHaveSizeOne".
+        ///
+        /// \returns    True if it is to be checked that the is "1" for dimension M for all non-pyramid-subblocks; false otherwise.
         bool GetDimensionMMustHaveSizeOneForPyramidSubblocks() const { return this->GetFlag(ParseFlags::kDimensionMMustHaveSizeOneExceptForPyramidSubblocks); }
+
+        /// Gets a boolean indicating whether to check that the size is "1" for dimension M for all subblocks.
+        ///
+        /// \returns    True if it is to be checked that the is "1" for dimension M for all subblocks; false otherwise.
         bool GetDimensionMMustHaveSizeOne() const { return this->GetFlag(ParseFlags::kDimensionMMustHaveSizeOne); }
+
+        /// Sets options to "lax parsing". This is the default.
         void SetLaxParsing()
         {
             this->SetDimensionXyMustBePresent(false);
             this->SetDimensionOtherThanMMustHaveSizeOne(false);
             this->SetDimensionMMustHaveSizeOne(false);
         }
+
+        /// Sets strict parsing - all options are enabled.
         void SetStrictParsing()
         {
             this->SetDimensionXyMustBePresent(true);
@@ -100,16 +120,16 @@ public:
     static CFileHeaderSegmentData ReadFileHeaderSegmentData(libCZI::IStream* str);
 
     /// Parse the subblock-directory from the specified stream at the specified offset.
-    /// Historically, libCZI did not check whether the elements in the dimensions-entry-list had a size other than
-    /// "1" given (for all dimensions other than X and Y). We refer to this as "lax parsing". If the argument 
-    /// lax_subblock_coordinate_checks is true, then we check for those sizes to be as expected and otherwise
-    /// throw an exception.
+    /// Historically, libCZI did not check whether the elements in the dimensions-entry-list had
+    /// a size other than "1" given (for all dimensions other than X and Y). We refer to this as
+    /// "lax parsing". If the argument lax_subblock_coordinate_checks is true, then we check for
+    /// those sizes to be as expected and otherwise throw an exception.
     ///
-    /// \param [in,out] str                            The stream to read from.
-    /// \param          offset                         The offset in the stream.
-    /// \param          lax_subblock_coordinate_checks True to do "lax subblock coordinate checking".
+    /// \param [in,out] str     The stream to read from.
+    /// \param          offset  The offset in the stream.
+    /// \param          options Options controlling the operation, allowing to choose various variants for parsing.
     ///
-    /// \returns An in-memory representation of the subblock-directory.
+    /// \returns    An in-memory representation of the subblock-directory.
     static CCziSubBlockDirectory ReadSubBlockDirectory(libCZI::IStream* str, std::uint64_t offset, const SubblockDirectoryParseOptions& options);
 
     static CCziAttachmentsDirectory ReadAttachmentsDirectory(libCZI::IStream* str, std::uint64_t offset);

--- a/Src/libCZI/CziParse.h
+++ b/Src/libCZI/CziParse.h
@@ -24,24 +24,45 @@ public:
     static const std::uint8_t ATTACHMENTBLKMAGIC[16];
     static const std::uint8_t DELETEDSEGMENTMAGIC[16];
 public:
+    /// Options for parsing the subblock-directory are gathered in this struct.
+    /// The default value is to do "lax parsing".
     struct SubblockDirectoryParseOptions
     {
     private:
         enum class ParseFlags : std::uint8_t
         {
-            kDimensionXyMustBePresent = 0x00,
-            kDimensionOtherThanMMustHaveSizeOne = 0x01,
-            kDimensionMMustHaveSizeOne = 0x02,
+            kDimensionXyMustBePresent = 0,
+            kDimensionOtherThanMMustHaveSizeOne,
+            kDimensionMMustHaveSizeOneExceptForPyramidSubblocks,
+            kDimensionMMustHaveSizeOne,
 
-            kParseFlagsCount = 3
+            kParseFlagsCount
         };
         std::bitset<static_cast<std::underlying_type<ParseFlags>::type>(ParseFlags::kParseFlagsCount)> flags;
     public:
+        /// Require that for each subblock, the dimensions X and Y are present.
+        /// 
+        /// \param  enable  True to enable, false to disable.
         void SetDimensionXyMustBePresent(bool enable) { return this->SetFlag(ParseFlags::kDimensionXyMustBePresent, enable); }
+
+        /// Require that for each subblock the size (for all dimensions other than X, Y and M) is "1".
+        ///
+        /// \param  enable  True to enable, false to disable.
         void SetDimensionOtherThanMMustHaveSizeOne(bool enable) { return this->SetFlag(ParseFlags::kDimensionOtherThanMMustHaveSizeOne, enable); }
+
+        /// Require that for all subblocks that the size of dimension M is "1" except for pyramid subblocks.
+        ///
+        /// \param  enable  True to enable, false to disable.
+        void SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(bool enable) { return this->SetFlag(ParseFlags::kDimensionMMustHaveSizeOneExceptForPyramidSubblocks, enable); }
+
+        /// Require that for all subblocks that the size of dimension M is "1" (without exceptions).
+        ///
+        /// \param  enable  True to enable, false to disable.
         void SetDimensionMMustHaveSizeOne(bool enable) { return this->SetFlag(ParseFlags::kDimensionMMustHaveSizeOne, enable); }
+
         bool GetDimensionXyMustBePresent() const { return this->GetFlag(ParseFlags::kDimensionXyMustBePresent); }
         bool GetDimensionOtherThanMMustHaveSizeOne() const { return this->GetFlag(ParseFlags::kDimensionOtherThanMMustHaveSizeOne); }
+        bool GetDimensionMMustHaveSizeOneForPyramidSubblocks() const { return this->GetFlag(ParseFlags::kDimensionMMustHaveSizeOneExceptForPyramidSubblocks); }
         bool GetDimensionMMustHaveSizeOne() const { return this->GetFlag(ParseFlags::kDimensionMMustHaveSizeOne); }
         void SetLaxParsing()
         {

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -396,7 +396,7 @@ void CCziReaderWriter::ReadCziStructure()
             {
                 this->sbBlkDirectory.AddSubBlock(e);
             },
-            true,
+            CCZIParse::SubblockDirectoryParseOptions{},
             &sbBlkDirSegmentSize);
 
         this->sbBlkDirectory.SetModified(false);

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -632,6 +632,14 @@ namespace libCZI
             /// disable this for new code.
             bool lax_subblock_coordinate_checks{ true };
 
+            /// This option controls whether the size-M-attribute of a pyramid-subblocks is to be ignored (when parsing and validating
+            /// the dimension-entry of a subblock). This flag is only relevant if strict validation is enabled (i.e. lax_subblock_coordinate_checks
+            /// is 'false'). If lax_subblock_coordinate_checks is true, then this flag has no effect.
+            /// This is useful as some versions of software creating CZI-files used to write bogus values for size-M, and those files
+            /// would otherwise not be usable with strict validation enabled. If this bogus size-M is ignored, then the files can be used
+            /// without problems.
+            bool ignore_sizem_for_pyramid_subblocks{ false };   
+
             /// Sets the the default.
             void SetDefault()
             {

--- a/Src/libCZI_UnitTests/test_CZIParse.cpp
+++ b/Src/libCZI_UnitTests/test_CZIParse.cpp
@@ -55,6 +55,10 @@ TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithSizeMOf2AndExpectException)
     // ...however, if we choose to ignore the sizeM-entry, we expect no exception
     parse_options.SetDimensionMMustHaveSizeOne(false);
     EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
+
+    // ...and, if we choose to ignore only pyramid-subblocks, we still expect an exception (since the subblock is not a pyramid-subblock)
+    parse_options.SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(true);
+    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
 }
 
 TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithoutXAndExpectException)

--- a/Src/libCZI_UnitTests/test_CZIParse.cpp
+++ b/Src/libCZI_UnitTests/test_CZIParse.cpp
@@ -26,11 +26,15 @@ TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithSizeTOf2AndExpectException)
     const auto memory_stream = make_shared<CMemInputOutputStream>(czi_with_subblock_of_size_t2, sizeof(czi_with_subblock_of_size_t2));
     auto file_header_segment_data = CCZIParse::ReadFileHeaderSegmentData(memory_stream.get());
 
+    CCZIParse::SubblockDirectoryParseOptions parse_options;
+
     // if doing "lax dimension-entry-parsing", we expect no exception
-    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), true));
+    parse_options.SetLaxParsing();
+    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options));
 
     // ...but, with strict parsing, we expect an exception
-    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), false), LibCZICZIParseException);
+    parse_options.SetStrictParsing();
+    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
 }
 
 TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithSizeMOf2AndExpectException)
@@ -38,11 +42,19 @@ TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithSizeMOf2AndExpectException)
     const auto memory_stream = make_shared<CMemInputOutputStream>(czi_with_subblock_of_size_m2, sizeof(czi_with_subblock_of_size_m2));
     auto file_header_segment_data = CCZIParse::ReadFileHeaderSegmentData(memory_stream.get());
 
+    CCZIParse::SubblockDirectoryParseOptions parse_options;
+
     // if doing "lax dimension-entry-parsing", we expect no exception
-    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), true));
+    parse_options.SetLaxParsing();
+    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options));
 
     // ...but, with strict parsing, we expect an exception
-    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), false), LibCZICZIParseException);
+    parse_options.SetStrictParsing();
+    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
+
+    // ...however, if we choose to ignore the sizeM-entry, we expect no exception
+    parse_options.SetDimensionMMustHaveSizeOne(false);
+    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
 }
 
 TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithoutXAndExpectException)
@@ -50,11 +62,15 @@ TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithoutXAndExpectException)
     const auto memory_stream = make_shared<CMemInputOutputStream>(czi_with_subblock_without_x, sizeof(czi_with_subblock_without_x));
     auto file_header_segment_data = CCZIParse::ReadFileHeaderSegmentData(memory_stream.get());
 
+    CCZIParse::SubblockDirectoryParseOptions parse_options;
+
     // if doing "lax dimension-entry-parsing", we expect no exception
-    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), true));
+    parse_options.SetLaxParsing();
+    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options));
 
     // ...but, with strict parsing, we expect an exception
-    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), false), LibCZICZIParseException);
+    parse_options.SetStrictParsing();
+    EXPECT_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
 }
 
 namespace

--- a/Src/libCZI_UnitTests/test_CZIParse.cpp
+++ b/Src/libCZI_UnitTests/test_CZIParse.cpp
@@ -54,7 +54,7 @@ TEST(CZIParse, ParseSubblockDirectoryWithSubblockWithSizeMOf2AndExpectException)
 
     // ...however, if we choose to ignore the sizeM-entry, we expect no exception
     parse_options.SetDimensionMMustHaveSizeOne(false);
-    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options), LibCZICZIParseException);
+    EXPECT_NO_THROW(CCZIParse::ReadSubBlockDirectory(memory_stream.get(), file_header_segment_data.GetSubBlockDirectoryPosition(), parse_options));
 
     // ...and, if we choose to ignore only pyramid-subblocks, we still expect an exception (since the subblock is not a pyramid-subblock)
     parse_options.SetDimensionMMustHaveSizeOneExceptForPyramidSubblocks(true);


### PR DESCRIPTION
## Description

This is following up on #63 , and adds a more fine-grained control over what is checked for in "strict parsing".
In particular, it turned out that quite a few CZI-documents exist where "SizeM" for a pyramid-subblock was >1. So, we want to exclude this error from "strict parsing", at least optionally, as this fluke can be safely ignored.

* add infrastructure for fine-grained control of parsing
* add option to ignore "SizeM>1 on pyramid-subblocks" to the public API
* (just a few unrelated) typos fixed

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
