### PR TITLE
Jbl/1013574 pyramidtype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.51.1
+      VERSION 0.52.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -234,6 +234,7 @@ CCZIReader::~CCZIReader()
         info->logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
         info->physicalSize = IntSize{ static_cast<std::uint32_t>(entry.storedWidth), static_cast<std::uint32_t>(entry.storedHeight) };
         info->mIndex = entry.mIndex;
+        info->pyramidType = CziUtils::PyramidTypeFromByte(entry.pyramid_type_from_spare);
     }
 
     return true;

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -96,6 +96,7 @@ CCZIReader::~CCZIReader()
             info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
             info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
             info.mIndex = entry.mIndex;
+            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.deprecated_pyramid_type);
             return funcEnum(index, info);
         });
 }
@@ -113,6 +114,7 @@ CCZIReader::~CCZIReader()
             info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
             info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
             info.mIndex = entry.mIndex;
+            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.deprecated_pyramid_type);
             info.filePosition = entry.FilePosition;
             return funcEnum(index, info);
         });
@@ -298,6 +300,7 @@ std::shared_ptr<ISubBlock> CCZIReader::ReadSubBlock(const CCziSubBlockDirectory:
     info.mIndex = subBlkData.mIndex;
     info.logicalRect = subBlkData.logicalRect;
     info.physicalSize = subBlkData.physicalSize;
+    info.pyramidType = CziUtils::PyramidTypeFromByte(subBlkData.spare[0]);
 
     return std::make_shared<CCziSubBlock>(info, subBlkData, free);
 }

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -268,7 +268,7 @@ CCZIReader::~CCZIReader()
         });
 }
 
-/*virtual*/void CCZIReader::EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum)
+/*virtual*/void CCZIReader::EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum)
 {
     this->ThrowIfNotOperational();
     libCZI::AttachmentInfo ai;

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -113,7 +113,7 @@ CCZIReader::~CCZIReader()
             info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
             info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
             info.mIndex = entry.mIndex;
-            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.deprecated_pyramid_type);
+            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.pyramid_type_from_spare);
             return funcEnum(index, info);
         });
 }
@@ -131,7 +131,7 @@ CCZIReader::~CCZIReader()
             info.logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
             info.physicalSize = IntSize{ (std::uint32_t)entry.storedWidth, (std::uint32_t)entry.storedHeight };
             info.mIndex = entry.mIndex;
-            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.deprecated_pyramid_type);
+            info.pyramidType = CziUtils::PyramidTypeFromByte(entry.pyramid_type_from_spare);
             info.filePosition = entry.FilePosition;
             return funcEnum(index, info);
         });

--- a/Src/libCZI/CZIReader.h
+++ b/Src/libCZI/CZIReader.h
@@ -43,7 +43,7 @@ public:
     void Close() override;
 
     // interface IAttachmentRepository
-    void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum) override;
+    void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
     void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum) override;
     std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
 

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -281,6 +281,7 @@ using namespace libCZI;
         sbd.compression = subBlckSegment.data.entryDV.Compression;
         sbd.pixelType = subBlckSegment.data.entryDV.PixelType;
         sbd.mIndex = (std::numeric_limits<int>::max)();
+        memcpy(sbd.spare, subBlckSegment.data.entryDV._spare, sizeof(sbd.spare));
 
         if (subBlckSegment.data.entryDV.DimensionCount > MAXDIMENSIONS)
         {
@@ -588,6 +589,7 @@ using namespace libCZI;
     entry.FilePosition = subBlkDirDV->FilePosition;
     entry.PixelType = subBlkDirDV->PixelType;
     entry.Compression = subBlkDirDV->Compression;
+    entry.deprecated_pyramid_type = subBlkDirDV->_spare[0]; // TODO(JBL)
 
     addFunc(entry);
 }

--- a/Src/libCZI/CziParse.cpp
+++ b/Src/libCZI/CziParse.cpp
@@ -617,7 +617,7 @@ using namespace libCZI;
     entry.FilePosition = subBlkDirDV->FilePosition;
     entry.PixelType = subBlkDirDV->PixelType;
     entry.Compression = subBlkDirDV->Compression;
-    entry.deprecated_pyramid_type = subBlkDirDV->_spare[0]; // TODO(JBL)
+    entry.pyramid_type_from_spare = subBlkDirDV->_spare[0];
 
     addFunc(entry);
 }

