### PR TITLE
Jbl/1036970 more lax checking for duplicate subblocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.53.1
+      VERSION 0.53.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -441,6 +441,12 @@ bool PixelTypeForChannelIndexStatistic::TryGetPixelTypeForNoChannelIndex(int* pi
 
 //----------------------------------------------------------------------------------------------
 
+CWriterCziSubBlockDirectory::CWriterCziSubBlockDirectory(bool allow_duplicate_subblocks)
+    : subBlkEntryComparison_{ allow_duplicate_subblocks },
+    subBlks(subBlkEntryComparison_)
+{
+}
+
 bool CWriterCziSubBlockDirectory::TryAddSubBlock(const SubBlkEntry& entry)
 {
     auto insert = this->subBlks.insert(entry);
@@ -533,7 +539,7 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
     }
 
     // test - if everything is "equal" so far, then let's check the fileposition
-    if (a.FilePosition < b.FilePosition)
+    if (this->include_file_position_ && a.FilePosition < b.FilePosition)
     {
         return true;
     }

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -532,6 +532,12 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         }
     }
 
+    // test - if everything is "equal" so far, then let's check the fileposition
+    if (a.FilePosition < b.FilePosition)
+    {
+        return true;
+    }
+
     return false;
 }
 

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -54,45 +54,45 @@ void CSbBlkStatisticsUpdater::UpdateStatistics(const CCziSubBlockDirectoryBase::
         [&](libCZI::DimensionIndex dim, int value)->bool
         {
             int start, size;
-    if (this->statistics.dimBounds.TryGetInterval(dim, &start, &size) == false)
-    {
-        this->statistics.dimBounds.Set(dim, value, 1);
-    }
-    else
-    {
-        bool changed = false;
-        if (value < start)
-        {
-            size += (start - value);
-            start = value;
-            changed = true;
-        }
-        else if (value >= start + size)
-        {
-            size = 1 + value - start;
-            changed = true;
-        }
+            if (this->statistics.dimBounds.TryGetInterval(dim, &start, &size) == false)
+            {
+                this->statistics.dimBounds.Set(dim, value, 1);
+            }
+            else
+            {
+                bool changed = false;
+                if (value < start)
+                {
+                    size += (start - value);
+                    start = value;
+                    changed = true;
+                }
+                else if (value >= start + size)
+                {
+                    size = 1 + value - start;
+                    changed = true;
+                }
 
-        if (changed)
-        {
-            this->statistics.dimBounds.Set(dim, start, size);
-        }
-    }
+                if (changed)
+                {
+                    this->statistics.dimBounds.Set(dim, start, size);
+                }
+            }
 
-    if (entry.IsMIndexValid())
-    {
-        if (entry.mIndex < this->statistics.minMindex)
-        {
-            this->statistics.minMindex = entry.mIndex;
-        }
+            if (entry.IsMIndexValid())
+            {
+                if (entry.mIndex < this->statistics.minMindex)
+                {
+                    this->statistics.minMindex = entry.mIndex;
+                }
 
-        if (entry.mIndex > this->statistics.maxMindex)
-        {
-            this->statistics.maxMindex = entry.mIndex;
-        }
-    }
+                if (entry.mIndex > this->statistics.maxMindex)
+                {
+                    this->statistics.maxMindex = entry.mIndex;
+                }
+            }
 
-    return true;
+            return true;
         });
 
     // now deal with "enclosing Rect" for the scenes...
@@ -331,35 +331,35 @@ void CSbBlkStatisticsUpdater::SortPyramidStatistics()
                     return true;
                 }
 
-        // ...and "not identified" always last
-        if (a.layerInfo.IsNotIdentifiedAsPyramidLayer())
-        {
-            return false;
-        }
+                // ...and "not identified" always last
+                if (a.layerInfo.IsNotIdentifiedAsPyramidLayer())
+                {
+                    return false;
+                }
 
-        if (b.layerInfo.IsLayer0())
-        {
-            return false;
-        }
+                if (b.layerInfo.IsLayer0())
+                {
+                    return false;
+                }
 
-        if (b.layerInfo.IsNotIdentifiedAsPyramidLayer())
-        {
-            return true;
-        }
+                if (b.layerInfo.IsNotIdentifiedAsPyramidLayer())
+                {
+                    return true;
+                }
 
