### PR TITLE
add option "kCurlHttp_CaInfo" & "kCurlHttp_CaInfoBlob", allow to retrieve properties from a stream-class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.55.1
+      VERSION 0.56.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -26,7 +26,7 @@ if (LIBCZI_BUILD_CURL_BASED_STREAM)
     message(STATUS "Using CURL lib(s): ${CURL_LIBRARIES}")
 
   else(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL)
-    message(STATUS "Could not find libcURL.  This dependency will be downloaded.")
+    message(STATUS "Attempting to download and build libcURL.")
     include(FetchContent)
     # It seems for MacOS, the secure transport API is deprecated (->  https://curl.se/mail/lib-2023-09/0027.html),
     #  using OpenSSL seems to be the way to go here - so, we better do not default to secure transport here.

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -1967,6 +1967,27 @@ void CCmdLineOptions::PrintHelpStreamsObjects()
     }
 
     this->GetLog()->WriteLineStdOut(string_stream.str());
+
+    for (int i = 0; i < libCZI::StreamsFactory::GetStreamClassesCount(); i++)
+    {
+        libCZI::StreamsFactory::StreamClassInfo stream_info;
+        if (libCZI::StreamsFactory::GetStreamInfoForClass(i, stream_info) &&
+            stream_info.class_name == "curl_http_inputstream")
+        {
+            if (stream_info.get_property)
+            {
+                auto property = stream_info.get_property(libCZI::StreamsFactory::kStreamClassInfoProperty_CurlHttp_CaInfo);
+                if (property.GetType() == libCZI::StreamsFactory::Property::Type::String)
+                {
+                    auto ca_info = property.GetAsStringOrThrow();
+                    if (!ca_info.empty())
+                    {
+                        this->GetLog()->WriteLineStdOut("CA-Info: " + ca_info);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /*static*/bool CCmdLineOptions::TryParseSubBlockMetadataKeyValue(const std::string& s, std::map<std::string, std::string>* subblock_metadata_property_bag)

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -1967,27 +1967,6 @@ void CCmdLineOptions::PrintHelpStreamsObjects()
     }
 
     this->GetLog()->WriteLineStdOut(string_stream.str());
-
-    for (int i = 0; i < libCZI::StreamsFactory::GetStreamClassesCount(); i++)
-    {
-        libCZI::StreamsFactory::StreamClassInfo stream_info;
-        if (libCZI::StreamsFactory::GetStreamInfoForClass(i, stream_info) &&
-            stream_info.class_name == "curl_http_inputstream")
-        {
-            if (stream_info.get_property)
-            {
-                auto property = stream_info.get_property(libCZI::StreamsFactory::kStreamClassInfoProperty_CurlHttp_CaInfo);
-                if (property.GetType() == libCZI::StreamsFactory::Property::Type::String)
-                {
-                    auto ca_info = property.GetAsStringOrThrow();
-                    if (!ca_info.empty())
-                    {
-                        this->GetLog()->WriteLineStdOut("CA-Info: " + ca_info);
-                    }
-                }
-            }
-        }
-    }
 }
 
 /*static*/bool CCmdLineOptions::TryParseSubBlockMetadataKeyValue(const std::string& s, std::map<std::string, std::string>* subblock_metadata_property_bag)

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -52,24 +52,24 @@ using namespace libCZI;
     return string_stream.str();
 }
 
-/*static*/Property CurlHttpInputStream::GetClassProperty(const char* property_name)
+/*static*/libCZI::StreamsFactory::Property CurlHttpInputStream::GetClassProperty(const char* property_name)
 {
     if (property_name != nullptr)
     {
         if (strcmp(property_name, StreamsFactory::StreamClassInfoProperty_CurlHttp_CaInfo) == 0)
         {
             const auto version_info = curl_version_info(CURLVERSION_NOW);
-            if (version_info.cainfo != nullptr)
+            if (version_info->cainfo != nullptr)
             {
-                return Property(version_info.cainfo);
+                return StreamsFactory::Property(version_info->cainfo);
             }
         }
         else if (strcmp(property_name, StreamsFactory::StreamClassInfoProperty_CurlHttp_CaPath) == 0)
         {
             const auto version_info = curl_version_info(CURLVERSION_NOW);
-            if (version_info.capath != nullptr)
+            if (version_info->capath != nullptr)
             {
-                return Property(version_info.capath);
+                return StreamsFactory::Property(version_info->capath);
             }
         }
     }

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -191,12 +191,15 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
     if (property != property_bag.end())
     {
         string ca_info_blob = property->second.GetAsStringOrThrow();
-        struct curl_blob blob;
-        blob.data = ca_info_blob.c_str();
-        blob.len = ca_info_blob.size();
-        blob.flags = CURL_BLOB_COPY;
-        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_CAINFO_BLOB, &blob);
-        ThrowIfCurlSetOptError(return_code, "CURLOPT_CAINFO_BLOB");
+        if (!ca_info_blob.empty())
+        {
+            struct curl_blob blob;
+            blob.data = &ca_info_blob[0];
+            blob.len = ca_info_blob.size();
+            blob.flags = CURL_BLOB_COPY;
+            return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_CAINFO_BLOB, &blob);
+            ThrowIfCurlSetOptError(return_code, "CURLOPT_CAINFO_BLOB");
+        }
     }
 
     this->curl_handle_ = up_curl_handle.release();

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -240,7 +240,7 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
         std::lock_guard<std::mutex> lck(this->request_mutex_);
 
         // TODO(JBL): We may be able to use a "header-function" (https://curl.se/libcurl/c/CURLOPT_HEADERFUNCTION.html) in order to find out
-        //             whether the server accepted out "Range-Request". According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests,
+        //             whether the server accepted our "Range-Request". According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests,
         //             we can expect to have a line "something like 'Accept-Ranges: bytes'" in the response header with a server that supports range
         //             requests (and a line 'Accept-Ranges: none') would tell us explicitly that range requests are *not* supported.
 

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -180,6 +180,25 @@ CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<
         ThrowIfCurlSetOptError(return_code, "CURLOPT_MAXREDIRS");
     }
 
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_CaInfo);
+    if (property != property_bag.end())
+    {
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_CAINFO, property->second.GetAsStringOrThrow().c_str());
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_CAINFO");
+    }
+
+    property = property_bag.find(StreamsFactory::StreamProperties::kCurlHttp_CaInfoBlob);
+    if (property != property_bag.end())
+    {
+        string ca_info_blob = property->second.GetAsStringOrThrow();
+        struct curl_blob blob;
+        blob.data = ca_info_blob.c_str();
+        blob.len = ca_info_blob.size();
+        blob.flags = CURL_BLOB_COPY;
+        return_code = curl_easy_setopt(up_curl_handle.get(), CURLOPT_CAINFO_BLOB, &blob);
+        ThrowIfCurlSetOptError(return_code, "CURLOPT_CAINFO_BLOB");
+    }
+
     this->curl_handle_ = up_curl_handle.release();
     this->curl_url_handle_ = up_curl_url_handle.release();
 }

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.cpp
@@ -52,6 +52,31 @@ using namespace libCZI;
     return string_stream.str();
 }
 