--- a/Src/libCZI/CziParse.h
+++ b/Src/libCZI/CziParse.h
@@ -82,6 +82,7 @@ public:
         libCZI::IntRect         logicalRect;
         libCZI::IntSize         physicalSize;
         int                     mIndex;         // if not present, then this is int::max
+        std::uint8_t            spare[6];   
     };
 
     static SubBlockData ReadSubBlock(libCZI::IStream* str, std::uint64_t offset, const SubBlockStorageAllocate& allocateInfo);

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -677,6 +677,7 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
     info.mIndex = subBlkData.mIndex;
     info.logicalRect = subBlkData.logicalRect;
     info.physicalSize = subBlkData.physicalSize;
+    info.pyramidType = CziUtils::PyramidTypeFromByte(subBlkData.spare[0]);
 
     return std::make_shared<CCziSubBlock>(info, subBlkData, free);
 }
@@ -698,6 +699,7 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
         info->logicalRect = IntRect{ entry.x,entry.y,entry.width,entry.height };
         info->physicalSize = IntSize{ static_cast<std::uint32_t>(entry.storedWidth), static_cast<std::uint32_t>(entry.storedHeight) };
         info->mIndex = entry.mIndex;
+        info->pyramidType = CziUtils::PyramidTypeFromByte(entry.pyramid_type_from_spare);
     }
 
     return true;

--- a/Src/libCZI/CziReaderWriter.h
+++ b/Src/libCZI/CziReaderWriter.h
@@ -50,7 +50,7 @@ public:
 
     // interface IAttachmentRepository
     void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
-    void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum) override;
+    void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
     std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
 
 private:

--- a/Src/libCZI/CziStructs.h
+++ b/Src/libCZI/CziStructs.h
@@ -179,8 +179,7 @@ struct PACKED SubBlockDirectoryEntryDV
     std::int64_t FilePosition;
     std::int32_t FilePart;
     std::int32_t Compression;
-    std::uint8_t deprecatedPyramidType;
-    std::uint8_t _spare[5];
+    std::uint8_t _spare[6];     // TODO(JBL): the first byte here is used as "pyramid-type" 
     std::int32_t DimensionCount;
 
     // max. allocation for ease of use (valid size = 32 + EntryCount * 20)

--- a/Src/libCZI/CziStructs.h
+++ b/Src/libCZI/CziStructs.h
@@ -179,7 +179,16 @@ struct PACKED SubBlockDirectoryEntryDV
     std::int64_t FilePosition;
     std::int32_t FilePart;
     std::int32_t Compression;
-    std::uint8_t _spare[6];     // TODO(JBL): the first byte here is used as "pyramid-type" 
+
+    /// _spare[0] seem to contain information the "pyramid-type", where valid valuea are
+    /// 
+    /// 0: None
+    /// 1: SingleSubblock  
+    /// 2: MultiSubblock  
+    /// 
+    /// The significance and importance of this field is unclear, and it seems of questionable use. It is
+    /// considered legacy and should not be used.
+    std::uint8_t _spare[6];
     std::int32_t DimensionCount;
 
     // max. allocation for ease of use (valid size = 32 + EntryCount * 20)

--- a/Src/libCZI/CziStructs.h
+++ b/Src/libCZI/CziStructs.h
@@ -180,7 +180,7 @@ struct PACKED SubBlockDirectoryEntryDV
     std::int32_t FilePart;
     std::int32_t Compression;
 
-    /// _spare[0] seem to contain information the "pyramid-type", where valid valuea are
+    /// _spare[0] seems to contain information about the "pyramid-type", where valid values are
     /// 
     /// 0: None
     /// 1: SingleSubblock  

--- a/Src/libCZI/CziStructs.h
+++ b/Src/libCZI/CziStructs.h
@@ -179,7 +179,8 @@ struct PACKED SubBlockDirectoryEntryDV
     std::int64_t FilePosition;
     std::int32_t FilePart;
     std::int32_t Compression;
-    unsigned char _spare[6];
+    std::uint8_t deprecatedPyramidType;
+    std::uint8_t _spare[5];
     std::int32_t DimensionCount;
 
     // max. allocation for ease of use (valid size = 32 + EntryCount * 20)

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -27,7 +27,7 @@ public:
         int PixelType;
         std::uint64_t FilePosition;
         int Compression;