-        int minificationFactorA = a.layerInfo.minificationFactor;
-        for (int i = 0; i < a.layerInfo.pyramidLayerNo - 1; ++i)
-        {
-            minificationFactorA *= a.layerInfo.minificationFactor;
-        }
+                int minificationFactorA = a.layerInfo.minificationFactor;
+                for (int i = 0; i < a.layerInfo.pyramidLayerNo - 1; ++i)
+                {
+                    minificationFactorA *= a.layerInfo.minificationFactor;
+                }
 
-        int minificationFactorB = b.layerInfo.minificationFactor;
-        for (int i = 0; i < b.layerInfo.pyramidLayerNo - 1; ++i)
-        {
-            minificationFactorB *= b.layerInfo.minificationFactor;
-        }
+                int minificationFactorB = b.layerInfo.minificationFactor;
+                for (int i = 0; i < b.layerInfo.pyramidLayerNo - 1; ++i)
+                {
+                    minificationFactorB *= b.layerInfo.minificationFactor;
+                }
 
-        return minificationFactorA < minificationFactorB;
+                return minificationFactorA < minificationFactorB;
             });
     }
 }
@@ -442,8 +442,8 @@ bool PixelTypeForChannelIndexStatistic::TryGetPixelTypeForNoChannelIndex(int* pi
 //----------------------------------------------------------------------------------------------
 
 CWriterCziSubBlockDirectory::CWriterCziSubBlockDirectory(bool allow_duplicate_subblocks)
-    : subBlkEntryComparison_{ allow_duplicate_subblocks },
-    subBlks(subBlkEntryComparison_)
+    : subBlkEntryComparison{ allow_duplicate_subblocks },
+    subBlks(subBlkEntryComparison)
 {
 }
 
@@ -469,6 +469,8 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
     // 2nd check:  coordinate
     // 3rd check:  m-Index
     // 4th check: (only if both subblocks have invalid M-indices) is coordinate
+    // 5th check: (only if the the property "include_file_position_" of the comparison-object is true)
+    //            the file-position is compared   
 
     // subblocks from a lower layer go before subblocks from an upper layer
     float zoomA = Utils::CalcZoom(IntSize{ (std::uint32_t)a.width,(std::uint32_t)a.height }, IntSize{ (std::uint32_t)a.storedWidth,(std::uint32_t)a.storedHeight });
@@ -538,7 +540,8 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         }
     }
 
-    // test - if everything is "equal" so far, then let's check the fileposition
+    // If we are instructed to include the file-position, then a lower file-position
+    //  shoud go first
     if (this->include_file_position_ && a.FilePosition < b.FilePosition)
     {
         return true;

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -472,7 +472,7 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
     // 5th check: (only if the the property "include_file_position_" of the comparison-object is true)
     //            the file-position is compared   
 
-    // subblocks from a lower layer go before subblocks from an upper layer
+    // 1st check: subblocks from a lower layer go before subblocks from an upper layer
     float zoomA = Utils::CalcZoom(IntSize{ (std::uint32_t)a.width,(std::uint32_t)a.height }, IntSize{ (std::uint32_t)a.storedWidth,(std::uint32_t)a.storedHeight });
     float zoomB = Utils::CalcZoom(IntSize{ (std::uint32_t)b.width,(std::uint32_t)b.height }, IntSize{ (std::uint32_t)b.storedWidth,(std::uint32_t)b.storedHeight });
     if (fabs(zoomA - zoomB) > 0.0001)
@@ -485,6 +485,7 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         return false;
     }
 
+    // 2nd check: plane coordinates
     int r = Utils::Compare(&a.coordinate, &b.coordinate);
     if (r < 0)
     {
@@ -495,6 +496,7 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         return false;
     }
 
+    // 3rd check: m-index
     if (a.IsMIndexValid() == true && b.IsMIndexValid() == false)
     {
         return true;
@@ -517,6 +519,7 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         }
     }
 
+    // 4th check: the x-y-position
     if (a.IsMIndexValid() == false && b.IsMIndexValid() == false)
     {
         int v = a.x - b.x;
@@ -540,8 +543,9 @@ bool CWriterCziSubBlockDirectory::SubBlkEntryCompare::operator()(const SubBlkEnt
         }
     }
 
