### PR TITLE
add option "kCurlHttp_FollowLocation"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.54.2
+      VERSION 0.54.3
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -2194,6 +2194,8 @@ void CCmdLineOptions::PrintHelpStreamsObjects()
         {"CurlHttp_Cookie", libCZI::StreamsFactory::StreamProperties::kCurlHttp_Cookie, libCZI::StreamsFactory::Property::Type::String},
         {"CurlHttp_SslVerifyPeer", libCZI::StreamsFactory::StreamProperties::kCurlHttp_SslVerifyPeer, libCZI::StreamsFactory::Property::Type::Boolean},
         {"CurlHttp_SslVerifyHost", libCZI::StreamsFactory::StreamProperties::kCurlHttp_SslVerifyHost, libCZI::StreamsFactory::Property::Type::Boolean},
+        {"CurlHttp_FollowLocation", libCZI::StreamsFactory::StreamProperties::kCurlHttp_FollowLocation, libCZI::StreamsFactory::Property::Type::Boolean},
+        {"CurlHttp_MaxRedirs", libCZI::StreamsFactory::StreamProperties::kCurlHttp_MaxRedirs, libCZI::StreamsFactory::Property::Type::Int32},
     };
 
     rapidjson::Document document;

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -159,11 +159,18 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
         ThrowIfCurlSetOptError(return_code, "CURLOPT_SSL_VERIFYPEER");
     }
 
-    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_SslVerifyHost);
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_FollowLocation);
     if (property != property_bag.end())
     {
-        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_SSL_VERIFYHOST, property->second.GetAsBoolOrThrow() ? 1L : 0L);
-        ThrowIfCurlSetOptError(return_code, "CURLOPT_SSL_VERIFYHOST");
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_FOLLOWLOCATION, property->second.GetAsBoolOrThrow() ? 1L : 0L);
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_FOLLOWLOCATION");
+    }
+
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_MaxRedirs);
+    if (property != property_bag.end())
+    {
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_MAXREDIRS, property->second.GetAsInt32OrThrow());
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_MAXREDIRS");
     }
 
     this->curl_handle_ = up_curl_handle.release();

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -159,6 +159,13 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
         ThrowIfCurlSetOptError(return_code, "CURLOPT_SSL_VERIFYPEER");
     }
 
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_SslVerifyHost);
+    if (property != property_bag.end())
+    {
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_SSL_VERIFYHOST, property->second.GetAsBoolOrThrow() ? 1L : 0L);
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_SSL_VERIFYHOST");
+    }
+
     property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_FollowLocation);
     if (property != property_bag.end())
     {

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -224,6 +224,10 @@ namespace libCZI
                 kCurlHttp_SslVerifyPeer = 106, ///< For CurlHttpInputStream, type bool: a boolean indicating whether the SSL-certificate of the remote host is to be verified, c.f. https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html for more information.
 
                 kCurlHttp_SslVerifyHost = 107, ///< For CurlHttpInputStream, type bool: a boolean indicating whether the SSL-certificate's name is to be verified against host, c.f. https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html for more information.
+
+                kCurlHttp_FollowLocation = 108, ///< For CurlHttpInputStream, type bool: a boolean indicating whether redirects are to be followed, c.f. https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html for more information.
+
+                kCurlHttp_MaxRedirs = 109, ///< For CurlHttpInputStream, type int32: gives the maximum number of redirects to follow, c.f. https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html for more information.
             };
         };
 


### PR DESCRIPTION
## Description

Add two useful options to the property-bag for configuring the "curl_http_inputstream".

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