-        std::uint8_t deprecated_pyramid_type;   // TOD(JBL)
+        std::uint8_t pyramid_type_from_spare;   ///< The field "pyramid-type" (from spare-bytes of the subblock-directory-entry)
 
         bool IsMIndexValid() const
         {

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -27,6 +27,7 @@ public:
         int PixelType;
         std::uint64_t FilePosition;
         int Compression;
+        std::uint8_t deprecated_pyramid_type;   // TOD(JBL)
 
         bool IsMIndexValid() const
         {

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -42,6 +42,7 @@ public:
         void Invalidate()
         {
             this->mIndex = this->x = this->y = this->width = this->height = this->storedWidth = this->storedHeight = (std::numeric_limits<int>::min)();
+            this->pyramid_type_from_spare = 0;
         }
     };
 

--- a/Src/libCZI/CziUtils.cpp
+++ b/Src/libCZI/CziUtils.cpp
@@ -28,6 +28,30 @@ using namespace libCZI;
     return PixelType::Invalid;
 }
 
+/*static*/libCZI::PyramidType CziUtils::PyramidTypeFromByte(std::uint8_t byte)
+{
+    switch (byte)
+    {
+    case 0: return PyramidType::None;
+    case 1: return PyramidType::SingleSubBlock;
+    case 2: return PyramidType::MultiSubBlock;
+    }
+
+    return PyramidType::Invalid;
+}
+
+/*static*/std::uint8_t CziUtils::ByteFromPyramidType(libCZI::PyramidType pyramid_type)
+{
+    switch (pyramid_type)
+    {
+    case PyramidType::None: return 0;
+    case PyramidType::SingleSubBlock: return 1;
+    case PyramidType::MultiSubBlock: return 2;
+    }
+
+    return 0;
+}
+
 /*static*/int CziUtils::IntFromPixelType(libCZI::PixelType p)
 {
     switch (p)

--- a/Src/libCZI/CziUtils.cpp
+++ b/Src/libCZI/CziUtils.cpp
@@ -28,25 +28,25 @@ using namespace libCZI;
     return PixelType::Invalid;
 }
 
-/*static*/libCZI::PyramidType CziUtils::PyramidTypeFromByte(std::uint8_t byte)
+/*static*/libCZI::SubBlockPyramidType CziUtils::PyramidTypeFromByte(std::uint8_t byte)
 {
     switch (byte)
     {
-    case 0: return PyramidType::None;
-    case 1: return PyramidType::SingleSubBlock;
-    case 2: return PyramidType::MultiSubBlock;
+    case 0: return SubBlockPyramidType::None;
+    case 1: return SubBlockPyramidType::SingleSubBlock;
+    case 2: return SubBlockPyramidType::MultiSubBlock;
     }
 
-    return PyramidType::Invalid;
+    return SubBlockPyramidType::Invalid;
 }
 