-    // If we are instructed to include the file-position, then a lower file-position
-    //  shoud go first
+    // 5th check: if we are instructed to include the file-position, then a lower file-position
+    //  shoud go first (otherwise - they are considered "equal" which means that we do not allow
+    //  to add a second one as it would be a duplicate).
     if (this->include_file_position_ && a.FilePosition < b.FilePosition)
     {
         return true;

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -146,12 +146,15 @@ public:
     const libCZI::PyramidStatistics& GetPyramidStatistics() const;
     const PixelTypeForChannelIndexStatistic& GetPixelTypeForChannel() const;
 private:
+    /// Implementation of a "less-comparison" for SubBlkEntry objects, which can
+    /// be parametrized.
     struct SubBlkEntryCompare
     {
         bool include_file_position_{ false };
         bool operator() (const SubBlkEntry& a, const SubBlkEntry& b) const;
     };
 
+    /// This object is used to implement the "less-comparison" for the set.
     SubBlkEntryCompare subBlkEntryComparison;
 
     std::set<SubBlkEntry, SubBlkEntryCompare> subBlks;

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -148,11 +148,11 @@ public:
 private:
     struct SubBlkEntryCompare
     {
-        bool include_file_position_;
+        bool include_file_position_{ false };
         bool operator() (const SubBlkEntry& a, const SubBlkEntry& b) const;
     };
 
-    SubBlkEntryCompare subBlkEntryComparison_;
+    SubBlkEntryCompare subBlkEntryComparison;
 
     std::set<SubBlkEntry, SubBlkEntryCompare> subBlks;
 };

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -136,6 +136,8 @@ private:
     std::map<int, int> mapChannelIdxPixelType;
     PixelTypeForChannelIndexStatisticCreate pixelTypeForChannel;
 public:
+    CWriterCziSubBlockDirectory() = delete;
+    CWriterCziSubBlockDirectory(bool allow_duplicate_subblocks);
     bool TryAddSubBlock(const SubBlkEntry& entry);
 
     bool EnumEntries(const std::function<bool(size_t index, const SubBlkEntry&)>& func) const;
@@ -146,8 +148,11 @@ public:
 private:
     struct SubBlkEntryCompare
     {
+        bool include_file_position_;
         bool operator() (const SubBlkEntry& a, const SubBlkEntry& b) const;
     };
+
+    SubBlkEntryCompare subBlkEntryComparison_;
 
     std::set<SubBlkEntry, SubBlkEntryCompare> subBlks;
 };

