### PR TITLE
fix for crash when libcurl is built w/o SSL-support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.54.1
+      VERSION 0.54.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -24,7 +24,7 @@ using namespace libCZI;
 
     stringstream string_stream;
     string_stream << "Version:" << version_info->version;
-    string_stream << " SSL:" << version_info->ssl_version;
+    string_stream << " SSL:" << (version_info->ssl_version != nullptr ? version_info->ssl_version : "none");
     if (version_info->age >= CURLVERSION_ELEVENTH)
     {
         for (size_t i = 0;; ++i)


### PR DESCRIPTION
## Description

fix a crash when libcurl was built w/o SSL-support.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