-/*static*/std::uint8_t CziUtils::ByteFromPyramidType(libCZI::PyramidType pyramid_type)
+/*static*/std::uint8_t CziUtils::ByteFromPyramidType(libCZI::SubBlockPyramidType pyramid_type)
 {
     switch (pyramid_type)
     {
-    case PyramidType::None: return 0;
-    case PyramidType::SingleSubBlock: return 1;
-    case PyramidType::MultiSubBlock: return 2;
+    case SubBlockPyramidType::None: return 0;
+    case SubBlockPyramidType::SingleSubBlock: return 1;
+    case SubBlockPyramidType::MultiSubBlock: return 2;
     }
 
     return 0;

--- a/Src/libCZI/CziUtils.h
+++ b/Src/libCZI/CziUtils.h
@@ -20,6 +20,8 @@ class CziUtils
 {
 public:
     static libCZI::PixelType PixelTypeFromInt(int i);
+    static libCZI::PyramidType PyramidTypeFromByte(std::uint8_t byte);
+    static std::uint8_t ByteFromPyramidType(libCZI::PyramidType pyramid_type);
     static int IntFromPixelType(libCZI::PixelType);
     static libCZI::CompressionMode CompressionModeFromInt(int i);
     static std::int32_t CompressionModeToInt(libCZI::CompressionMode m);

--- a/Src/libCZI/CziUtils.h
+++ b/Src/libCZI/CziUtils.h
@@ -20,8 +20,8 @@ class CziUtils
 {
 public:
     static libCZI::PixelType PixelTypeFromInt(int i);
-    static libCZI::PyramidType PyramidTypeFromByte(std::uint8_t byte);
-    static std::uint8_t ByteFromPyramidType(libCZI::PyramidType pyramid_type);
+    static libCZI::SubBlockPyramidType PyramidTypeFromByte(std::uint8_t byte);
+    static std::uint8_t ByteFromPyramidType(libCZI::SubBlockPyramidType pyramid_type);
     static int IntFromPixelType(libCZI::PixelType);
     static libCZI::CompressionMode CompressionModeFromInt(int i);
     static std::int32_t CompressionModeToInt(libCZI::CompressionMode m);

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -267,6 +267,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     ptr->SchemaType[0] = 'D';
     ptr->SchemaType[1] = 'V';
     ptr->PixelType = CziUtils::IntFromPixelType(addSbBlkInfo.PixelType);
+    ptr->_spare[0] = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
     ptr->FilePosition = ptr->FilePart = 0;
     ptr->Compression = addSbBlkInfo.compressionModeRaw;
     memset(ptr->_spare, 0, sizeof(ptr->_spare));

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -267,10 +267,10 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     ptr->SchemaType[0] = 'D';
     ptr->SchemaType[1] = 'V';
     ptr->PixelType = CziUtils::IntFromPixelType(addSbBlkInfo.PixelType);
-    ptr->_spare[0] = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
     ptr->FilePosition = ptr->FilePart = 0;
     ptr->Compression = addSbBlkInfo.compressionModeRaw;
-    memset(ptr->_spare, 0, sizeof(ptr->_spare));
+    ptr->_spare[0] = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
+    memset(ptr->_spare + 1, 0, sizeof(ptr->_spare) - 1);
     ptr->DimensionCount = CalcCountOfDimensionsEntriesInDirectoryEntryDV(addSbBlkInfo);
 
     // first X and Y
@@ -1181,8 +1181,8 @@ std::tuple<std::uint64_t, std::uint64_t>  CCziWriter::WriteCurrentAttachmentsDir
         {
             this->attachmentDirectory.EnumEntries([&](size_t index, const CCziAttachmentsDirectoryBase::AttachmentEntry& e)->bool
                 {
-                        f(index, e);
-                        return true;
+                    f(index, e);
+                    return true;
                 });
         };
     info.writeFunc = std::bind(&CCziWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);
@@ -1222,8 +1222,8 @@ std::tuple<std::uint64_t, std::uint64_t> CCziWriter::WriteCurrentSubBlkDirectory
         {
             this->sbBlkDirectory.EnumEntries([&](size_t index, const CCziSubBlockDirectoryBase::SubBlkEntry& e)->bool
                 {
-                        f(index, e);
-                        return true;
+                    f(index, e);
+                    return true;
                 });
         };
     info.writeFunc = std::bind(&CCziWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -332,8 +332,8 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     ptr->FilePosition = entry.FilePosition;
     ptr->FilePart = 0;
     ptr->Compression = entry.Compression;
-    ptr->_spare[0] = entry.deprecated_pyramid_type;
-    memset(ptr->_spare + 1, 0, sizeof(ptr->_spare) - 1);
+    ptr->_spare[0] = entry.pyramid_type_from_spare;
+    memset(ptr->_spare + 1, 0, sizeof(ptr->_spare) - 1);    // skipping the pyramid-spare-byte we set above here
     ptr->DimensionCount = CalcCountOfDimensionsEntriesInDirectoryEntryDV(entry);
 
     // first X and Y
@@ -831,7 +831,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     entry.PixelType = CziUtils::IntFromPixelType(addSbBlkInfo.PixelType);
     entry.FilePosition = 0;
     entry.Compression = addSbBlkInfo.compressionModeRaw;
-    entry.deprecated_pyramid_type = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
+    entry.pyramid_type_from_spare = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
     return entry;
 }
 

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -831,6 +831,7 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     entry.PixelType = CziUtils::IntFromPixelType(addSbBlkInfo.PixelType);
     entry.FilePosition = 0;
     entry.Compression = addSbBlkInfo.compressionModeRaw;
+    entry.deprecated_pyramid_type = CziUtils::ByteFromPyramidType(addSbBlkInfo.pyramid_type);
     return entry;
 }
 

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -31,21 +31,21 @@ void libCZI::ICziWriter::SyncAddSubBlock(const libCZI::AddSubBlockInfoMemPtr& ad
     AddSubBlockInfo addSbInfo(addSbBlkInfo);
     addSbInfo.sizeData = addSbBlkInfo.dataSize;
     addSbInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrData, addSbBlkInfo.dataSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrData, addSbBlkInfo.dataSize, ptr, size);
+        };
 
     addSbInfo.sizeAttachment = addSbBlkInfo.sbBlkAttachmentSize;
     addSbInfo.getAttachment = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrSbBlkAttachment, addSbBlkInfo.sbBlkAttachmentSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrSbBlkAttachment, addSbBlkInfo.sbBlkAttachmentSize, ptr, size);