--- a/Src/libCZI/CziSubBlockDirectory.h
+++ b/Src/libCZI/CziSubBlockDirectory.h
@@ -150,6 +150,7 @@ private:
     /// be parametrized.
     struct SubBlkEntryCompare
     {
+        SubBlkEntryCompare(bool include_file_position) : include_file_position_(include_file_position) {}
         bool include_file_position_{ false };
         bool operator() (const SubBlkEntry& a, const SubBlkEntry& b) const;
     };

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -880,7 +880,10 @@ CCziWriter::CziWriterInfoWrapper::CziWriterInfoWrapper(std::shared_ptr<libCZI::I
 
 //--------------------------------------------------------------------------------------------------
 
-CCziWriter::CCziWriter() : nextSegmentPos(0)
+CCziWriter::CCziWriter() : CCziWriter(CZIWriterOptions{})
+{}
+
+CCziWriter::CCziWriter(const libCZI::CZIWriterOptions& options) : sbBlkDirectory{options.allow_duplicate_subblocks}, nextSegmentPos(0)
 {
 }
 
@@ -1003,7 +1006,7 @@ CCziWriter::~CCziWriter()
     this->ThrowIfNotOperational();
     this->Finish();
     this->nextSegmentPos = 0;
-    this->sbBlkDirectory = CWriterCziSubBlockDirectory();
+    this->sbBlkDirectory = CWriterCziSubBlockDirectory{true};   // TODO
     this->attachmentDirectory = CWriterCziAttachmentsDirectory();
     this->metadataSegment.Invalidate();
     this->subBlockDirectorySegment.Invalidate();

--- a/Src/libCZI/CziWriter.cpp
+++ b/Src/libCZI/CziWriter.cpp
@@ -883,7 +883,8 @@ CCziWriter::CziWriterInfoWrapper::CziWriterInfoWrapper(std::shared_ptr<libCZI::I
 CCziWriter::CCziWriter() : CCziWriter(CZIWriterOptions{})
 {}
 
-CCziWriter::CCziWriter(const libCZI::CZIWriterOptions& options) : sbBlkDirectory{options.allow_duplicate_subblocks}, nextSegmentPos(0)
+CCziWriter::CCziWriter(const libCZI::CZIWriterOptions& options) 
+    : cziWriterOptions(options), sbBlkDirectory{options.allow_duplicate_subblocks}, nextSegmentPos(0)
 {
 }
 
@@ -1006,7 +1007,7 @@ CCziWriter::~CCziWriter()
     this->ThrowIfNotOperational();
     this->Finish();
     this->nextSegmentPos = 0;
-    this->sbBlkDirectory = CWriterCziSubBlockDirectory{true};   // TODO
+    this->sbBlkDirectory = CWriterCziSubBlockDirectory{ this->cziWriterOptions.allow_duplicate_subblocks };
     this->attachmentDirectory = CWriterCziAttachmentsDirectory();
     this->metadataSegment.Invalidate();
     this->subBlockDirectorySegment.Invalidate();

--- a/Src/libCZI/CziWriter.h
+++ b/Src/libCZI/CziWriter.h
@@ -247,6 +247,7 @@ private:
     };
 public:
     CCziWriter();
+    CCziWriter(const libCZI::CZIWriterOptions& options);
 
     void Create(std::shared_ptr<libCZI::IOutputStream> stream, std::shared_ptr<libCZI::ICziWriterInfo> info) override;
     ~CCziWriter() override;

--- a/Src/libCZI/CziWriter.h
+++ b/Src/libCZI/CziWriter.h
@@ -223,6 +223,7 @@ private:
 class CCziWriter : public libCZI::ICziWriter
 {
 private:
+    libCZI::CZIWriterOptions cziWriterOptions;
     CWriterCziSubBlockDirectory sbBlkDirectory;
     CWriterCziAttachmentsDirectory attachmentDirectory;
     std::shared_ptr<libCZI::IOutputStream> stream;

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -100,8 +100,12 @@ namespace libCZI
     /// \return The newly created CZI-reader.
     LIBCZI_API std::shared_ptr<ICZIReader> CreateCZIReader();
 
+    /// Options controlling the operation of a CZI-writer object. Those options are set at construction
+    /// time and cannot be mutated afterwards.
     struct CZIWriterOptions
     {
+        /// True if the writer should allow that duplicate subblocks are added. In general, it is
+        /// not recommended to bypass the check for duplicate subblocks.
         bool allow_duplicate_subblocks{ false };
     };
 

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -100,9 +100,14 @@ namespace libCZI
     /// \return The newly created CZI-reader.
     LIBCZI_API std::shared_ptr<ICZIReader> CreateCZIReader();
 
+    struct CZIWriterOptions
+    {
+        bool allow_duplicate_subblocks{ false };
+    };
+
     /// Creates a new instance of the CZI-writer class.
     /// \return The newly created CZI-writer.
-    LIBCZI_API std::shared_ptr<ICziWriter> CreateCZIWriter();
+    LIBCZI_API std::shared_ptr<ICziWriter> CreateCZIWriter(const CZIWriterOptions* options = nullptr);
 
     /// Creates a new instance of the CZI-reader-writer class.
     /// \return The newly created CZI-reader-writer.

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -110,7 +110,9 @@ namespace libCZI
     };
 
     /// Creates a new instance of the CZI-writer class.
-    /// \return The newly created CZI-writer.
+    /// \param  options (Optional) Options for controlling the operation. This argument may
+    ///                 be null, in which case default options are used.
+    /// \returns The newly created CZI-writer.
     LIBCZI_API std::shared_ptr<ICziWriter> CreateCZIWriter(const CZIWriterOptions* options = nullptr);
 
     /// Creates a new instance of the CZI-reader-writer class.

--- a/Src/libCZI/libCZI_Lib.cpp
+++ b/Src/libCZI/libCZI_Lib.cpp
@@ -53,9 +53,14 @@ std::shared_ptr<ICZIReader> libCZI::CreateCZIReader()
     return std::make_shared<CCZIReader>();
 }
 
-std::shared_ptr<ICziWriter> libCZI::CreateCZIWriter()
+std::shared_ptr<ICziWriter> libCZI::CreateCZIWriter(const CZIWriterOptions* options)
 {
-    return std::make_shared<CCziWriter>();
+    if (options == nullptr)
+    {
+        return std::make_shared<CCziWriter>();
+    }
+
+    return std::make_shared<CCziWriter>(*options);
 }
 
 std::shared_ptr<ICziReaderWriter> libCZI::CreateCZIReaderWriter()

