### PR TITLE
Add handling of cainfo property for cURL streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.55.1
+      VERSION 0.55.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -180,6 +180,13 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
         ThrowIfCurlSetOptError(return_code, "CURLOPT_MAXREDIRS");
     }
 
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlCaInfo);
+    if (property != property_bag.end())
+    {
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_CAINFO, property->second.GetAsStringOrThrow().c_str());
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_CAINFO");
+    }
+
     this->curl_handle_ = up_curl_handle.release();
     this->curl_url_handle_ = up_curl_url_handle.release();
 }

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -228,6 +228,9 @@ namespace libCZI
                 kCurlHttp_FollowLocation = 108, ///< For CurlHttpInputStream, type bool: a boolean indicating whether redirects are to be followed, c.f. https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html for more information.
 
                 kCurlHttp_MaxRedirs = 109, ///< For CurlHttpInputStream, type int32: gives the maximum number of redirects to follow, c.f. https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html for more information.
+            
+                kCurlCaInfo= 110, ///< For CurlHttpInputStream, type string: gives the directory to check for ca certificate bundle , c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO.html for more information.
+            
             };
         };
 

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -229,7 +229,7 @@ namespace libCZI
 
                 kCurlHttp_MaxRedirs = 109, ///< For CurlHttpInputStream, type int32: gives the maximum number of redirects to follow, c.f. https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html for more information.
             
-                kCurlCaInfo= 110, ///< For CurlHttpInputStream, type string: gives the directory to check for ca certificate bundle , c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO.html for more information.
+                kCurlCaInfo = 110, ///< For CurlHttpInputStream, type string: gives the directory to check for ca certificate bundle , c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO.html for more information.
             
             };
         };


### PR DESCRIPTION
# STOP - Read this First!
Reporting a security vulnerability?  
Check out the project's [security policy](https://github.com/zeiss/libczi/security/policy).

# Fill out and Adjust this Template

## Description

Add a flag to the StreamProperties that allows setting the CURLOPT_CAINFO option for cURL based streams to a custom location.
The reason for this is that libczi is being consumed by pylibCZIrw and built for multiple different platforms that have their certificates storead at different locations. As a result, it's necessary to determine the location of the certificate bundle at runtime instead of build time.

Fixes # (issue)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This functionality is going to be used in an upcoming release of pylibCZIrw and will be tested there (either automatically or manually)

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