+        };
 
     addSbInfo.sizeMetadata = addSbBlkInfo.sbBlkMetadataSize;
     addSbInfo.getMetaData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrSbBlkMetadata, addSbBlkInfo.sbBlkMetadataSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbBlkInfo.ptrSbBlkMetadata, addSbBlkInfo.sbBlkMetadataSize, ptr, size);
+        };
 
     return this->SyncAddSubBlock(addSbInfo);
 }
@@ -58,28 +58,28 @@ void libCZI::ICziWriter::SyncAddSubBlock(const libCZI::AddSubBlockInfoLinewiseBi
     addSbInfo.sizeData = addSbInfoLinewise.physicalHeight * stride;
     auto linesCnt = addSbInfoLinewise.physicalHeight;
     addSbInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        if (callCnt < linesCnt)
         {
-            ptr = addSbInfoLinewise.getBitmapLine(callCnt);
-            size = stride;
-            return true;
-        }
+            if (callCnt < linesCnt)
+            {
+                ptr = addSbInfoLinewise.getBitmapLine(callCnt);
+                size = stride;
+                return true;
+            }
 
-        return false;
-    };
+            return false;
+        };
 
     addSbInfo.sizeAttachment = addSbInfoLinewise.sbBlkAttachmentSize;
     addSbInfo.getAttachment = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbInfoLinewise.ptrSbBlkAttachment, addSbInfoLinewise.sbBlkAttachmentSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbInfoLinewise.ptrSbBlkAttachment, addSbInfoLinewise.sbBlkAttachmentSize, ptr, size);
+        };
 
     addSbInfo.sizeMetadata = addSbInfoLinewise.sbBlkMetadataSize;
     addSbInfo.getMetaData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbInfoLinewise.ptrSbBlkMetadata, addSbInfoLinewise.sbBlkMetadataSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbInfoLinewise.ptrSbBlkMetadata, addSbInfoLinewise.sbBlkMetadataSize, ptr, size);
+        };
 
     return this->SyncAddSubBlock(addSbInfo);
 }
@@ -90,28 +90,28 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
 
     addSbInfo.sizeData = addSbBlkInfoStrideBitmap.physicalHeight * (addSbBlkInfoStrideBitmap.physicalWidth * (size_t)CziUtils::GetBytesPerPel(addSbBlkInfoStrideBitmap.PixelType));
     addSbInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        if (callCnt < addSbBlkInfoStrideBitmap.physicalHeight)
         {
-            ptr = static_cast<const char*>(addSbBlkInfoStrideBitmap.ptrBitmap) + callCnt * (size_t)addSbBlkInfoStrideBitmap.strideBitmap;
-            size = addSbBlkInfoStrideBitmap.physicalWidth * (size_t)CziUtils::GetBytesPerPel(addSbBlkInfoStrideBitmap.PixelType);
-            return true;
-        }
+            if (callCnt < addSbBlkInfoStrideBitmap.physicalHeight)
+            {
+                ptr = static_cast<const char*>(addSbBlkInfoStrideBitmap.ptrBitmap) + callCnt * (size_t)addSbBlkInfoStrideBitmap.strideBitmap;
+                size = addSbBlkInfoStrideBitmap.physicalWidth * (size_t)CziUtils::GetBytesPerPel(addSbBlkInfoStrideBitmap.PixelType);
+                return true;
+            }
 
-        return false;
-    };
+            return false;
+        };
 
     addSbInfo.sizeAttachment = addSbBlkInfoStrideBitmap.sbBlkAttachmentSize;
     addSbInfo.getAttachment = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbBlkInfoStrideBitmap.ptrSbBlkAttachment, addSbBlkInfoStrideBitmap.sbBlkAttachmentSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbBlkInfoStrideBitmap.ptrSbBlkAttachment, addSbBlkInfoStrideBitmap.sbBlkAttachmentSize, ptr, size);
+        };
 
     addSbInfo.sizeMetadata = addSbBlkInfoStrideBitmap.sbBlkMetadataSize;
     addSbInfo.getMetaData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        return SetIfCallCountZero(callCnt, addSbBlkInfoStrideBitmap.ptrSbBlkMetadata, addSbBlkInfoStrideBitmap.sbBlkMetadataSize, ptr, size);
-    };
+        {
+            return SetIfCallCountZero(callCnt, addSbBlkInfoStrideBitmap.ptrSbBlkMetadata, addSbBlkInfoStrideBitmap.sbBlkMetadataSize, ptr, size);
+        };
 
     return this->SyncAddSubBlock(addSbInfo);
 }