+/*static*/Property CurlHttpInputStream::GetClassProperty(const char* property_name)
+{
+    if (property_name != nullptr)
+    {
+        if (strcmp(property_name, StreamsFactory::StreamClassInfoProperty_CurlHttp_CaInfo) == 0)
+        {
+            const auto version_info = curl_version_info(CURLVERSION_NOW);
+            if (version_info.cainfo != nullptr)
+            {
+                return Property(version_info.cainfo);
+            }
+        }
+        else if (strcmp(property_name, StreamsFactory::StreamClassInfoProperty_CurlHttp_CaPath) == 0)
+        {
+            const auto version_info = curl_version_info(CURLVERSION_NOW);
+            if (version_info.capath != nullptr)
+            {
+                return Property(version_info.capath);
+            }
+        }
+    }
+
+    return {};
+}
+
 CurlHttpInputStream::CurlHttpInputStream(const std::string& url, const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
 {
     /* init the curl session */

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.h
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.h
@@ -31,6 +31,7 @@ public:
     static void OneTimeGlobalCurlInitialization();
 
     static std::string GetBuildInformation();
+    static GetClassProperty(const char* property_name)
 private:
     /// This struct is passed to the WriteData function as user-data.
     struct WriteDataContext

--- a/Src/libCZI/StreamsLib/curlhttpinputstream.h
+++ b/Src/libCZI/StreamsLib/curlhttpinputstream.h
@@ -31,7 +31,7 @@ public:
     static void OneTimeGlobalCurlInitialization();
 
     static std::string GetBuildInformation();
-    static GetClassProperty(const char* property_name)
+    static libCZI::StreamsFactory::Property GetClassProperty(const char* property_name);
 private:
     /// This struct is passed to the WriteData function as user-data.
     struct WriteDataContext

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -14,6 +14,9 @@
 
 using namespace libCZI;
 
+/*static*/const char* StreamsFactory::StreamClassInfoProperty_CurlHttp_CaInfo = "CurlHttp_CaInfo";
+/*static*/const char* StreamsFactory::StreamClassInfoProperty_CurlHttp_CaPath = "CurlHttp_CaPath";
+
 static const struct
 {
     StreamsFactory::StreamClassInfo stream_class_info;

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -31,7 +31,7 @@ static const struct
 {
 #if LIBCZI_CURL_BASED_STREAM_AVAILABLE
         {
-            { "curl_http_inputstream", "curl-based http/https stream", CurlHttpInputStream::GetBuildInformation },
+            { "curl_http_inputstream", "curl-based http/https stream", CurlHttpInputStream::GetBuildInformation, CurlHttpInputStream::GetClassProperty },
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<CurlHttpInputStream>(file_name, stream_info.property_bag);
@@ -41,7 +41,7 @@ static const struct
 #endif  // LIBCZI_CURL_BASED_STREAM_AVAILABLE
 #if _WIN32
         {
-            { "windows_file_inputstream", "stream implementation based on Windows-API" },
+            { "windows_file_inputstream", "stream implementation based on Windows-API", nullptr, nullptr },
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<WindowsFileInputStream>(file_name);
@@ -54,7 +54,7 @@ static const struct
 #endif  // _WIN32
 #if LIBCZI_USE_PREADPWRITEBASED_STREAMIMPL
         {
-            { "pread_file_inputstream", "stream implementation based on pread-API" },
+            { "pread_file_inputstream", "stream implementation based on pread-API", nullptr, nullptr },
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<PreadFileInputStream>(file_name);
@@ -63,7 +63,7 @@ static const struct
         },
 #endif // LIBCZI_USE_PREADPWRITEBASED_STREAMIMPL
         {
-            { "c_runtime_file_inputstream", "stream implementation based on C-runtime library" },
+            { "c_runtime_file_inputstream", "stream implementation based on C-runtime library", nullptr, nullptr },
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<SimpleFileInputStream>(file_name);

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -14,8 +14,8 @@
 
 using namespace libCZI;
 
-/*static*/const char* StreamsFactory::StreamClassInfoProperty_CurlHttp_CaInfo = "CurlHttp_CaInfo";
-/*static*/const char* StreamsFactory::StreamClassInfoProperty_CurlHttp_CaPath = "CurlHttp_CaPath";
+/*static*/const char* StreamsFactory::kStreamClassInfoProperty_CurlHttp_CaInfo = "CurlHttp_CaInfo";
+/*static*/const char* StreamsFactory::kStreamClassInfoProperty_CurlHttp_CaPath = "CurlHttp_CaPath";
 
 static const struct
 {

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -275,6 +275,12 @@ namespace libCZI
             std::string class_name;                         ///< Name of the class (this uniquely identifies the class).
             std::string short_description;                  ///< A short and informal description of the class.  
             std::function<std::string()> get_build_info;    ///< A function which returns a string with build information for the class (e.g. version information).
+
+            /// A function which returns a class-specific property about the class. This is e.g. intended for
+            /// providing information about build-time options for a specific class. Currently, it is used for
+            /// the libcurl-based stream-class to provide information about the build-time configured paths for
+            /// the CA certificates.
+            std::function<Property(const char* property_name)> get_property;    
         };
 
         /// Gets information about a stream class available in the factory. The function returns false if the index is out of range.
@@ -304,5 +310,8 @@ namespace libCZI
         ///
         /// \returns A new instance of a streams-objects for reading the specified file from the file-system.
         static std::shared_ptr<libCZI::IStream> CreateDefaultStreamForFile(const wchar_t* filename);
+
+        static const char* StreamClassInfoProperty_CurlHttp_CaInfo;
+        static const char* StreamClassInfoProperty_CurlHttp_CaPath;
     };
 }

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -273,14 +273,18 @@ namespace libCZI
         struct LIBCZI_API StreamClassInfo
         {
             std::string class_name;                         ///< Name of the class (this uniquely identifies the class).
-            std::string short_description;                  ///< A short and informal description of the class.  
-            std::function<std::string()> get_build_info;    ///< A function which returns a string with build information for the class (e.g. version information).
+            std::string short_description;                  ///< A short and informal description of the class.
+
+            /// A function which returns a string with build information for the class (e.g. version information). Note 
+            /// that this field may be null, in which case no information is available.
+            std::function<std::string()> get_build_info;
 
             /// A function which returns a class-specific property about the class. This is e.g. intended for
             /// providing information about build-time options for a specific class. Currently, it is used for
             /// the libcurl-based stream-class to provide information about the build-time configured paths for
             /// the CA certificates.
-            std::function<Property(const char* property_name)> get_property;    
+            /// Note that this field may be null, in which case no information is available.
+            std::function<Property(const char* property_name)> get_property;
         };
 
         /// Gets information about a stream class available in the factory. The function returns false if the index is out of range.

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -311,7 +311,14 @@ namespace libCZI
         /// \returns A new instance of a streams-objects for reading the specified file from the file-system.
         static std::shared_ptr<libCZI::IStream> CreateDefaultStreamForFile(const wchar_t* filename);
 
-        static const char* StreamClassInfoProperty_CurlHttp_CaInfo;
-        static const char* StreamClassInfoProperty_CurlHttp_CaPath;
+        /// A static string for the property_name for the get_property-function of the StreamClassInfo identifying the
+        /// build-time configured file holding one or more certificates to verify the peer with. C.f. https://curl.se/libcurl/c/curl_version_info.html, this
+        /// property gives the value of the "cainfo"-field. If it is null, then an invalid property is returned. 
+        static const char* kStreamClassInfoProperty_CurlHttp_CaInfo;
+
+        /// A static string for the property_name for the get_property-function of the StreamClassInfo identifying the
+        /// build-time configured directory holding CA certificates. C.f. https://curl.se/libcurl/c/curl_version_info.html, this
+        /// property gives the value of the "capath"-field. If it is null, then an invalid property is returned.
+        static const char* kStreamClassInfoProperty_CurlHttp_CaPath;
     };
 }

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -228,6 +228,10 @@ namespace libCZI
                 kCurlHttp_FollowLocation = 108, ///< For CurlHttpInputStream, type bool: a boolean indicating whether redirects are to be followed, c.f. https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html for more information.
 
                 kCurlHttp_MaxRedirs = 109, ///< For CurlHttpInputStream, type int32: gives the maximum number of redirects to follow, c.f. https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html for more information.
+
+                kCurlHttp_CaInfo = 110, ///< For CurlHttpInputStream, type string: gives the directory to check for CA certificate bundle , c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO.html for more information.
+
+                kCurlHttp_CaInfoBlob = 111, ///< For CurlHttpInputStream, type string: give PEM encoded content holding one or more certificates to verify the HTTPS server with, c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html for more information.
             };
         };
 


### PR DESCRIPTION
## Description

This is following up on #81.
* add options  "kCurlHttp_CaInfo" & "kCurlHttp_CaInfoBlob" for the curl-based http-stream-class
* add functionality to query (class-specific) properties from a stream-class (intended to be used to query compile-time options)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally, manually and the functionality is going to be used in an upcoming release of pylibCZIrw and will be tested there (either automatically or manually)

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