--- a/Src/libCZI_UnitTests/test_writer.cpp
+++ b/Src/libCZI_UnitTests/test_writer.cpp
@@ -2147,6 +2147,7 @@ TEST(CziWriter, TryAddingDuplicateAttachmentToCziWriterAndExpectError)
 
 TEST(CziWriter, TryAddingDuplicateSubBlocksToCziWriterAndExpectError)
 {
+    // arrange
     const auto writer = CreateCZIWriter();
     const auto output_stream = make_shared<CMemOutputStream>(0);
 
@@ -2154,9 +2155,9 @@ TEST(CziWriter, TryAddingDuplicateSubBlocksToCziWriterAndExpectError)
 
     writer->Create(output_stream, czi_writer_info);
 
-    // now add two subblocks (does not really matter, though)
     auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
 
+    // now we try to add the same subblock twice
     ScopedBitmapLockerSP lockBm{ bitmap };
     AddSubBlockInfoStridedBitmap addSbBlkInfo;
     addSbBlkInfo.Clear();
@@ -2189,7 +2190,6 @@ TEST(CziWriter, TryAddingDuplicateSubBlocksToCziWriterAndWhenCheckIsDisable)
 
     writer->Create(output_stream, czi_writer_info);
 
-    // now add two subblocks (does not really matter, though)
     auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
 
     ScopedBitmapLockerSP lockBm{ bitmap };

--- a/Src/libCZI_UnitTests/test_writer.cpp
+++ b/Src/libCZI_UnitTests/test_writer.cpp
@@ -724,13 +724,13 @@ TEST(CziWriter, Writer5)
     std::uint8_t data = 0;
     int cnt = 0;
     addSbBlkInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        ++data;
-        ptr = &data;
-        size = 1;
-        ++cnt;
-        return true;
-    };
+        {
+            ++data;
+            ptr = &data;
+            size = 1;
+            ++cnt;
+            return true;
+        };
 
     writer->SyncAddSubBlock(addSbBlkInfo);
 
@@ -795,18 +795,18 @@ TEST(CziWriter, Writer6)
     std::uint8_t data = 0;
     int cnt = 0;
     addSbBlkInfo.getData = [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
-    {
-        if (callCnt > 500)
         {
-            return false;
-        }
+            if (callCnt > 500)
+            {
+                return false;
+            }
 
-        ++data;
-        ptr = &data;
-        size = 1;
-        ++cnt;
-        return true;
-    };
+            ++data;
+            ptr = &data;
+            size = 1;
+            ++cnt;
+            return true;
+        };
 
     writer->SyncAddSubBlock(addSbBlkInfo);
 
@@ -1140,8 +1140,8 @@ TEST(CziWriter, Writer11)
                 return true;
             }
 
-    success = false;
-    return false;
+            success = false;
+            return false;
         });
 
     EXPECT_TRUE(success) << "did not behave as expected";
@@ -1251,8 +1251,8 @@ TEST(CziWriter, Writer12)
                 return true;
             }
 
-    success = false;
-    return false;
+            success = false;
+            return false;
         });
 
     EXPECT_TRUE(success && allReceived) << "did not behave as expected";
@@ -1531,7 +1531,7 @@ TEST(CziWriter, WriterReturnFalseFromCallback)
     addSbBlkInfo.physicalHeight = 10;
     addSbBlkInfo.PixelType = PixelType::Gray8;
     addSbBlkInfo.sizeData = 1000;