@@ -332,7 +332,8 @@ void libCZI::ICziWriter::SyncAddSubBlock(const AddSubBlockInfoStridedBitmap& add
     ptr->FilePosition = entry.FilePosition;
     ptr->FilePart = 0;
     ptr->Compression = entry.Compression;
-    memset(ptr->_spare, 0, sizeof(ptr->_spare));
+    ptr->_spare[0] = entry.deprecated_pyramid_type;
+    memset(ptr->_spare + 1, 0, sizeof(ptr->_spare) - 1);
     ptr->DimensionCount = CalcCountOfDimensionsEntriesInDirectoryEntryDV(entry);
 
     // first X and Y
@@ -1177,13 +1178,13 @@ std::tuple<std::uint64_t, std::uint64_t>  CCziWriter::WriteCurrentAttachmentsDir
     info.segmentPosForNewSegment = this->nextSegmentPos;
     info.entryCnt = this->attachmentDirectory.GetAttachmentCount();
     info.enumEntriesFunc = [&](const std::function<void(size_t, const CCziAttachmentsDirectoryBase::AttachmentEntry&)>& f)->void
-    {
-        this->attachmentDirectory.EnumEntries([&](size_t index, const CCziAttachmentsDirectoryBase::AttachmentEntry& e)->bool
-            {
-                f(index, e);
-                return true;
-            });
-    };
+        {
+            this->attachmentDirectory.EnumEntries([&](size_t index, const CCziAttachmentsDirectoryBase::AttachmentEntry& e)->bool
+                {
+                        f(index, e);
+                        return true;
+                });
+        };
     info.writeFunc = std::bind(&CCziWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);
     auto posAndSize = CWriterUtils::WriteAttachmentDirectory(info);
     if (get<0>(posAndSize) == info.segmentPosForNewSegment)
@@ -1218,13 +1219,13 @@ std::tuple<std::uint64_t, std::uint64_t> CCziWriter::WriteCurrentSubBlkDirectory
 
     info.segmentPosForNewSegment = this->nextSegmentPos;
     info.enumEntriesFunc = [&](const std::function<void(size_t, const CCziSubBlockDirectoryBase::SubBlkEntry&)>& f)->void
-    {
-        this->sbBlkDirectory.EnumEntries([&](size_t index, const CCziSubBlockDirectoryBase::SubBlkEntry& e)->bool
-            {
-                f(index, e);
-                return true;
-            });
-    };
+        {
+            this->sbBlkDirectory.EnumEntries([&](size_t index, const CCziSubBlockDirectoryBase::SubBlkEntry& e)->bool
+                {
+                        f(index, e);
+                        return true;
+                });
+        };
     info.writeFunc = std::bind(&CCziWriter::WriteToOutputStream, this, placeholders::_1, placeholders::_2, placeholders::_3, placeholders::_4, placeholders::_5);
     auto posAndSize = CWriterUtils::WriteSubBlkDirectory(info);
     if (get<0>(posAndSize) == info.segmentPosForNewSegment)

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -231,6 +231,8 @@ namespace libCZI
         /// The M-index of the sub-block (if available). If not available, it has the value std::numeric_limits<int>::max() or std::numeric_limits<int>::min().
         int                     mIndex;
 
+        /// This field is deprecated or of questionable use. It identifies whether a pyramid tile covers multiple lower level tiles or just a single tile.
+        /// TOD(JBL): elaborate
         PyramidType             pyramidType;
 
         /// Calculate a zoom-factor from the physical- and logical size.

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -231,6 +231,8 @@ namespace libCZI
         /// The M-index of the sub-block (if available). If not available, it has the value std::numeric_limits<int>::max() or std::numeric_limits<int>::min().
         int                     mIndex;
 
+        PyramidType             pyramidType;
+
         /// Calculate a zoom-factor from the physical- and logical size.
         /// \remark
         /// This calculation not really well-defined.

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -231,9 +231,9 @@ namespace libCZI
         /// The M-index of the sub-block (if available). If not available, it has the value std::numeric_limits<int>::max() or std::numeric_limits<int>::min().
         int                     mIndex;
 
-        /// This field is deprecated or of questionable use. It identifies whether a pyramid tile covers multiple lower level tiles or just a single tile.
-        /// TOD(JBL): elaborate
-        PyramidType             pyramidType;
+        /// This field indicates the "pyramid-type" of the sub-block. The significance and importance of this field is unclear, and is considered
+        /// legacy. It is recommended to ignore this field.
+        SubBlockPyramidType     pyramidType;
 
         /// Calculate a zoom-factor from the physical- and logical size.
         /// \remark
@@ -355,7 +355,7 @@ namespace libCZI
         /// \return The raw data.
         virtual std::shared_ptr<const void> GetRawData(size_t* ptrSize) = 0;
 
-        virtual ~IAttachment() {}
+        virtual ~IAttachment() = default;
 
         /// A helper method used to cast the pointer to a specific type.
         /// \param [out] ptr     The pointer to the data is stored here.
@@ -599,7 +599,7 @@ namespace libCZI
         ///                 functor is true, the enumeration is continued, otherwise it is stopped.
         ///                 The first argument is the index of the attachment and the second is providing
         ///                 information about the attachment.
-        virtual void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const AttachmentInfo& infi)>& funcEnum) = 0;
+        virtual void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const AttachmentInfo& info)>& funcEnum) = 0;
 
         /// Reads the attachment identified by the specified index. If there is no attachment present (for
         /// the specified index) then an empty shared_ptr is returned. If a different kind of problem

--- a/Src/libCZI/libCZI_Pixels.h
+++ b/Src/libCZI/libCZI_Pixels.h
@@ -134,12 +134,15 @@ namespace libCZI
         Zstd1 = 6           ///< The data contains a header, followed by a zstd-compressed block. 
     };
 
-    enum class PyramidType : std::uint8_t
+    /// This enum is used in the context of a subblock to describe which "type of pyramid" is represented by the subblock.
+    /// The significance and importance of this enum is not yet fully understood, and seems questionable. It is not recommended
+    /// to make use of it at this point for any purposes.
+    enum class SubBlockPyramidType : std::uint8_t
     {
-        Invalid = 0xff,
-        None = 0,
-        SingleSubBlock= 1,
-        MultiSubBlock = 2
+        Invalid = 0xff,     ///< Invalid pyramid type.
+        None = 0,           ///< No pyramid (indicating that the subblock is not a pyramid subblock, but a layer-0 subblock).    
+        SingleSubBlock= 1,  ///< The subblock is a pyramid subblock, and it covers a single subblock of the lower layer (or: it is a minification of a single lower-layer-subblock).
+        MultiSubBlock = 2   ///< The subblock is a pyramid subblock, and it covers multiple subblocks of the lower layer.
     };
 
     /// Information about a locked bitmap - allowing direct access to the image data in memory.

--- a/Src/libCZI/libCZI_Pixels.h
+++ b/Src/libCZI/libCZI_Pixels.h
@@ -134,6 +134,13 @@ namespace libCZI
         Zstd1 = 6           ///< The data contains a header, followed by a zstd-compressed block. 
     };
 