-    addSbBlkInfo.getData = std::function<bool(int callCnt, size_t offset, const void*& ptr, size_t& size)>(
+    addSbBlkInfo.getData = std::function<bool(int callCnt, size_t offset, const void*& ptr, size_t & size)>(
         [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
         {
             return false;
@@ -1599,7 +1599,7 @@ TEST(CziWriter, WriterReturnOneByteAndThenFalseFromCallback)
     addSbBlkInfo.physicalHeight = 10;
     addSbBlkInfo.PixelType = PixelType::Gray8;
     addSbBlkInfo.sizeData = 1000;
-    addSbBlkInfo.getData = std::function<bool(int callCnt, size_t offset, const void*& ptr, size_t& size)>(
+    addSbBlkInfo.getData = std::function<bool(int callCnt, size_t offset, const void*& ptr, size_t & size)>(
         [&](int callCnt, size_t offset, const void*& ptr, size_t& size)->bool
         {
             if (callCnt == 0)
@@ -1609,7 +1609,7 @@ TEST(CziWriter, WriterReturnOneByteAndThenFalseFromCallback)
                 return true;
             }
 
-    return false;
+            return false;
         }
     );
 
@@ -2143,4 +2143,93 @@ TEST(CziWriter, TryAddingDuplicateAttachmentToCziWriterAndExpectError)
 
     // now, try to add it a second time
     EXPECT_THROW(writer->SyncAddAttachment(add_attachment_info), LibCZIException);
+}
+
+TEST(CziWriter, TryAddingDuplicateSubBlocksToCziWriterAndExpectError)
+{
+    const auto writer = CreateCZIWriter();
+    const auto output_stream = make_shared<CMemOutputStream>(0);
+
+    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(GUID{ 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0} });
+
+    writer->Create(output_stream, czi_writer_info);
+
+    // now add two subblocks (does not really matter, though)
+    auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
+
+    ScopedBitmapLockerSP lockBm{ bitmap };
+    AddSubBlockInfoStridedBitmap addSbBlkInfo;
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C0T0Z1");
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = 0;
+    addSbBlkInfo.x = 0;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    addSbBlkInfo.ptrBitmap = lockBm.ptrDataRoi;
+    addSbBlkInfo.strideBitmap = lockBm.stride;
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    // now add it a second time - and expect an excpetion
+    EXPECT_THROW(writer->SyncAddSubBlock(addSbBlkInfo), LibCZIException);
+}
+
+TEST(CziWriter, TryAddingDuplicateSubBlocksToCziWriterAndWhenCheckIsDisable)
+{
+    CZIWriterOptions czi_writer_options;
+    czi_writer_options.allow_duplicate_subblocks = true;
+    const auto writer = CreateCZIWriter(&czi_writer_options);
+    const auto output_stream = make_shared<CMemOutputStream>(0);
+
+    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(GUID{ 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0} });
+
+    writer->Create(output_stream, czi_writer_info);
+
+    // now add two subblocks (does not really matter, though)
+    auto bitmap = CreateTestBitmap(PixelType::Gray8, 64, 64);
+
+    ScopedBitmapLockerSP lockBm{ bitmap };
+    AddSubBlockInfoStridedBitmap addSbBlkInfo;
+    addSbBlkInfo.Clear();
+    addSbBlkInfo.coordinate = CDimCoordinate::Parse("C0T0Z1");
+    addSbBlkInfo.mIndexValid = true;
+    addSbBlkInfo.mIndex = 0;
+    addSbBlkInfo.x = 0;
+    addSbBlkInfo.y = 0;
+    addSbBlkInfo.logicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.logicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.physicalWidth = bitmap->GetWidth();
+    addSbBlkInfo.physicalHeight = bitmap->GetHeight();
+    addSbBlkInfo.PixelType = bitmap->GetPixelType();
+    addSbBlkInfo.ptrBitmap = lockBm.ptrDataRoi;
+    addSbBlkInfo.strideBitmap = lockBm.stride;
+    writer->SyncAddSubBlock(addSbBlkInfo);
+
+    // now add it a second time - this should now work (since we configured the writer to ignore
+    //  duplicate subblocks)
+    writer->SyncAddSubBlock(addSbBlkInfo);
+    
+    auto metadataBuilder = writer->GetPreparedMetadata(PrepareMetadataInfo());
+    string xml = metadataBuilder->GetXml(true);
+    WriteMetadataInfo writerMdInfo = { 0 };
+    writerMdInfo.szMetadata = xml.c_str();
+    writerMdInfo.szMetadataSize = xml.size();
+    writer->SyncWriteMetadata(writerMdInfo);
+    writer->Close();
+
+    // let's open the CZI-document we created, and check that we now actually have two subblocks in there
+    size_t sizeBuffer = 0;
+    auto buffer = output_stream->GetCopy(&sizeBuffer);
+    ASSERT_TRUE(buffer != nullptr);
+    ASSERT_NE(sizeBuffer, 0);
+
+    auto input_stream = CreateStreamFromMemory(buffer, sizeBuffer);
+    const auto  reader = CreateCZIReader();
+    reader->Open(input_stream, nullptr);
+    auto statistics = reader->GetStatistics();
+    EXPECT_EQ(statistics.subBlockCount, 2);
 }


### PR DESCRIPTION
## Description

This PR adds an option to the CZIWriter-object to "ignore" duplicate subblocks being added.

Unfortunately, some formatting changes crept also into this - apparently, the auto-format-bug in VS when dealing with lambdas has been fixed :-).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- locally
- unittests have been added

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