+    enum class PyramidType : std::uint8_t
+    {
+        None = 0,
+        SingleSubBlock= 1,
+        MultiSubBlock = 2
+    };
+
     /// Information about a locked bitmap - allowing direct access to the image data in memory.
     struct BitmapLockInfo
     {

--- a/Src/libCZI/libCZI_Pixels.h
+++ b/Src/libCZI/libCZI_Pixels.h
@@ -136,6 +136,7 @@ namespace libCZI
 
     enum class PyramidType : std::uint8_t
     {
+        Invalid = 0xff,
         None = 0,
         SingleSubBlock= 1,
         MultiSubBlock = 2

--- a/Src/libCZI/libCZI_Write.h
+++ b/Src/libCZI/libCZI_Write.h
@@ -92,7 +92,7 @@ namespace libCZI
         /// \return True if space (in bytes) for the metadata is to be reserved, false otherwise.
         virtual bool TryGetReservedSizeForMetadataSegment(size_t* size) const = 0;
 
-        virtual ~ICziWriterInfo() {}
+        virtual ~ICziWriterInfo() = default;
     };
 
     /// An implementation of the ICziWriterInfo-interface.
@@ -178,19 +178,23 @@ namespace libCZI
     struct LIBCZI_API AddSubBlockInfoBase
     {
         /// Default constructor
-        AddSubBlockInfoBase() { this->Clear(); }
+        AddSubBlockInfoBase() { this->AddSubBlockInfoBase::Clear(); }
 
-        libCZI::CDimCoordinate coordinate;  ///< The subblock's coordinate.
-        bool mIndexValid;                   ///< Whether the field 'mIndex' is valid;
-        int mIndex;                         ///< The M-index of the subblock.
-        int x;                              ///< The x-coordinate of the subblock.
-        int y;                              ///< The x-coordinate of the subblock.
-        int logicalWidth;                   ///< The logical with of the subblock (in pixels).
-        int logicalHeight;                  ///< The logical height of the subblock (in pixels).
-        int physicalWidth;                  ///< The physical with of the subblock (in pixels).
-        int physicalHeight;                 ///< The physical height of the subblock (in pixels).
-        libCZI::PixelType PixelType;        ///< The pixel type of the subblock.
-        libCZI::PyramidType pyramid_type;   ///< TODO(JBL): 
+        virtual ~AddSubBlockInfoBase() = default;
+
+        libCZI::CDimCoordinate coordinate;          ///< The subblock's coordinate.
+        bool mIndexValid;                           ///< Whether the field 'mIndex' is valid;
+        int mIndex;                                 ///< The M-index of the subblock.
+        int x;                                      ///< The x-coordinate of the subblock.
+        int y;                                      ///< The x-coordinate of the subblock.
+        int logicalWidth;                           ///< The logical with of the subblock (in pixels).
+        int logicalHeight;                          ///< The logical height of the subblock (in pixels).
+        int physicalWidth;                          ///< The physical with of the subblock (in pixels).
+        int physicalHeight;                         ///< The physical height of the subblock (in pixels).
+        libCZI::PixelType PixelType;                ///< The pixel type of the subblock.
+        libCZI::SubBlockPyramidType pyramid_type;   ///< The pyramid type of the subblock. The significance of this field
+                                                    ///< is unclear (and considered legacy). It is recommended to have this
+                                                    ///< field set to 'SubBlockPyramidType::None' (which is the value set as default).
 
         /// The compression-mode (applying to the subblock-data). If using a compressed format, the data
         /// passed in must be already compressed - the writer does _not_ perform the compression.
@@ -475,7 +479,7 @@ namespace libCZI
         this->physicalWidth = 0;
         this->physicalHeight = 0;
         this->PixelType = libCZI::PixelType::Invalid;
-        this->pyramid_type = libCZI::PyramidType::None;
+        this->pyramid_type = libCZI::SubBlockPyramidType::None;
         this->SetCompressionMode(CompressionMode::UnCompressed);
     }
 

--- a/Src/libCZI/libCZI_Write.h
+++ b/Src/libCZI/libCZI_Write.h
@@ -190,6 +190,7 @@ namespace libCZI
         int physicalWidth;                  ///< The physical with of the subblock (in pixels).
         int physicalHeight;                 ///< The physical height of the subblock (in pixels).
         libCZI::PixelType PixelType;        ///< The pixel type of the subblock.
+        libCZI::PyramidType pyramid_type;   ///< TODO(JBL): 
 
         /// The compression-mode (applying to the subblock-data). If using a compressed format, the data
         /// passed in must be already compressed - the writer does _not_ perform the compression.
@@ -474,6 +475,7 @@ namespace libCZI
         this->physicalWidth = 0;
         this->physicalHeight = 0;
         this->PixelType = libCZI::PixelType::Invalid;
+        this->pyramid_type = libCZI::PyramidType::None;
         this->SetCompressionMode(CompressionMode::UnCompressed);
     }
 

--- a/Src/libCZI_UnitTests/test_CziSubBlockDirectory.cpp
+++ b/Src/libCZI_UnitTests/test_CziSubBlockDirectory.cpp
@@ -23,6 +23,7 @@ struct SubBlockEntryData
 static CCziSubBlockDirectory::SubBlkEntry SubBlkEntryFromSubBlockEntryData(const SubBlockEntryData* ptrData)
 {
     CCziSubBlockDirectory::SubBlkEntry entry;
+    entry.Invalidate();
     entry.coordinate = CDimCoordinate::Parse(ptrData->coordinate);
     entry.mIndex = ptrData->mIndex;
     entry.x = ptrData->x;
@@ -36,7 +37,6 @@ static CCziSubBlockDirectory::SubBlkEntry SubBlkEntryFromSubBlockEntryData(const
     entry.Compression = 1;
     return entry;
 }
-
 
 TEST(CziSubBlockDirectory, CziSubBlockDirectory1)
 {


### PR DESCRIPTION
## Description

Make some "obscure and questionable" field in the subblock-data accessible to libCZI.
To my current understanding, this "pyramid-type" field has no importance, but it turned out that some applications seem to evaluate it. So - for the purpose of "replicating the exact same behavior with libCZI-created files", it is necessary to set this accordingly.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally and a unit-test is added

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
