### PR TITLE
adding ability to use a cache with accessors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.56.0
+      VERSION 0.57.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 FetchContent_Declare(
   cli11
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11
-  GIT_TAG        v2.2.0
+  GIT_TAG        v2.3.2
 )
 
 if (NOT cli11_POPULATED)
@@ -94,7 +94,9 @@ set (CZICMDSRCFILES
          inc_rapidjson.h      
          BitmapGenNull.h        
          CZIcmd.cpp          
-         platform_defines.h)
+         platform_defines.h
+         executePlaneScan.h
+         executePlaneScan.cpp)
 
 add_executable(CZIcmd ${CZICMDSRCFILES})
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -96,7 +96,9 @@ set (CZICMDSRCFILES
          CZIcmd.cpp          
          platform_defines.h
          executePlaneScan.h
-         executePlaneScan.cpp)
+         executePlaneScan.cpp
+         executeBase.h
+         executeBase.cpp)
 
 add_executable(CZIcmd ${CZICMDSRCFILES})
 

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -618,7 +618,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
            using display-settings.
            \N'ExtractAttachment' allows to extract (and save to a file) the contents of attachments.)
            \N'CreateCZI' is used to demonstrate the CZI-creation capabilities of libCZI.)
-           \N'PlaneScan' does the following: over a ROI of given with the --rect option a rectangle of size given with 
+           \N'PlaneScan' does the following: over a ROI given with the --rect option a rectangle of size given with 
            the --tilesize-for-plane-scan option is moved, and the image content of this rectangle is written out to
            files. The operation takes place on a plane which is given with the --plane-coordinate option. The filenames of the
            tile-bitmaps are generated from the filename given with the --output option, where a string _X[x-position]_Y[y-position]_W[width]_H[height]

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -1496,10 +1496,12 @@ bool CCmdLineOptions::TryParseDisplaySettings(const std::string& s, std::map<int
             *color = libCZI::RgbFloatColor{ f[0],f[0],f[0] };
         }
     }
-
-    if (color != nullptr)
+    else
     {
-        *color = libCZI::RgbFloatColor{ f[0],f[1],f[2] };
+        if (color != nullptr)
+        {
+            *color = libCZI::RgbFloatColor{ f[0],f[1],f[2] };
+        }
     }
 
     return true;

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -497,6 +497,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         { "ScalingChannelComposite",            Command::ScalingChannelComposite },
         { "ExtractAttachment",                  Command::ExtractAttachment},
         { "CreateCZI",                          Command::CreateCZI },
+        { "PlaneScan",                          Command::PlaneScan },
     };
 
     const static PlaneCoordinateValidator plane_coordinate_validator;

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -1539,14 +1539,14 @@ bool CCmdLineOptions::TryParseDisplaySettings(const std::string& s, std::map<int
     {
         if (color != nullptr)
         {
-            *color = libCZI::RgbFloatColor{ f[0],f[0],f[0] };
+            *color = libCZI::RgbFloatColor{ f[0], f[0], f[0] };
         }
     }
     else
     {
         if (color != nullptr)
         {
-            *color = libCZI::RgbFloatColor{ f[0],f[1],f[2] };
+            *color = libCZI::RgbFloatColor{ f[0], f[1], f[2] };
         }
     }
 

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -2345,31 +2345,31 @@ void CCmdLineOptions::PrintHelpStreamsObjects()
     {
         factor = 1000;
     }
-    else if (icasecmp(suffix_string, "ki") == 0)
+    else if (icasecmp(suffix_string, "ki"))
     {
         factor = 1024;
     }
-    else if (icasecmp(suffix_string, "m") == 0)
+    else if (icasecmp(suffix_string, "m") )
     {
         factor = 1000 * 1000;
     }
-    else if (icasecmp(suffix_string, "mi") == 0)
+    else if (icasecmp(suffix_string, "mi"))
     {
         factor = 1024 * 1024;
     }
-    else if (icasecmp(suffix_string, "g") == 0)
+    else if (icasecmp(suffix_string, "g"))
     {
         factor = 1000 * 1000 * 1000;
     }
-    else if (icasecmp(suffix_string, "gi") == 0)
+    else if (icasecmp(suffix_string, "gi"))
     {
         factor = 1024 * 1024 * 1024;
     }
-    else if (icasecmp(suffix_string, "t") == 0)
+    else if (icasecmp(suffix_string, "t"))
     {
         factor = 1000ULL * 1000 * 1000 * 1000;
     }
-    else if (icasecmp(suffix_string, "ti") == 0)
+    else if (icasecmp(suffix_string, "ti"))
     {
         factor = 1024ULL * 1024 * 1024 * 1024;
     }

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -2364,6 +2364,18 @@ void CCmdLineOptions::PrintHelpStreamsObjects()
 
 /*static*/bool CCmdLineOptions::TryParseSubBlockCacheSize(const std::string& text, std::uint64_t* size)
 {
+    // This regular expression is used to match strings that represent sizes in bytes, kilobytes, megabytes, gigabytes, terabytes, kibibytes, mebibytes, gibibytes, and tebibytes. 
+    //
+    // Here is a breakdown of the regular expression:
+    //
+    // - ^\s*: Matches the start of the string, followed by any amount of whitespace.
+    // - ([+]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+)): Matches a positive number, which can be an integer or a decimal. The number may optionally be preceded by a plus sign.
+    // - \s*: Matches any amount of whitespace following the number.
+    // - (k|m|g|t|ki|mi|gi|ti): Matches one of the following units of size: k (kilobytes), m (megabytes), g (gigabytes), t (terabytes), ki (kibibytes), mi (mebibytes), gi (gibibytes), ti (tebibytes).
+    // - (?:b?): Optionally matches a 'b', which can be used to explicitly specify that the size is in bytes.
+    // - \s*$: Matches any amount of whitespace at the end of the string, followed by the end of the string.
+    //
+    // This regular expression is case-insensitive.
     regex regex(R"(^\s*([+]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+))\s*(k|m|g|t|ki|mi|gi|ti)(?:b?)\s*$)", regex_constants::icase);
     smatch match;
     regex_search(text, match, regex);

--- a/Src/CZICmd/cmdlineoptions.h
+++ b/Src/CZICmd/cmdlineoptions.h
@@ -192,6 +192,8 @@ private:
     libCZI::CompressionMode compressionMode;
     std::shared_ptr<libCZI::ICompressParameters> compressionParameters;
     libCZI::PixelType pixelTypeForBitmapGenerator;
+
+    std::uint64_t subBlockCacheSize;    ///< The size of the sub-block cache in bytes.
 public:
     /// Values that represent the result of the "Parse"-operation.
     enum class ParseResult
@@ -259,6 +261,7 @@ public:
     libCZI::CompressionMode GetCompressionMode() const { return this->compressionMode; }
     std::shared_ptr<libCZI::ICompressParameters> GetCompressionParameters() const { return this->compressionParameters; }
     libCZI::PixelType GetPixelGeneratorPixeltype() const { return this->pixelTypeForBitmapGenerator; }
+    std::uint64_t GetSubBlockCacheSize() const { return this->subBlockCacheSize; }
 private:
     friend struct RegionOfInterestValidator;
     friend struct DisplaySettingsValidator;
@@ -278,6 +281,7 @@ private:
     friend struct CreateSubblockMetadataValidator;
     friend struct CompressionOptionsValidator;
     friend struct GeneratorPixelTypeValidator;
+    friend struct CachesizeValidator;
 
     bool CheckArgumentConsistency() const;
     void SetOutputFilename(const std::wstring& s);
@@ -309,6 +313,7 @@ private:
     static bool TryParseCompressionOptions(const std::string& s, libCZI::Utils::CompressionOption* compression_option);
     static bool TryParseGeneratorPixeltype(const std::string& s, libCZI::PixelType* pixel_type);
     static bool TryParseInputStreamCreationPropertyBag(const std::string& s, std::map<int, libCZI::StreamsFactory::Property>* property_bag);
+    static bool TryParseSubBlockCacheSize(const std::string& text, std::uint64_t* size);
 
     static void ThrowIfFalse(bool b, const std::string& argument_switch, const std::string& argument);
 };

--- a/Src/CZICmd/cmdlineoptions.h
+++ b/Src/CZICmd/cmdlineoptions.h
@@ -194,6 +194,9 @@ private:
     libCZI::PixelType pixelTypeForBitmapGenerator;
 
     std::uint64_t subBlockCacheSize;    ///< The size of the sub-block cache in bytes.
+    std::tuple<std::uint32_t, std::uint32_t> tilesSizeForPlaneScan; ///< The size of the tiles in pixels for the plane scan operation.
+
+    bool useVisibilityCheckOptimization;
 public:
     /// Values that represent the result of the "Parse"-operation.
     enum class ParseResult
@@ -262,6 +265,8 @@ public:
     std::shared_ptr<libCZI::ICompressParameters> GetCompressionParameters() const { return this->compressionParameters; }
     libCZI::PixelType GetPixelGeneratorPixeltype() const { return this->pixelTypeForBitmapGenerator; }
     std::uint64_t GetSubBlockCacheSize() const { return this->subBlockCacheSize; }
+    const std::tuple<std::uint32_t, std::uint32_t>& GetTileSizeForPlaneScan() const { return this->tilesSizeForPlaneScan; }
+    bool GetUseVisibilityCheckOptimization() const { return this->useVisibilityCheckOptimization; }
 private:
     friend struct RegionOfInterestValidator;
     friend struct DisplaySettingsValidator;
@@ -282,6 +287,7 @@ private:
     friend struct CompressionOptionsValidator;
     friend struct GeneratorPixelTypeValidator;
     friend struct CachesizeValidator;
+    friend struct TileSizeForPlaneScanValidator;
 
     bool CheckArgumentConsistency() const;
     void SetOutputFilename(const std::wstring& s);

--- a/Src/CZICmd/cmdlineoptions.h
+++ b/Src/CZICmd/cmdlineoptions.h
@@ -32,7 +32,9 @@ enum class Command
 
     CreateCZI,
 
-    ReadWriteCZI
+    ReadWriteCZI,
+
+    PlaneScan,
 };
 
 enum class InfoLevel : std::uint32_t

--- a/Src/CZICmd/execute.cpp
+++ b/Src/CZICmd/execute.cpp
@@ -553,6 +553,9 @@ public:
         libCZI::ISingleChannelTileAccessor::Options sctaOptions; sctaOptions.Clear();
         sctaOptions.sortByM = true;
         sctaOptions.drawTileBorder = options.GetDrawTileBoundaries();
+        sctaOptions.backGroundColor = GetBackgroundColorFromOptions(options);
+        sctaOptions.sceneFilter = options.GetSceneIndexSet();
+        sctaOptions.useVisibilityCheckOptimization = options.GetUseVisibilityCheckOptimization();
 
         IntRect roi{ options.GetRectX() ,options.GetRectY(),options.GetRectW(),options.GetRectH() };
         if (options.GetIsRelativeRectCoordinate())
@@ -748,6 +751,7 @@ public:
         libCZI::ISingleChannelScalingTileAccessor::Options scstaOptions; scstaOptions.Clear();
         scstaOptions.backGroundColor = GetBackgroundColorFromOptions(options);
         scstaOptions.sceneFilter = options.GetSceneIndexSet();
+        scstaOptions.useVisibilityCheckOptimization = options.GetUseVisibilityCheckOptimization();
 
         auto re = accessor->Get(roi, &coordinate, options.GetZoom(), &scstaOptions);
 
@@ -854,6 +858,7 @@ private:
         sctaOptions.backGroundColor = GetBackgroundColorFromOptions(options);
         sctaOptions.drawTileBorder = options.GetDrawTileBoundaries();
         sctaOptions.sceneFilter = options.GetSceneIndexSet();
+        sctaOptions.useVisibilityCheckOptimization = options.GetUseVisibilityCheckOptimization();
         IntRect roi{ options.GetRectX() ,options.GetRectY() ,options.GetRectW(),options.GetRectH() };
         if (options.GetIsRelativeRectCoordinate())
         {

--- a/Src/CZICmd/execute.cpp
+++ b/Src/CZICmd/execute.cpp
@@ -4,6 +4,7 @@
 
 #include "stdafx.h"
 #include "execute.h"
+#include "executeBase.h"
 #include "executeCreateCzi.h"
 #include "executePlaneScan.h"
 #include "inc_libCZI.h"
@@ -19,110 +20,6 @@
 using namespace libCZI;
 using namespace std;
 using namespace rapidjson;
-
-class CExecuteBase
-{
-protected:
-    static std::shared_ptr<ICZIReader> CreateAndOpenCziReader(const CCmdLineOptions& options)
-    {
-        shared_ptr<IStream> stream;
-        if (options.GetInputStreamClassName().empty())
-        {
-            stream = CExecuteBase::CreateStandardFileBasedStreamObject(options.GetCZIFilename().c_str());
-        }
-        else
-        {
-            stream = CExecuteBase::CreateInputStreamObject(
-                                    options.GetCZIFilename().c_str(), 
-                                    options.GetInputStreamClassName(),
-                                    &options.GetInputStreamPropertyBag());
-        }
-
-        auto spReader = libCZI::CreateCZIReader();
-        spReader->Open(stream);
-        return spReader;
-    }
-
-    static std::shared_ptr<IStream> CreateStandardFileBasedStreamObject(const wchar_t* fileName)
-    {
-        auto stream = libCZI::CreateStreamFromFile(fileName);
-        return stream;
-    }
-
-    static std::shared_ptr<IStream> CreateInputStreamObject(const wchar_t* uri, const string& class_name, const std::map<int, libCZI::StreamsFactory::Property>* property_bag)
-    {
-        libCZI::StreamsFactory::Initialize();
-        libCZI::StreamsFactory::CreateStreamInfo stream_info;
-        stream_info.class_name = class_name;
-        if (property_bag != nullptr)
-        {
-            stream_info.property_bag = *property_bag;
-        }
-
-        auto stream = libCZI::StreamsFactory::CreateStream(stream_info, uri);
-        if (!stream)
-        {
-            stringstream string_stream;
-            string_stream << "Failed to create stream object of the class \"" << class_name << "\".";
-            throw std::runtime_error(string_stream.str());
-        }
-
-        return stream;
-    }
-
-    static IntRect GetRoiFromOptions(const CCmdLineOptions& options, const SubBlockStatistics& subBlockStatistics)
-    {
-        IntRect roi{ options.GetRectX(), options.GetRectY(), options.GetRectW(), options.GetRectH() };
-        if (options.GetIsRelativeRectCoordinate())
-        {
-            roi.x += subBlockStatistics.boundingBox.x;
-            roi.y += subBlockStatistics.boundingBox.y;
-        }
-
-        return roi;
-    }
-
-    static libCZI::RgbFloatColor GetBackgroundColorFromOptions(const CCmdLineOptions& options)
-    {
-        return options.GetBackGroundColor();
-    }
-
-    static void DoCalcHashOfResult(shared_ptr<libCZI::IBitmapData> bm, const CCmdLineOptions& options)
-    {
-        DoCalcHashOfResult(bm.get(), options);
-    }
-
-    static void HandleHashOfResult(const std::function<bool(uint8_t*, size_t)>& f, const CCmdLineOptions& options)
-    {
-        if (!options.GetCalcHashOfResult())
-        {
-            return;
-        }
-
-        uint8_t md5sumHash[16];
-        if (!f(md5sumHash, sizeof(md5sumHash)))
-        {
-            return;
-        }
-
-        string hashHex = BytesToHexString(md5sumHash, sizeof(md5sumHash));
-        std::stringstream ss;
-        ss << "hash of result: " << hashHex;
-        auto log = options.GetLog();
-        log->WriteLineStdOut(ss.str().c_str());
-    }
-
-    static void DoCalcHashOfResult(libCZI::IBitmapData* bm, const CCmdLineOptions& options)
-    {
-        HandleHashOfResult(
-            [&](uint8_t* ptrHash, size_t size)->bool
-            {
-                Utils::CalcMd5SumHash(bm, ptrHash, (int)size);
-                return true;
-            },
-            options);
-    }
-};
 
 class CExecutePrintInformation : CExecuteBase
 {

--- a/Src/CZICmd/execute.cpp
+++ b/Src/CZICmd/execute.cpp
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "stdafx.h"
-#include <limits>
 #include "execute.h"
 #include "executeCreateCzi.h"
+#include "executePlaneScan.h"
 #include "inc_libCZI.h"
 #include "SaveBitmap.h"
 #include "utils.h"
 #include "DisplaySettingsHelper.h"
 #include "inc_rapidjson.h"
+#include <limits>
 #include <iomanip>
 #include <map>
 #include <fstream>
@@ -1228,6 +1229,9 @@ bool execute(const CCmdLineOptions& options)
             break;
         case Command::CreateCZI:
             success = executeCreateCzi(options);
+            break;
+        case Command::PlaneScan:
+            success = executePlaneScan(options);
             break;
         default:
             break;

--- a/Src/CZICmd/executeBase.cpp
+++ b/Src/CZICmd/executeBase.cpp
@@ -1,0 +1,106 @@
+#include "executeBase.h"
+
+#include "cmdlineoptions.h"
+
+using namespace std;
+using namespace libCZI;
+
+std::shared_ptr<ICZIReader> CExecuteBase::CreateAndOpenCziReader(const CCmdLineOptions& options)
+{
+    shared_ptr<IStream> stream;
+    if (options.GetInputStreamClassName().empty())
+    {
+        stream = CExecuteBase::CreateStandardFileBasedStreamObject(options.GetCZIFilename().c_str());
+    }
+    else
+    {
+        stream = CExecuteBase::CreateInputStreamObject(
+                                options.GetCZIFilename().c_str(),
+                                options.GetInputStreamClassName(),
+                                &options.GetInputStreamPropertyBag());
+    }
+
+    auto spReader = libCZI::CreateCZIReader();
+    spReader->Open(stream);
+    return spReader;
+}
+
+std::shared_ptr<IStream> CExecuteBase::CreateStandardFileBasedStreamObject(const wchar_t* fileName)
+{
+    auto stream = libCZI::CreateStreamFromFile(fileName);
+    return stream;
+}
+
+std::shared_ptr<IStream> CExecuteBase::CreateInputStreamObject(const wchar_t* uri, const string& class_name, const std::map<int, libCZI::StreamsFactory::Property>* property_bag)
+{
+    libCZI::StreamsFactory::Initialize();
+    libCZI::StreamsFactory::CreateStreamInfo stream_info;
+    stream_info.class_name = class_name;
+    if (property_bag != nullptr)
+    {
+        stream_info.property_bag = *property_bag;
+    }
+
+    auto stream = libCZI::StreamsFactory::CreateStream(stream_info, uri);
+    if (!stream)
+    {
+        stringstream string_stream;
+        string_stream << "Failed to create stream object of the class \"" << class_name << "\".";
+        throw std::runtime_error(string_stream.str());
+    }
+
+    return stream;
+}
+
+IntRect CExecuteBase::GetRoiFromOptions(const CCmdLineOptions& options, const SubBlockStatistics& subBlockStatistics)
+{
+    IntRect roi{ options.GetRectX(), options.GetRectY(), options.GetRectW(), options.GetRectH() };
+    if (options.GetIsRelativeRectCoordinate())
+    {
+        roi.x += subBlockStatistics.boundingBox.x;
+        roi.y += subBlockStatistics.boundingBox.y;
+    }
+
+    return roi;
+}
+
+libCZI::RgbFloatColor CExecuteBase::GetBackgroundColorFromOptions(const CCmdLineOptions& options)
+{
+    return options.GetBackGroundColor();
+}
+
+void CExecuteBase::DoCalcHashOfResult(shared_ptr<libCZI::IBitmapData> bm, const CCmdLineOptions& options)
+{
+    DoCalcHashOfResult(bm.get(), options);
+}
+
+void CExecuteBase::HandleHashOfResult(const std::function<bool(uint8_t*, size_t)>& f, const CCmdLineOptions& options)
+{
+    if (!options.GetCalcHashOfResult())
+    {
+        return;
+    }
+
+    uint8_t md5sumHash[16];
+    if (!f(md5sumHash, sizeof(md5sumHash)))
+    {
+        return;
+    }
+
+    string hashHex = BytesToHexString(md5sumHash, sizeof(md5sumHash));
+    std::stringstream ss;
+    ss << "hash of result: " << hashHex;
+    auto log = options.GetLog();
+    log->WriteLineStdOut(ss.str().c_str());
+}
+
+void CExecuteBase::DoCalcHashOfResult(libCZI::IBitmapData* bm, const CCmdLineOptions& options)
+{
+    HandleHashOfResult(
+        [&](uint8_t* ptrHash, size_t size)->bool
+        {
+        Utils::CalcMd5SumHash(bm, ptrHash, (int)size);
+        return true;
+        },
+        options);
+}

--- a/Src/CZICmd/executeBase.cpp
+++ b/Src/CZICmd/executeBase.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "executeBase.h"
 
 #include "cmdlineoptions.h"

--- a/Src/CZICmd/executeBase.h
+++ b/Src/CZICmd/executeBase.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <functional>
+#include <map>
+#include "executeBase.h"
+#include "inc_libCZI.h"
+
+class CCmdLineOptions;
+
+class CExecuteBase
+{
+protected:
+    static std::shared_ptr<libCZI::ICZIReader> CreateAndOpenCziReader(const CCmdLineOptions& options);
+   
+    static std::shared_ptr<libCZI::IStream> CreateStandardFileBasedStreamObject(const wchar_t* fileName);
+
+    static std::shared_ptr<libCZI::IStream> CreateInputStreamObject(const wchar_t* uri, const std::string& class_name, const std::map<int, libCZI::StreamsFactory::Property>* property_bag);
+
+    static libCZI::IntRect GetRoiFromOptions(const CCmdLineOptions& options, const libCZI::SubBlockStatistics& subBlockStatistics);
+
+    static libCZI::RgbFloatColor GetBackgroundColorFromOptions(const CCmdLineOptions& options);
+
+    static void DoCalcHashOfResult(std::shared_ptr<libCZI::IBitmapData> bm, const CCmdLineOptions& options);
+
+    static void HandleHashOfResult(const std::function<bool(uint8_t*, size_t)>& f, const CCmdLineOptions& options);
+
+    static void DoCalcHashOfResult(libCZI::IBitmapData* bm, const CCmdLineOptions& options);
+};

--- a/Src/CZICmd/executeBase.h
+++ b/Src/CZICmd/executeBase.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include <memory>

--- a/Src/CZICmd/executeBase.h
+++ b/Src/CZICmd/executeBase.h
@@ -12,18 +12,11 @@ class CExecuteBase
 {
 protected:
     static std::shared_ptr<libCZI::ICZIReader> CreateAndOpenCziReader(const CCmdLineOptions& options);
-   
     static std::shared_ptr<libCZI::IStream> CreateStandardFileBasedStreamObject(const wchar_t* fileName);
-
     static std::shared_ptr<libCZI::IStream> CreateInputStreamObject(const wchar_t* uri, const std::string& class_name, const std::map<int, libCZI::StreamsFactory::Property>* property_bag);
-
     static libCZI::IntRect GetRoiFromOptions(const CCmdLineOptions& options, const libCZI::SubBlockStatistics& subBlockStatistics);
-
     static libCZI::RgbFloatColor GetBackgroundColorFromOptions(const CCmdLineOptions& options);
-
     static void DoCalcHashOfResult(std::shared_ptr<libCZI::IBitmapData> bm, const CCmdLineOptions& options);
-
     static void HandleHashOfResult(const std::function<bool(uint8_t*, size_t)>& f, const CCmdLineOptions& options);
-
     static void DoCalcHashOfResult(libCZI::IBitmapData* bm, const CCmdLineOptions& options);
 };

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -34,8 +34,8 @@ public:
             cache_context.cache = CreateSubBlockCache();
             cache_context.prune_options.maxMemoryUsage = max_cache_size;
         }
-
-        const IntSize tileSize = { get<0>(options.GetTileSizeForPlaneScan()), get<1>(options.GetTileSizeForPlaneScan()) };
+        const auto tile_size_for_plane_scan = options.GetTileSizeForPlaneScan();
+        const IntSize tileSize = { get<0>(tile_size_for_plane_scan), get<1>(tile_size_for_plane_scan) };
         const auto saver = CSaveBitmapFactory::CreateSaveBitmapObj(nullptr);
 
         for (int y = 0; y < (roi.h + static_cast<int>(tileSize.h) - 1) / static_cast<int>(tileSize.h); ++y)

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "stdafx.h"
+#include "executePlaneScan.h"
+
+using namespace std;
+using namespace libCZI;
+
+bool executePlaneScan(const CCmdLineOptions& options)
+{
+    return false;
+}

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -34,11 +34,11 @@ public:
 
         IntSize tileSize = { 512, 512 };
 
-        for (int y = roi.y; y < roi.y + roi.h; y += tileSize.h)
+        for (int y = 0; y < roi.h / tileSize.h; ++y)
         {
-            for (int x = roi.x; x < roi.x + roi.w; x += tileSize.w)
+            for (int x = 0; x <  roi.w / tileSize.w; ++x)
             {
-                IntRect tileRect = { x, y, (int)tileSize.w, (int)tileSize.h };
+                IntRect tileRect = { (int)(roi.x + x * tileSize.w), (int)(roi.y + y * tileSize.h), (int)tileSize.w, (int)tileSize.h };
                 WriteRoi(accessor, coordinate, tileRect, cache_context, options);
             }
         }

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -30,8 +30,12 @@ public:
 
 
         CacheContext cache_context;
-        cache_context.cache = CreateSubBlockCache();
-        cache_context.prune_options.maxMemoryUsage = 40 * 1024 * 1024;
+        const uint64_t max_cache_size = options.GetSubBlockCacheSize();
+        if (max_cache_size > 0)
+        {
+            cache_context.cache = CreateSubBlockCache();
+            cache_context.prune_options.maxMemoryUsage = max_cache_size;
+        }
 
         IntSize tileSize = { 512, 512 };
 

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -60,14 +60,18 @@ public:
 protected:
     static void WriteRoi(const shared_ptr<ISingleChannelScalingTileAccessor>& accessor, const CDimCoordinate& coordinate, const IntRect& roi, const CacheContext& cache_context, const CCmdLineOptions& options)
     {
-        libCZI::ISingleChannelScalingTileAccessor::Options scstaOptions; scstaOptions.Clear();
+        libCZI::ISingleChannelScalingTileAccessor::Options scstaOptions;
+        scstaOptions.Clear();
         scstaOptions.backGroundColor = GetBackgroundColorFromOptions(options);
         scstaOptions.sceneFilter = options.GetSceneIndexSet();
         scstaOptions.subBlockCache = cache_context.cache;
 
         auto bitmap = accessor->Get(roi, &coordinate, options.GetZoom(), &scstaOptions);
 
-        cache_context.cache->Prune(cache_context.prune_options);
+        if (cache_context.cache)
+        {
+            cache_context.cache->Prune(cache_context.prune_options);
+        }
 
         auto filename = GetFileName(options, roi);
         auto saver = CSaveBitmapFactory::CreateSaveBitmapObj(nullptr);

--- a/Src/CZICmd/executePlaneScan.cpp
+++ b/Src/CZICmd/executePlaneScan.cpp
@@ -4,11 +4,64 @@
 
 #include "stdafx.h"
 #include "executePlaneScan.h"
+#include "executeBase.h"
 
 using namespace std;
 using namespace libCZI;
 
+class CExecutePlaneScan : public CExecuteBase
+{
+protected:
+    struct CacheContext
+    {
+        shared_ptr<ISubBlockCache> cache;
+        ISubBlockCache::PruneOptions prune_options;
+    };
+public:
+    static bool execute(const CCmdLineOptions& options)
+    {
+        auto reader = CreateAndOpenCziReader(options);
+        const auto subblock_statistics = reader->GetStatistics();
+        auto accessor = reader->CreateSingleChannelScalingTileAccessor();
+
+        auto roi = GetRoiFromOptions(options, subblock_statistics);
+        CDimCoordinate coordinate = options.GetPlaneCoordinate();
+
+
+        CacheContext cache_context;
+        cache_context.cache = CreateSubBlockCache();
+        cache_context.prune_options.maxMemoryUsage = 40 * 1024 * 1024;
+
+        IntSize tileSize = { 512, 512 };
+
+        for (int y = roi.y; y < roi.y + roi.h; y += tileSize.h)
+        {
+            for (int x = roi.x; x < roi.x + roi.w; x += tileSize.w)
+            {
+                IntRect tileRect = { x, y, (int)tileSize.w, (int)tileSize.h };
+                WriteRoi(accessor, coordinate, tileRect, cache_context, options);
+            }
+        }
+
+        return true;
+        //for (int x = 0; x < statistics.boundingBoxLayer0Only.w / size_x; ++x)
+    //auto re = accessor->Get(roi, &coordinate, options.GetZoom(), &scstaOptions);
+    }
+protected:
+    static void WriteRoi(const shared_ptr<ISingleChannelScalingTileAccessor>& accessor, const CDimCoordinate& coordinate, const IntRect& roi, const CacheContext& cache_context, const CCmdLineOptions& options)
+    {
+        libCZI::ISingleChannelScalingTileAccessor::Options scstaOptions; scstaOptions.Clear();
+        scstaOptions.backGroundColor = GetBackgroundColorFromOptions(options);
+        scstaOptions.sceneFilter = options.GetSceneIndexSet();
+        scstaOptions.subBlockCache = cache_context.cache;
+
+        auto bitmap = accessor->Get(roi, &coordinate, options.GetZoom(), &scstaOptions);
+
+        cache_context.cache->Prune(cache_context.prune_options);
+    }
+};
+
 bool executePlaneScan(const CCmdLineOptions& options)
 {
-    return false;
+    return CExecutePlaneScan::execute(options);
 }

--- a/Src/CZICmd/executePlaneScan.h
+++ b/Src/CZICmd/executePlaneScan.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+#include "cmdlineoptions.h"
+
+bool executePlaneScan(const CCmdLineOptions& options);

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -114,6 +114,8 @@ set(LIBCZISRCFILES
             StreamsLib/simplefileinputstream.h
             StreamsLib/preadfileinputstream.cpp
             StreamsLib/preadfileinputstream.h
+            subblock_cache.h
+            subblock_cache.cpp
 )
 
 # prepare the configuration-file "libCZI_Config.h"

--- a/Src/libCZI/Doc/CZICmd_usage.markdown
+++ b/Src/libCZI/Doc/CZICmd_usage.markdown
@@ -7,222 +7,248 @@ The console application "CZIcmd" is provided for two purposes:
 
 The synopsis of the program is:
 
-    Usage: CZIcmd.exe [OPTIONS]
+```
+Usage: CZIcmd.exe [OPTIONS]
 
-      using libCZI version 0.54.0
-    
-    Options:
-      -h,--help         Print this help message and exit
-    
-      -c,--command COMMAND
-                        COMMAND can be one of 'PrintInformation', 'ExtractSubBlock',
-                        'SingleChannelTileAccessor', 'ChannelComposite',
-                        'SingleChannelPyramidTileAccessor',
-                        'SingleChannelScalingTileAccessor',
-                        'ScalingChannelComposite', 'ExtractAttachment' and
-                        'CreateCZI'.
-    
-                        'PrintInformation' will print information about the CZI-file
-                        to the console. The argument 'info-level' can be used to
-                        specify which information is to be printed.
-    
-                        'ExtractSubBlock' will write the bitmap contained in the
-                        specified sub-block to the OUTPUTFILE.
-    
-                        'ChannelComposite' will create a channel-composite of the
-                        specified region and plane and apply display-settings to it.
-                        The resulting bitmap will be written to the specified
-                        OUTPUTFILE.
-    
-                        'SingleChannelTileAccessor' will create a tile-composite
-                        (only from sub-blocks on pyramid-layer 0) of the specified
-                        region and plane. The resulting bitmap will be written to
-                        the specified OUTPUTFILE.
-    
-                        'SingleChannelPyramidTileAccessor' adds to the previous
-                        command the ability to explictely address a specific
-                        pyramid-layer (which must exist in the CZI-document).
-    
-                        'SingleChannelScalingTileAccessor' gets the specified region
-                        with an arbitrary zoom factor. It uses the pyramid-layers in
-                        the CZI-document and scales the bitmap if necessary. The
-                        resulting bitmap will be written to the specified
-                        OUTPUTFILE.
-    
-                        'ScalingChannelComposite' operates like the previous
-                        command, but in addition gets all channels and creates a
-                        multi-channel-composite from them using display-settings.
-    
-                        'ExtractAttachment' allows to extract (and save to a file)
-                        the contents of attachments.)
-    
-                        'CreateCZI' is used to demonstrate the CZI-creation
-                        capabilities of libCZI.
-    
-      -s,--source SOURCEFILE
-                        Specifies the source CZI-file.
-    
-      --source-stream-class STREAMCLASS
-                        Specifies the stream-class used for reading the source
-                        CZI-file. If not specified, the default file-reader
-                        stream-class is used. Run with argument '--version' to get a
-                        list of available stream-classes.
-    
-      --propbag-source-stream-creation PROPBAG
-                        Specifies the property-bag used for creating the stream used
-                        for reading the source CZI-file. The data is given in
-                        JSON-notation.
-    
-      -o,--output OUTPUTFILE
-                        specifies the output-filename. A suffix will be appended to
-                        the name given here depending on the type of the file.
-    
-      -p,--plane-coordinate PLANE-COORDINATE
-                        Uniquely select a 2D-plane from the document. It is given in
-                        the form [DimChar][number], where 'DimChar' specifies a
-                        dimension and can be any of 'Z', 'C', 'T', 'R', 'I', 'H',
-                        'V' or 'B'. 'number' is an integer.
-                        Examples: C1T3, C0T-2, C1T44Z15H1.
-    
-      -r,--rect ROI     Select a paraxial rectangular region as the
-                        region-of-interest. The coordinates may be given either
-                        absolute or relative. If using relative coordinates, they
-                        are relative to what is determined as the upper-left point
-                        in the document.\nRelative coordinates are specified with
-                        the syntax 'rel([x],[y],[width],[height])', absolute
-                        coordinates are specified 'abs([x],[y],[width],[height])'.
-                        Examples: rel(0, 0, 1024, 1024), rel(-100, -100, 500, 500),
-                        abs(-230, 100, 800, 800).
-    
-      -d,--display-settings DISPLAYSETTINGS
-                        Specifies the display-settings used for creating a
-                        channel-composite. The data is given in JSON-notation.
-    
-      --calc-hash       Calculate a hash of the output-picture. The MD5Sum-algorithm
-                        is used for this.
-    
-      -t,--drawtileboundaries
-                        Draw a one-pixel black line around each tile.
-    
-      -j,--jpgxrcodec DECODERNAME
-                        Choose which decoder implementation is used. Specifying
-                        "WIC" will request the Windows-provided decoder - which is
-                        only available on Windows.By default the internal
-                        JPG-XR-decoder is used.
-    
-      -v,--verbosity VERBOSITYLEVEL
-                        Set the verbosity of this program. The argument is a comma-
-                        or semicolon-separated list of the following strings :
-                        'All', 'Errors', 'Warnings', 'Infos', 'Errors1',
-                        'Warnings1', 'Infos1', 'Errors2', 'Warnings2', 'Infos2'.
-    
-      -b,--background BACKGROUND
-                        Specify the background color. BACKGROUND is either a single
-                        float or three floats, separated by a comma or semicolon. In
-                        case of a single float, it gives a grayscale value, in case
-                        of three floats it gives a RGB - value.The floats are given
-                        normalized to a range from 0 to 1.
-    
-      -y,--pyramidinfo PYRAMIDINFO
-                        For the command 'SingleChannelPyramidTileAccessor' the
-                        argument PYRAMIDINFO specifies the pyramid layer. It
-                        consists of two integers(separated by a comma, semicolon or
-                        pipe-symbol), where the first specifies the
-                        minification-factor (between pyramid-layers) and the second
-                        the pyramid-layer (starting with 0 for the layer with the
-                        highest resolution).
-    
-      -z,--zoom ZOOM    The zoom-factor (which is used for the commands
-                        'SingleChannelScalingTileAccessor' and
-                        'ScalingChannelComposite'). It is a float between 0 and 1.
-    
-      -i,--info-level INFO-LEVEL
-                        When using the command 'PrintInformation' the INFO-LEVEL can
-                        be used to specify which information is printed. Possible
-                        values are "Statistics", "RawXML", "DisplaySettings",
-                        "DisplaySettingsJson", "AllSubBlocks", "Attachments",
-                        "AllAttachments", "PyramidStatistics", "GeneralInfo",
-                        "ScalingInfo" and "All". The values are given as a list
-                        separated by comma or semicolon.
-    
-      -e,--selection SELECTION
-                        For the command 'ExtractAttachment' this allows to specify a
-                        subset which is to be extracted (and saved to a file). It is
-                        possible to specify the name and the index - only
-                        attachments for which the name/index is equal to those
-                        values specified are processed. The arguments are given in
-                        JSON-notation, e.g. {"name":"Thumbnail"} or {"index":3.0}.
-    
-      -f,--tile-filter FILTER
-                        Specify to filter subblocks according to the scene-index. A
-                        comma separated list of either an interval or a single
-                        integer may be given here, e.g. "2,3" or "2-4,6" or
-                        "0-3,5-8".
-    
-      -m,--channelcompositionformat CHANNELCOMPOSITIONFORMAT
-                        In case of a channel-composition, specifies the pixeltype of
-                        the output. Possible values are "bgr24" (the default) and
-                        "bgra32". If specifying "bgra32" it is possible to give the
-                        value of the alpha-pixels in the form "bgra32(128)" - for an
-                        alpha-value of 128.
-    
-      --createbounds BOUNDS
-                        Only used for 'CreateCZI': specify the range of coordinates
-                        used to create a CZI. Format is e.g. 'T0:3Z0:3C0:2'.
-    
-      --createsubblocksize SIZE
-                        Only used for 'CreateCZI': specify the size of the subblocks
-                        created in pixels. Format is e.g. '1600x1200'.
-    
-      --createtileinfo TILEINFO
-                        Only used for 'CreateCZI': specify the number of tiles on
-                        each plane. Format is e.g. '3x3;10%' for a 3 by 3 tiles
-                        arrangement with 10% overlap.
-    
-      --font NAME/FILENAME
-                        Only used for 'CreateCZI': (on Linux) specify the filename
-                        of a TrueType-font (.ttf) to be used for generating text in
-                        the subblocks; (on Windows) name of the font.
-    
-      --fontheight HEIGHT
-                        Only used for 'CreateCZI': specifies the height of the font
-                        in pixels (default: 36).
-    
-      -g,--guidofczi CZI-File-GUID
-                        Only used for 'CreateCZI': specify the GUID of the file
-                        (which is useful for bit-exact reproducible results); the
-                        GUID must be given in the form
-                        "cfc4a2fe-f968-4ef8-b685-e73d1b77271a" or
-                        "{cfc4a2fe-f968-4ef8-b685-e73d1b77271a}"
-    
-      --bitmapgenerator BITMAPGENERATORCLASSNAME
-                        Only used for 'CreateCZI': specifies the bitmap-generator to
-                        use. Possibly values are "gdi", "freetype", "null" or
-                        "default". Run with argument '--version' to get a list of
-                        available bitmap-generators.
-    
-      --createczisbblkmetadata KEY_VALUE_SUBBLOCKMETADATA
-                        Only used for 'CreateCZI': a key-value list in JSON-notation
-                        which will be written as subblock-metadata. For example:
-                        {"StageXPosition":-8906.346,"StageYPosition":-648.51}
-    
-      --compressionopts COMPRESSIONDESCRIPTION
-                        Only used for 'CreateCZI': a string in a defined format
-                        which states the compression-method and (compression-method
-                        specific) parameters.The format is "compression_method:
-                        key=value; ...". It starts with the name of the
-                        compression-method, followed by a colon, then followed by a
-                        list of key-value pairs which are separated by a semicolon.
-                        Examples: "zstd0:ExplicitLevel=3",
-                        "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack".
-    
-      --generatorpixeltype PIXELTYPE
-                        Only used for 'CreateCZI': a string defining the pixeltype
-                        used by the bitmap - generator. Possible values are 'Gray8',
-                        'Gray16', 'Bgr24' or 'Bgr48'. Default is 'Bgr24'.
-    
-      --version         Print extended version-info and supported operations, then
-                        exit.
+  using libCZI version 0.57.0
+
+Options:
+  -h,--help         Print this help message and exit
+
+  -c,--command COMMAND
+                    COMMAND can be one of 'PrintInformation', 'ExtractSubBlock',
+                    'SingleChannelTileAccessor', 'ChannelComposite',
+                    'SingleChannelPyramidTileAccessor',
+                    'SingleChannelScalingTileAccessor',
+                    'ScalingChannelComposite', 'ExtractAttachment' and
+                    'CreateCZI'.
+
+                    'PrintInformation' will print information about the CZI-file
+                    to the console. The argument 'info-level' can be used to
+                    specify which information is to be printed.
+
+                    'ExtractSubBlock' will write the bitmap contained in the
+                    specified sub-block to the OUTPUTFILE.
+
+                    'ChannelComposite' will create a channel-composite of the
+                    specified region and plane and apply display-settings to it.
+                    The resulting bitmap will be written to the specified
+                    OUTPUTFILE.
+
+                    'SingleChannelTileAccessor' will create a tile-composite
+                    (only from sub-blocks on pyramid-layer 0) of the specified
+                    region and plane. The resulting bitmap will be written to
+                    the specified OUTPUTFILE.
+
+                    'SingleChannelPyramidTileAccessor' adds to the previous
+                    command the ability to explicitly address a specific
+                    pyramid-layer (which must exist in the CZI-document).
+
+                    'SingleChannelScalingTileAccessor' gets the specified region
+                    with an arbitrary zoom factor. It uses the pyramid-layers in
+                    the CZI-document and scales the bitmap if necessary. The
+                    resulting bitmap will be written to the specified
+                    OUTPUTFILE.
+
+                    'ScalingChannelComposite' operates like the previous
+                    command, but in addition gets all channels and creates a
+                    multi-channel-composite from them using display-settings.
+
+                    'ExtractAttachment' allows to extract (and save to a file)
+                    the contents of attachments.)
+
+                    'CreateCZI' is used to demonstrate the CZI-creation
+                    capabilities of libCZI.)
+
+                    'PlaneScan' does the following: over a ROI given with the
+                    --rect option a rectangle of size given with the
+                    --tilesize-for-plane-scan option is moved, and the image
+                    content of this rectangle is written out to files. The
+                    operation takes place on a plane which is given with the
+                    --plane-coordinate option. The filenames of the tile-bitmaps
+                    are generated from the filename given with the --output
+                    option, where a string
+                    _X[x-position]_Y[y-position]_W[width]_H[height] is added.
+
+  -s,--source SOURCEFILE
+                    Specifies the source CZI-file.
+
+  --source-stream-class STREAMCLASS
+                    Specifies the stream-class used for reading the source
+                    CZI-file. If not specified, the default file-reader
+                    stream-class is used. Run with argument '--version' to get a
+                    list of available stream-classes.
+
+  --propbag-source-stream-creation PROPBAG
+                    Specifies the property-bag used for creating the stream used
+                    for reading the source CZI-file. The data is given in
+                    JSON-notation.
+
+  -o,--output OUTPUTFILE
+                    specifies the output-filename. A suffix will be appended to
+                    the name given here depending on the type of the file.
+
+  -p,--plane-coordinate PLANE-COORDINATE
+                    Uniquely select a 2D-plane from the document. It is given in
+                    the form [DimChar][number], where 'DimChar' specifies a
+                    dimension and can be any of 'Z', 'C', 'T', 'R', 'I', 'H',
+                    'V' or 'B'. 'number' is an integer.
+                    Examples: C1T3, C0T-2, C1T44Z15H1.
+
+  -r,--rect ROI     Select a paraxial rectangular region as the
+                    region-of-interest. The coordinates may be given either
+                    absolute or relative. If using relative coordinates, they
+                    are relative to what is determined as the upper-left point
+                    in the document.\nRelative coordinates are specified with
+                    the syntax 'rel([x],[y],[width],[height])', absolute
+                    coordinates are specified 'abs([x],[y],[width],[height])'.
+                    Examples: rel(0, 0, 1024, 1024), rel(-100, -100, 500, 500),
+                    abs(-230, 100, 800, 800).
+
+  -d,--display-settings DISPLAYSETTINGS
+                    Specifies the display-settings used for creating a
+                    channel-composite. The data is given in JSON-notation.
+
+  --calc-hash       Calculate a hash of the output-picture. The MD5Sum-algorithm
+                    is used for this.
+
+  -t,--drawtileboundaries
+                    Draw a one-pixel black line around each tile.
+
+  -j,--jpgxrcodec DECODERNAME
+                    Choose which decoder implementation is used. Specifying
+                    "WIC" will request the Windows-provided decoder - which is
+                    only available on Windows.By default the internal
+                    JPG-XR-decoder is used.
+
+  -v,--verbosity VERBOSITYLEVEL
+                    Set the verbosity of this program. The argument is a comma-
+                    or semicolon-separated list of the following strings :
+                    'All', 'Errors', 'Warnings', 'Infos', 'Errors1',
+                    'Warnings1', 'Infos1', 'Errors2', 'Warnings2', 'Infos2'.
+
+  -b,--background BACKGROUND
+                    Specify the background color. BACKGROUND is either a single
+                    float or three floats, separated by a comma or semicolon. In
+                    case of a single float, it gives a grayscale value, in case
+                    of three floats it gives a RGB - value.The floats are given
+                    normalized to a range from 0 to 1.
+
+  -y,--pyramidinfo PYRAMIDINFO
+                    For the command 'SingleChannelPyramidTileAccessor' the
+                    argument PYRAMIDINFO specifies the pyramid layer. It
+                    consists of two integers(separated by a comma, semicolon or
+                    pipe-symbol), where the first specifies the
+                    minification-factor (between pyramid-layers) and the second
+                    the pyramid-layer (starting with 0 for the layer with the
+                    highest resolution).
+
+  -z,--zoom ZOOM    The zoom-factor (which is used for the commands
+                    'SingleChannelScalingTileAccessor' and
+                    'ScalingChannelComposite'). It is a float between 0 and 1.
+
+  -i,--info-level INFO-LEVEL
+                    When using the command 'PrintInformation' the INFO-LEVEL can
+                    be used to specify which information is printed. Possible
+                    values are "Statistics", "RawXML", "DisplaySettings",
+                    "DisplaySettingsJson", "AllSubBlocks", "Attachments",
+                    "AllAttachments", "PyramidStatistics", "GeneralInfo",
+                    "ScalingInfo" and "All". The values are given as a list
+                    separated by comma or semicolon.
+
+  -e,--selection SELECTION
+                    For the command 'ExtractAttachment' this allows to specify a
+                    subset which is to be extracted (and saved to a file). It is
+                    possible to specify the name and the index - only
+                    attachments for which the name/index is equal to those
+                    values specified are processed. The arguments are given in
+                    JSON-notation, e.g. {"name":"Thumbnail"} or {"index":3.0}.
+
+  -f,--tile-filter FILTER
+                    Specify to filter subblocks according to the scene-index. A
+                    comma separated list of either an interval or a single
+                    integer may be given here, e.g. "2,3" or "2-4,6" or
+                    "0-3,5-8".
+
+  -m,--channelcompositionformat CHANNELCOMPOSITIONFORMAT
+                    In case of a channel-composition, specifies the pixeltype of
+                    the output. Possible values are "bgr24" (the default) and
+                    "bgra32". If specifying "bgra32" it is possible to give the
+                    value of the alpha-pixels in the form "bgra32(128)" - for an
+                    alpha-value of 128.
+
+  --createbounds BOUNDS
+                    Only used for 'CreateCZI': specify the range of coordinates
+                    used to create a CZI. Format is e.g. 'T0:3Z0:3C0:2'.
+
+  --createsubblocksize SIZE
+                    Only used for 'CreateCZI': specify the size of the subblocks
+                    created in pixels. Format is e.g. '1600x1200'.
+
+  --createtileinfo TILEINFO
+                    Only used for 'CreateCZI': specify the number of tiles on
+                    each plane. Format is e.g. '3x3;10%' for a 3 by 3 tiles
+                    arrangement with 10% overlap.
+
+  --font NAME/FILENAME
+                    Only used for 'CreateCZI': (on Linux) specify the filename
+                    of a TrueType-font (.ttf) to be used for generating text in
+                    the subblocks; (on Windows) name of the font.
+
+  --fontheight HEIGHT
+                    Only used for 'CreateCZI': specifies the height of the font
+                    in pixels (default: 36).
+
+  -g,--guidofczi CZI-File-GUID
+                    Only used for 'CreateCZI': specify the GUID of the file
+                    (which is useful for bit-exact reproducible results); the
+                    GUID must be given in the form
+                    "cfc4a2fe-f968-4ef8-b685-e73d1b77271a" or
+                    "{cfc4a2fe-f968-4ef8-b685-e73d1b77271a}"
+
+  --bitmapgenerator BITMAPGENERATORCLASSNAME
+                    Only used for 'CreateCZI': specifies the bitmap-generator to
+                    use. Possibly values are "gdi", "freetype", "null" or
+                    "default". Run with argument '--version' to get a list of
+                    available bitmap-generators.
+
+  --createczisbblkmetadata KEY_VALUE_SUBBLOCKMETADATA
+                    Only used for 'CreateCZI': a key-value list in JSON-notation
+                    which will be written as subblock-metadata. For example:
+                    {"StageXPosition":-8906.346,"StageYPosition":-648.51}
+
+  --compressionopts COMPRESSIONDESCRIPTION
+                    Only used for 'CreateCZI': a string in a defined format
+                    which states the compression-method and (compression-method
+                    specific) parameters.The format is "compression_method:
+                    key=value; ...". It starts with the name of the
+                    compression-method, followed by a colon, then followed by a
+                    list of key-value pairs which are separated by a semicolon.
+                    Examples: "zstd0:ExplicitLevel=3",
+                    "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack".
+
+  --generatorpixeltype PIXELTYPE
+                    Only used for 'CreateCZI': a string defining the pixeltype
+                    used by the bitmap - generator. Possible values are 'Gray8',
+                    'Gray16', 'Bgr24' or 'Bgr48'. Default is 'Bgr24'.
+
+  --cachesize CACHESIZE
+                    Only used for 'PlaneScan' - specify the size of the
+                    subblock-cache in bytes. The argument is to be given with a
+                    suffix k, M, G, ...
+
+  --tilesize-for-plane-scan TILESIZE
+                    Only used for 'PlaneScan' - specify the size of ROI which is
+                    used for scanning the plane in units of pixels. Format is
+                    e.g. '1600x1200' and default is 512x512.
+
+  --use-visibility-check-optimization
+                    Whether to enable the experimental "visibility check
+                    optimization" for the accessors.
+
+  --version         Print extended version-info and supported operations, then
+                    exit.
+```
 
 The above text is printed if the program is executed with the argument '-?' or '\--help':
 

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -12,3 +12,4 @@ version history                 {#version_history}
  0.55.0             | [78](https://github.com/ZEISS/libczi/pull/78)        | optimization: for multi-tile-composition, check relevant tiles for visibility before loading them (and do not load/decode non-visible tiles)
  0.55.1             | [80](https://github.com/ZEISS/libczi/pull/80)        | bugfix for above optimization
  0.56.0             | [82](https://github.com/ZEISS/libczi/pull/82)        | add option "kCurlHttp_CaInfo" & "kCurlHttp_CaInfoBlob", allow to retrieve properties from a stream-class
+ 0.57.0             | [84](https://github.com/ZEISS/libczi/pull/84)        | add caching for accessors, update CLI11 to version 2.3.2

--- a/Src/libCZI/SingleChannelAccessorBase.cpp
+++ b/Src/libCZI/SingleChannelAccessorBase.cpp
@@ -156,7 +156,6 @@ std::vector<int> CSingleChannelAccessorBase::CheckForVisibility(const libCZI::In
         {
             sbBlkRepository->TryGetSubBlockInfo(subBlockIndex, &result.subBlockInfo);
             result.bitmap = bitmap_from_cache;
-            return result;
         }
         else
         {
@@ -164,7 +163,6 @@ std::vector<int> CSingleChannelAccessorBase::CheckForVisibility(const libCZI::In
             result.bitmap = subblock->CreateBitmap();
             cache->Add(subBlockIndex, result.bitmap);
             result.subBlockInfo = subblock->GetSubBlockInfo();
-            return result;
         }
     }
 

--- a/Src/libCZI/SingleChannelAccessorBase.h
+++ b/Src/libCZI/SingleChannelAccessorBase.h
@@ -75,6 +75,7 @@ protected:
 
     static SubBlockData GetSubBlockDataForSubBlockIndex(
         const std::shared_ptr<libCZI::ISubBlockRepository>& sbBlkRepository, 
-        const std::shared_ptr<libCZI::ISubBlockCache>& cache,
-        int subBlockIndex);
+        const std::shared_ptr<libCZI::ISubBlockCacheOperation>& cache,
+        int subBlockIndex,
+        bool onlyAddCompressedSubBlockToCache);
 };

--- a/Src/libCZI/SingleChannelAccessorBase.h
+++ b/Src/libCZI/SingleChannelAccessorBase.h
@@ -66,4 +66,15 @@ protected:
     ///             given here, then the result is guaranteed to be the same as if all subblocks were rendered. Non-visible subblocks are not
     ///             part of this list.
     static std::vector<int> CheckForVisibilityCore(const libCZI::IntRect& roi, int count, const std::function<int(int)>& get_subblock_index, const std::function<libCZI::IntRect(int)>& get_rect_of_subblock);
+
+    struct SubBlockData
+    {
+        std::shared_ptr<libCZI::IBitmapData> bitmap;
+        libCZI::SubBlockInfo subBlockInfo;
+    };
+
+    static SubBlockData GetSubBlockDataForSubBlockIndex(
+        const std::shared_ptr<libCZI::ISubBlockRepository>& sbBlkRepository, 
+        const std::shared_ptr<libCZI::ISubBlockCache>& cache,
+        int subBlockIndex);
 };

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -103,11 +103,19 @@ void CSingleChannelPyramidLevelTileAccessor::ComposeTiles(libCZI::IBitmapData* b
         {
             if (index < bitmapCnt)
             {
-                SbInfo sbinfo = getSbInfo(index);
+                /*SbInfo sbinfo = getSbInfo(index);
                 auto sb = this->sbBlkRepository->ReadSubBlock(sbinfo.index);
                 spBm = sb->CreateBitmap();
                 xPosTile = (sb->GetSubBlockInfo().logicalRect.x - xPos) / sizeOfPixel;
-                yPosTile = (sb->GetSubBlockInfo().logicalRect.y - yPos) / sizeOfPixel;
+                yPosTile = (sb->GetSubBlockInfo().logicalRect.y - yPos) / sizeOfPixel;*/
+                const SbInfo sbinfo = getSbInfo(index);
+                const auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
+                        this->sbBlkRepository,
+                        options.subBlockCache,
+                        sbinfo.index);
+                spBm = subblock_bitmap_data.bitmap;
+                xPosTile = (subblock_bitmap_data.subBlockInfo.logicalRect.x - xPos) / sizeOfPixel;
+                yPosTile = (subblock_bitmap_data.subBlockInfo.logicalRect.y - yPos) / sizeOfPixel;
                 return true;
             }
 

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -107,7 +107,8 @@ void CSingleChannelPyramidLevelTileAccessor::ComposeTiles(libCZI::IBitmapData* b
                 const auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,
                         options.subBlockCache,
-                        sbinfo.index);
+                        sbinfo.index,
+                        options.onlyUseSubBlockCacheForCompressedData);
                 spBm = subblock_bitmap_data.bitmap;
                 xPosTile = (subblock_bitmap_data.subBlockInfo.logicalRect.x - xPos) / sizeOfPixel;
                 yPosTile = (subblock_bitmap_data.subBlockInfo.logicalRect.y - yPos) / sizeOfPixel;

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -137,7 +137,7 @@ libCZI::IntRect CSingleChannelPyramidLevelTileAccessor::CalcDestinationRectFromS
 
 libCZI::IntRect CSingleChannelPyramidLevelTileAccessor::NormalizePyramidRect(int x, int y, int w, int h, const PyramidLayerInfo& pyramidInfo)
 {
-    const int p = this->CalcSizeOfPixelOnLayer0(pyramidInfo);
+    const int p = CSingleChannelPyramidLevelTileAccessor::CalcSizeOfPixelOnLayer0(pyramidInfo);
     return IntRect{ x,y,w * p,h * p };
 }
 

--- a/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelPyramidLevelTileAccessor.cpp
@@ -103,11 +103,6 @@ void CSingleChannelPyramidLevelTileAccessor::ComposeTiles(libCZI::IBitmapData* b
         {
             if (index < bitmapCnt)
             {
-                /*SbInfo sbinfo = getSbInfo(index);
-                auto sb = this->sbBlkRepository->ReadSubBlock(sbinfo.index);
-                spBm = sb->CreateBitmap();
-                xPosTile = (sb->GetSubBlockInfo().logicalRect.x - xPos) / sizeOfPixel;
-                yPosTile = (sb->GetSubBlockInfo().logicalRect.y - yPos) / sizeOfPixel;*/
                 const SbInfo sbinfo = getSbInfo(index);
                 const auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -80,17 +80,6 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(const std::
 
 void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo, const libCZI::ISingleChannelScalingTileAccessor::Options& options)
 {
-    /*
-    const auto sb = this->sbBlkRepository->ReadSubBlock(sbInfo.index);
-    if (GetSite()->IsEnabled(LOGLEVEL_CHATTYINFORMATION))
-    {
-        stringstream ss;
-        ss << "   bounds: " << Utils::DimCoordinateToString(&sb->GetSubBlockInfo().coordinate) << " M=" << (Utils::IsValidMindex(sbInfo.mIndex) ? to_string(sbInfo.mIndex) : "invalid");
-        GetSite()->Log(LOGLEVEL_CHATTYINFORMATION, ss);
-    }
-
-    const auto source = sb->CreateBitmap();
-    */
     auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
         this->sbBlkRepository,
         options.subBlockCache,

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -78,8 +78,9 @@ CSingleChannelScalingTileAccessor::CSingleChannelScalingTileAccessor(const std::
     return IntSize{ static_cast<uint32_t>(roi.w * zoom),static_cast<uint32_t>(roi.h * zoom) };
 }
 
-void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo)
+void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo, const libCZI::ISingleChannelScalingTileAccessor::Options& options)
 {
+    /*
     const auto sb = this->sbBlkRepository->ReadSubBlock(sbInfo.index);
     if (GetSite()->IsEnabled(LOGLEVEL_CHATTYINFORMATION))
     {
@@ -89,6 +90,19 @@ void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, fl
     }
 
     const auto source = sb->CreateBitmap();
+    */
+    auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
+        this->sbBlkRepository,
+        options.subBlockCache,
+        sbInfo.index);
+    if (GetSite()->IsEnabled(LOGLEVEL_CHATTYINFORMATION))
+    {
+        stringstream ss;
+        ss << "   bounds: " << Utils::DimCoordinateToString(&subblock_bitmap_data.subBlockInfo.coordinate) << " M=" << (Utils::IsValidMindex(subblock_bitmap_data.subBlockInfo.mIndex) ? to_string(subblock_bitmap_data.subBlockInfo.mIndex) : "invalid");
+        GetSite()->Log(LOGLEVEL_CHATTYINFORMATION, ss);
+    }
+
+    const auto& source = subblock_bitmap_data.bitmap;
 
     // In order not to run into trouble with floating point precision, if the scale is exactly 1, we refrain from using the scaling operation
     //  and do instead a simple copy operation. This should ensure a pixel-accurate result if zoom is exactly 1.
@@ -118,15 +132,15 @@ void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, fl
         // calculate the intersection of the subblock (logical rect) and the destination
         const auto intersect = Utilities::Intersect(sbInfo.logicalRect, roi);
 
-        const double roiSrcTopLeftX = double(intersect.x - sbInfo.logicalRect.x) / sbInfo.logicalRect.w;
-        const double roiSrcTopLeftY = double(intersect.y - sbInfo.logicalRect.y) / sbInfo.logicalRect.h;
-        const double roiSrcBttmRightX = double(intersect.x + intersect.w - sbInfo.logicalRect.x) / sbInfo.logicalRect.w;
-        const double roiSrcBttmRightY = double(intersect.y + intersect.h - sbInfo.logicalRect.y) / sbInfo.logicalRect.h;
+        const double roiSrcTopLeftX = static_cast<double>(intersect.x - sbInfo.logicalRect.x) / sbInfo.logicalRect.w;
+        const double roiSrcTopLeftY = static_cast<double>(intersect.y - sbInfo.logicalRect.y) / sbInfo.logicalRect.h;
+        const double roiSrcBttmRightX = static_cast<double>(intersect.x + intersect.w - sbInfo.logicalRect.x) / sbInfo.logicalRect.w;
+        const double roiSrcBttmRightY = static_cast<double>(intersect.y + intersect.h - sbInfo.logicalRect.y) / sbInfo.logicalRect.h;
 
-        const double destTopLeftX = double(intersect.x - roi.x) / roi.w;
-        const double destTopLeftY = double(intersect.y - roi.y) / roi.h;
-        const double destBttmRightX = double(intersect.x + intersect.w - roi.x) / roi.w;
-        const double destBttmRightY = double(intersect.y + intersect.h - roi.y) / roi.h;
+        const double destTopLeftX = static_cast<double>(intersect.x - roi.x) / roi.w;
+        const double destTopLeftY = static_cast<double>(intersect.y - roi.y) / roi.h;
+        const double destBttmRightX = static_cast<double>(intersect.x + intersect.w - roi.x) / roi.w;
+        const double destBttmRightY = static_cast<double>(intersect.y + intersect.h - roi.y) / roi.h;
 
         DblRect srcRoi{ roiSrcTopLeftX ,roiSrcTopLeftY,roiSrcBttmRightX - roiSrcTopLeftX ,roiSrcBttmRightY - roiSrcTopLeftY };
         DblRect dstRoi{ destTopLeftX ,destTopLeftY,destBttmRightX - destTopLeftX ,destBttmRightY - destTopLeftY };
@@ -292,19 +306,19 @@ void CSingleChannelScalingTileAccessor::InternalGet(libCZI::IBitmapData* bmDest,
         // we only have to deal with a single scene (or: the document does not include a scene-dimension at all), in this
         //  case we do not have group by scene and save some cycles
         auto sbSetsortedByZoom = this->GetSubSetFilteredBySceneSortedByZoom(roi, planeCoordinate, scenesInvolved, options.sortByM);
-        this->Paint(bmDest, roi, sbSetsortedByZoom, zoom, options.useVisibilityCheckOptimization);
+        this->Paint(bmDest, roi, sbSetsortedByZoom, zoom, options/*.useVisibilityCheckOptimization*/);
     }
     else
     {
         const auto sbSetSortedByZoomPerScene = this->GetSubSetSortedByZoomPerScene(scenesInvolved, roi, planeCoordinate, options.sortByM);
         for (const auto& it : sbSetSortedByZoomPerScene)
         {
-            this->Paint(bmDest, roi, get<1>(it), zoom, options.useVisibilityCheckOptimization);
+            this->Paint(bmDest, roi, get<1>(it), zoom, options/*.useVisibilityCheckOptimization*/);
         }
     }
 }
 
-void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, bool useCoverageOptimization)
+void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options/*bool useCoverageOptimization*/)
 {
     const int idxOf1stSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, zoom);
     if (idxOf1stSubBlockOfZoomGreater < 0)
@@ -334,7 +348,7 @@ void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const
         }
     }
 
-    if (!useCoverageOptimization)
+    if (!/*useCoverageOptimization*/options.useVisibilityCheckOptimization)
     {
         for (auto it = start_iterator; it != end_iterator; ++it)
         {
@@ -347,7 +361,7 @@ void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const
                 GetSite()->Log(LOGLEVEL_CHATTYINFORMATION, ss);
             }
 
-            this->ScaleBlt(bmDest, zoom, roi, sbInfo);
+            this->ScaleBlt(bmDest, zoom, roi, sbInfo, options);
         }
     }
     else
@@ -375,7 +389,7 @@ void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const
                 GetSite()->Log(LOGLEVEL_CHATTYINFORMATION, ss);
             }
 
-            this->ScaleBlt(bmDest, zoom, roi, sbInfo);
+            this->ScaleBlt(bmDest, zoom, roi, sbInfo, options);
         }
     }
 }

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -83,7 +83,8 @@ void CSingleChannelScalingTileAccessor::ScaleBlt(libCZI::IBitmapData* bmDest, fl
     auto subblock_bitmap_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
         this->sbBlkRepository,
         options.subBlockCache,
-        sbInfo.index);
+        sbInfo.index,
+        options.onlyUseSubBlockCacheForCompressedData);
     if (GetSite()->IsEnabled(LOGLEVEL_CHATTYINFORMATION))
     {
         stringstream ss;

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -308,7 +308,7 @@ void CSingleChannelScalingTileAccessor::InternalGet(libCZI::IBitmapData* bmDest,
     }
 }
 
-void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options/*bool useCoverageOptimization*/)
+void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options)
 {
     const int idxOf1stSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, zoom);
     if (idxOf1stSubBlockOfZoomGreater < 0)
@@ -338,7 +338,7 @@ void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const
         }
     }
 
-    if (!/*useCoverageOptimization*/options.useVisibilityCheckOptimization)
+    if (!options.useVisibilityCheckOptimization)
     {
         for (auto it = start_iterator; it != end_iterator; ++it)
         {

--- a/Src/libCZI/SingleChannelScalingTileAccessor.h
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.h
@@ -38,7 +38,7 @@ private:
     std::vector<int> CreateSortByZoom(const std::vector<SbInfo>& sbBlks, bool sortByM);
     std::vector<SbInfo> GetSubSet(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const std::vector<int>* allowedScenes);
     int GetIdxOf1stSubBlockWithZoomGreater(const std::vector<SbInfo>& sbBlks, const std::vector<int>& byZoom, float zoom);
-    void ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo);
+    void ScaleBlt(libCZI::IBitmapData* bmDest, float zoom, const libCZI::IntRect& roi, const SbInfo& sbInfo, const libCZI::ISingleChannelScalingTileAccessor::Options& options);
 
     void InternalGet(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options);
 
@@ -55,5 +55,5 @@ private:
     SubSetSortedByZoom GetSubSetFilteredBySceneSortedByZoom(const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, const std::vector<int>& allowedScenes, bool sortByM);
 
     std::vector<std::tuple<int, SubSetSortedByZoom>> GetSubSetSortedByZoomPerScene(const std::vector<int>& scenes, const libCZI::IntRect& roi, const libCZI::IDimCoordinate* planeCoordinate, bool sortByM);
-    void Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, bool useCoverageOptimization);
+    void Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options);
 };

--- a/Src/libCZI/SingleChannelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelTileAccessor.cpp
@@ -97,10 +97,17 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
             {
                 if (index < static_cast<int>(subBlocksSet.size()))
                 {
-                    const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[index].index);
+                    /*const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[index].index);
                     spBm = sb->CreateBitmap();
                     xPosTile = sb->GetSubBlockInfo().logicalRect.x;
-                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;
+                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;*/
+                    const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
+                        this->sbBlkRepository,
+                        options.subBlockCache,
+                        subBlocksSet[index].index);
+                    spBm = subblock_data.bitmap;
+                    xPosTile = subblock_data.subBlockInfo.logicalRect.x;
+                    yPosTile = subblock_data.subBlockInfo.logicalRect.y;
                     return true;
                 }
 

--- a/Src/libCZI/SingleChannelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelTileAccessor.cpp
@@ -69,10 +69,17 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
             {
                 if (index < static_cast<int>(indices_of_visible_tiles.size()))
                 {
-                    const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[indices_of_visible_tiles[index]].index);
+                    /*const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[indices_of_visible_tiles[index]].index);
                     spBm = sb->CreateBitmap();
                     xPosTile = sb->GetSubBlockInfo().logicalRect.x;
-                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;
+                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;*/
+                    const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
+                        this->sbBlkRepository,
+                        options.subBlockCache,
+                        subBlocksSet[indices_of_visible_tiles[index]].index);
+                    spBm = subblock_data.bitmap;
+                    xPosTile = subblock_data.subBlockInfo.logicalRect.x;
+                    yPosTile = subblock_data.subBlockInfo.logicalRect.y;
                     return true;
                 }
 

--- a/Src/libCZI/SingleChannelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelTileAccessor.cpp
@@ -69,10 +69,6 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
             {
                 if (index < static_cast<int>(indices_of_visible_tiles.size()))
                 {
-                    /*const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[indices_of_visible_tiles[index]].index);
-                    spBm = sb->CreateBitmap();
-                    xPosTile = sb->GetSubBlockInfo().logicalRect.x;
-                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;*/
                     const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,
                         options.subBlockCache,
@@ -97,10 +93,6 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
             {
                 if (index < static_cast<int>(subBlocksSet.size()))
                 {
-                    /*const auto sb = this->sbBlkRepository->ReadSubBlock(subBlocksSet[index].index);
-                    spBm = sb->CreateBitmap();
-                    xPosTile = sb->GetSubBlockInfo().logicalRect.x;
-                    yPosTile = sb->GetSubBlockInfo().logicalRect.y;*/
                     const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,
                         options.subBlockCache,

--- a/Src/libCZI/SingleChannelTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelTileAccessor.cpp
@@ -72,7 +72,8 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
                     const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,
                         options.subBlockCache,
-                        subBlocksSet[indices_of_visible_tiles[index]].index);
+                        subBlocksSet[indices_of_visible_tiles[index]].index,
+                        options.onlyUseSubBlockCacheForCompressedData);
                     spBm = subblock_data.bitmap;
                     xPosTile = subblock_data.subBlockInfo.logicalRect.x;
                     yPosTile = subblock_data.subBlockInfo.logicalRect.y;
@@ -96,7 +97,8 @@ void CSingleChannelTileAccessor::ComposeTiles(libCZI::IBitmapData* pBm, int xPos
                     const auto subblock_data = CSingleChannelAccessorBase::GetSubBlockDataForSubBlockIndex(
                         this->sbBlkRepository,
                         options.subBlockCache,
-                        subBlocksSet[index].index);
+                        subBlocksSet[index].index,
+                        options.onlyUseSubBlockCacheForCompressedData);
                     spBm = subblock_data.bitmap;
                     xPosTile = subblock_data.subBlockInfo.logicalRect.x;
                     yPosTile = subblock_data.subBlockInfo.logicalRect.y;

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -174,6 +174,8 @@ namespace libCZI
     /// \return The newly created metadata-builder-object.
     LIBCZI_API std::shared_ptr<ICziMetadataBuilder> CreateMetadataBuilder();
 
+    /// Creates a sub block cache object.
+    /// \returns    The newly created sub block cache.
     LIBCZI_API std::shared_ptr<ISubBlockCache> CreateSubBlockCache();
 
     /// Creates metadata builder object from the specified UTF8-encoded XML-string. If the XML is

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -66,6 +66,7 @@ namespace libCZI
     class IMetadataSegment;
     class ISubBlockRepository;
     class IAttachment;
+    class ISubBlockCache;
 
     /// This structure contains information about the compiler settings and the version of the source
     /// which was used to create the library.
@@ -172,6 +173,8 @@ namespace libCZI
     /// Creates a metadata-builder-object.
     /// \return The newly created metadata-builder-object.
     LIBCZI_API std::shared_ptr<ICziMetadataBuilder> CreateMetadataBuilder();
+
+    LIBCZI_API std::shared_ptr<ISubBlockCache> CreateSubBlockCache();
 
     /// Creates metadata builder object from the specified UTF8-encoded XML-string. If the XML is
     /// invalid or if the root-node "ImageDocument" is not present, then an exception is thrown.

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -46,7 +46,7 @@ namespace libCZI
             std::uint32_t elementsCount;
         };
 
-        /// Gets momentarily valid statistics about the cache. The mask defines which statistics is to be retrieved.
+        /// Gets momentarily valid statistics about the cache. The mask defines which statistic/s is/are to be retrieved.
         /// In case of multiple fields being requested, it is guaranteed that all requested fields are a transactional 
         /// snapshot of the state.
         ///

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -72,8 +72,8 @@ namespace libCZI
         /// Options for controlling the prune operation. There are two metrics which can be used to control what
         /// remains in the cache and what is discarded: the maximum memory usage (for all elements in the cache) and 
         /// the maximum number of sub-blocks. If the cache exceeds one of those limits, then elements are evicted from the cache
-        /// until both conditions are met. Eviction is done in the order starting with elements where their last access is the longest 
-        /// time ago. As "access" we define either the Add-operation or the Get-operation - so, when an element is retrieved from the
+        /// until both conditions are met. Eviction is done in the order starting with elements which have been least recently accessed.
+        /// As "access" we define either the Add-operation or the Get-operation - so, when an element is retrieved from the
         /// cache, it is considered as "accessed".
         /// If only one condition is desired, then the other condition can be set to the maximum value of the respective type (which is the
         /// default value).

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -25,6 +25,25 @@ namespace libCZI
         SingleChannelScalingTileAccessor        ///< The scaling-single-channel-tile accessor (associated interface: ISingleChannelScalingTileAccessor).
     };
 
+    class ISubBlockCache
+    {
+    public:
+        struct Options
+        {
+            /// The maximum memory usage (in bytes) for the cache. If the cache exceeds this limit, 
+            /// then the least recently used sub-blocks are removed from the cache.
+            std::uint64_t   maxMemoryUsage;     
+
+            /// The maximum number of sub-blocks in the cache. If the cache exceeds this limit,
+            /// then the least recently used sub-blocks are removed from the cache.
+            std::uint32_t  maxSubBlockCount;
+        };
+
+        virtual std::shared_ptr<IBitmapData> Get(int subblock_index) = 0;
+        virtual void Add(int subblock_index, std::shared_ptr<IBitmapData> pBitmap) = 0;
+        virtual ~ISubBlockCache() = default;
+    };
+
     /// The base interface (all accessor-interface must derive from this).
     class IAccessor
     {
@@ -76,6 +95,8 @@ namespace libCZI
             /// If specified, only subblocks with a scene-index contained in the set will be considered.
             std::shared_ptr<libCZI::IIndexSet> sceneFilter;
 
+            std::shared_ptr<libCZI::ISubBlockCache> subBlockCache;
+
             /// Clears this object to its blank state.
             void Clear()
             {
@@ -84,6 +105,7 @@ namespace libCZI
                 this->useVisibilityCheckOptimization = false;
                 this->drawTileBorder = false;
                 this->sceneFilter.reset();
+                this->subBlockCache.reset();
             }
         };
 

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -282,7 +282,9 @@ namespace libCZI
             /// all relevant tiles are checked whether they are visible in the destination bitmap. If a tile is not visible, then
             /// the corresponding sub-block is not read. This can speed up the operation considerably. The result is the same as
             /// without this optimization - i.e. there should be no reason to turn it off besides potential bugs.
-            bool useVisibilityCheckOptimization;   
+            bool useVisibilityCheckOptimization;
+
+            std::shared_ptr<libCZI::ISubBlockCache> subBlockCache;
 
             /// Clears this object to its blank state.
             void Clear()
@@ -292,6 +294,7 @@ namespace libCZI
                 this->backGroundColor.r = this->backGroundColor.g = this->backGroundColor.b = std::numeric_limits<float>::quiet_NaN();
                 this->sceneFilter.reset();
                 this->useVisibilityCheckOptimization = false;
+                this->subBlockCache.reset();
             }
         };
 

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -31,13 +31,28 @@ namespace libCZI
         static constexpr std::uint8_t kMemoryUsage = 1;
         static constexpr std::uint8_t kElementsCount = 2;
 
+        /// This struct defines the statistics which can be queried from the cache. There is a bitfield which
+        /// defines which elements are valid. If the bit is set, then the corresponding member is valid.
         struct Statistics
         {
+            /// A bit mask which indicates which members are valid. C.f. the constants kMemoryUsage and kElementsCount.
             std::uint8_t validityMask;
+
+            /// The memory usage of all elements in the cache. This field is only valid if the bit kMemoryUsage is set in the validityMask.
             std::uint64_t memoryUsage;
+
+            /// The number of elements in the cache. This field is only valid if the bit kElementsCount is set in the validityMask.
             std::uint32_t elementsCount;
         };
 
+        /// Gets momentarily valid statistics about the cache. The mask defines which statistics is to be retrieved.
+        /// In case of multiple fields being requested, it is guaranteed that all requested fields are a transactional 
+        /// snapshot of the state.
+        ///
+        /// \param  mask A bitmask specifying which fields are requested. Only the fields requested are guaranteed to be valid
+        ///              in the returned struct.
+        ///
+        /// \returns A consistent snapshot of the statistics.
         virtual Statistics GetStatistics(std::uint8_t mask) const = 0;
 
         virtual ~ISubBlockCacheStatistics() = default;

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -198,6 +198,8 @@ namespace libCZI
             /// If specified, only subblocks with a scene-index contained in the set will be considered.
             std::shared_ptr<libCZI::IIndexSet> sceneFilter;
 
+            std::shared_ptr<libCZI::ISubBlockCache> subBlockCache;
+
             /// Clears this object to its blank state.
             void Clear()
             {
@@ -205,6 +207,7 @@ namespace libCZI
                 this->sortByM = true;
                 this->backGroundColor.r = this->backGroundColor.g = this->backGroundColor.b = std::numeric_limits<float>::quiet_NaN();
                 this->sceneFilter.reset();
+                this->subBlockCache.reset();
             }
         };
 

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -50,17 +50,17 @@ namespace libCZI
         {
             /// The maximum memory usage (in bytes) for the cache. If the cache exceeds this limit, 
             /// then the least recently used sub-blocks are removed from the cache.
-            std::uint64_t   maxMemoryUsage;
+            std::uint64_t   maxMemoryUsage{ (std::numeric_limits<decltype(maxMemoryUsage)>::max)() };
 
             /// The maximum number of sub-blocks in the cache. If the cache exceeds this limit,
             /// then the least recently used sub-blocks are removed from the cache.
-            std::uint32_t  maxSubBlockCount;
+            std::uint32_t  maxSubBlockCount{ (std::numeric_limits<decltype(maxSubBlockCount)>::max)() };
         };
 
         virtual std::shared_ptr<IBitmapData> Get(int subblock_index) = 0;
         virtual void Add(int subblock_index, std::shared_ptr<IBitmapData> pBitmap) = 0;
         virtual void Prune(const PruneOptions& options) = 0;
-        virtual ~ISubBlockCache() = default;
+        ~ISubBlockCache() override = default;
     };
 
     /// The base interface (all accessor-interface must derive from this).

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -29,8 +29,8 @@ namespace libCZI
     class ISubBlockCacheStatistics
     {
     public:
-        static constexpr std::uint8_t kMemoryUsage = 1;
-        static constexpr std::uint8_t kElementsCount = 2;
+        static constexpr std::uint8_t kMemoryUsage = 1;     ///< Bit-mask identifying the memory-usage field in the statistics struct.
+        static constexpr std::uint8_t kElementsCount = 2;   ///< Bit-mask identifying the elements-count field in the statistics struct.
 
         /// This struct defines the statistics which can be queried from the cache. There is a bitfield which
         /// defines which elements are valid. If the bit is set, then the corresponding member is valid.
@@ -57,6 +57,12 @@ namespace libCZI
         virtual Statistics GetStatistics(std::uint8_t mask) const = 0;
 
         virtual ~ISubBlockCacheStatistics() = default;
+
+        ISubBlockCacheStatistics() = default;
+        ISubBlockCacheStatistics(const ISubBlockCacheStatistics&) = delete;
+        ISubBlockCacheStatistics& operator=(const ISubBlockCacheStatistics&) = delete;
+        ISubBlockCacheStatistics(ISubBlockCacheStatistics&&) noexcept = delete;
+        ISubBlockCacheStatistics& operator=(ISubBlockCacheStatistics&&) noexcept = delete;
     };
 
     /// This interface defines the global operations on the cache. It is used to control the memory usage of the cache.
@@ -66,7 +72,7 @@ namespace libCZI
         /// Options for controlling the prune operation. There are two metrics which can be used to control what
         /// remains in the cache and what is discarded: the maximum memory usage (for all elements in the cache) and 
         /// the maximum number of sub-blocks. If the cache exceeds one of those limits, then elements are evicted from the cache
-        /// until both condions are met. Eviction is done in the order starting with elements where their last access is the longest 
+        /// until both conditions are met. Eviction is done in the order starting with elements where their last access is the longest 
         /// time ago. As "access" we define either the Add-operation or the Get-operation - so, when an element is retrieved from the
         /// cache, it is considered as "accessed".
         /// If only one condition is desired, then the other condition can be set to the maximum value of the respective type (which is the
@@ -87,16 +93,35 @@ namespace libCZI
         virtual void Prune(const PruneOptions& options) = 0;
 
         virtual ~ISubBlockCacheControl() = default;
+
+        ISubBlockCacheControl() = default;
+        ISubBlockCacheControl(const ISubBlockCacheControl&) = delete;
+        ISubBlockCacheControl& operator=(const ISubBlockCacheControl&) = delete;
+        ISubBlockCacheControl(ISubBlockCacheControl&&) noexcept = delete;
+        ISubBlockCacheControl& operator=(ISubBlockCacheControl&&) noexcept = delete;
     };
 
     /// This interface defines the operations of adding and querying an element to/from the cache.
     class ISubBlockCacheOperation
     {
     public:
+        /// Gets the bitmap for the specified subblock-index. If the subblock is not in the cache, then a nullptr is returned.
+        /// \param  subblock_index  The subblock index to get.
+        /// \returns    If the subblock is in the cache, then a std::shared_ptr&lt;libCZI::IBitmapData&gt; is returned. Otherwise a nullptr is returned.
         virtual std::shared_ptr<IBitmapData> Get(int subblock_index) = 0;
+
+        /// Adds the specified bitmap for the specified subblock_index to the cache. If the subblock is already in the cache, then it is overwritten.
+        /// \param  subblock_index  The subblock index to add.
+        /// \param  pBitmap         The bitmap.
         virtual void Add(int subblock_index, std::shared_ptr<IBitmapData> pBitmap) = 0;
 
         virtual ~ISubBlockCacheOperation() = default;
+
+        ISubBlockCacheOperation() = default;
+        ISubBlockCacheOperation(const ISubBlockCacheOperation&) = delete;
+        ISubBlockCacheOperation& operator=(const ISubBlockCacheOperation&) = delete;
+        ISubBlockCacheOperation(ISubBlockCacheOperation&&) noexcept = delete;
+        ISubBlockCacheOperation& operator=(ISubBlockCacheOperation&&) noexcept = delete;
     };
 
     /// Interface for a caching component (which can be used with the compositors). The intended use is as follows:
@@ -111,6 +136,12 @@ namespace libCZI
     {
     public:
         ~ISubBlockCache() override = default;
+
+        ISubBlockCache() = default;
+        ISubBlockCache(const ISubBlockCache&) = delete;
+        ISubBlockCache& operator=(const ISubBlockCache&) = delete;
+        ISubBlockCache(ISubBlockCache&&) noexcept = delete;
+        ISubBlockCache& operator=(ISubBlockCache&&) noexcept = delete;
     };
 
     /// The base interface (all accessor-interface must derive from this).
@@ -169,7 +200,9 @@ namespace libCZI
             /// in the cache, then the bitmap from the cache is used instead of reading the sub-block from the file.
             std::shared_ptr<libCZI::ISubBlockCacheOperation> subBlockCache;
 
-            /// If true, then only bitmaps from sub-blocks with compressed data are added to the cache.
+            /// If true, then only bitmaps from sub-blocks with compressed data are added to the cache. For uncompressed
+            /// data, the time for reading the bitmap can be negligible, so the benefit of caching might not outweigh the
+            /// increased memory usage.
             bool onlyUseSubBlockCacheForCompressedData;
 
             /// Clears this object to its blank state.
@@ -376,7 +409,7 @@ namespace libCZI
             std::shared_ptr<libCZI::ISubBlockCacheOperation> subBlockCache;
 
             /// If true, then only bitmaps from sub-blocks with compressed data are added to the cache.
-            bool onlyUseSubBlockCacheForCompressedData; 
+            bool onlyUseSubBlockCacheForCompressedData;
 
             /// Clears this object to its blank state.
             void Clear()

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -43,9 +43,25 @@ namespace libCZI
         virtual ~ISubBlockCacheStatistics() = default;
     };
 
+    /// Interface for a caching components (which can be used with the compositors). The intended use is as follows:
+    /// * Whenever the bitmap corresponding to a subblock (c.f. ISubBlock::CreateBitmap) is accessed, the bitmap may be added  
+    ///   to a cache object, where the subblock-index is the key.
+    /// * Whenever a bitmap is needed (for a given subblock-index), the cache object is first queried whether it contains the bitmap. If yes, then the bitmap  
+    ///   returned may be used instead of executing the subblock-read-and-decode operation.
+    /// In order to control the memory usage of the cache, the cache object must be pruned (i.e. subblocks are removed from the cache). Currently this means,
+    /// that the Prune-method must be called manually. The cache object does not do any pruning automatically.
+    /// The operations of Adding, Querying and Pruning the cache object are thread-safe.
     class ISubBlockCache : public ISubBlockCacheStatistics
     {
     public:
+        /// Options for controlling the prune operation. There are two metrics which can be used to control what
+        /// remains in the cache and what is discarded: the maximum memory usage (for all elements in the cache) and 
+        /// the maximum number of sub-blocks. If the cache exceeds one of those limits, then elements are evicted from the cache
+        /// until both condions are met. Eviction is done in the order starting with elements where their last access is the longest 
+        /// time ago. As "access" we define either the Add-operation or the Get-operation - so, when an element is retrieved from the
+        /// cache, it is considered as "accessed".
+        /// If only one condition is desired, then the other condition can be set to the maximum value of the respective type (which is the
+        /// default value).
         struct PruneOptions
         {
             /// The maximum memory usage (in bytes) for the cache. If the cache exceeds this limit, 

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -165,7 +165,7 @@ namespace libCZI
     /// The pixel type of the output bitmap is either specified as an argument or it is automatically
     /// determined. In the latter case the first sub-block found on the specified plane is examined for its
     /// pixeltype, and this pixeltype is used.\n
-    /// The pixels in the output bitmap get converted from the source pixels (if their pixeltypes differs).
+    /// The pixels in the output bitmap get converted from the source pixels (if their pixeltypes differ).
     class ISingleChannelTileAccessor : public IAccessor
     {
     public:

--- a/Src/libCZI/libCZI_Compositor.h
+++ b/Src/libCZI/libCZI_Compositor.h
@@ -89,6 +89,8 @@ namespace libCZI
         };
 
         /// Prunes the cache. This means that sub-blocks are removed from the cache until the cache satisfies the conditions given in the options.
+        /// Note that the prune operation is not done automatically - it must be called manually. I.e. when adding an element to the cache, the cache
+        /// is **not** pruned automatically.
         /// \param  options Options for controlling the operation.
         virtual void Prune(const PruneOptions& options) = 0;
 

--- a/Src/libCZI/subblock_cache.cpp
+++ b/Src/libCZI/subblock_cache.cpp
@@ -18,20 +18,40 @@ SubBlockCache::~SubBlockCache()
 std::shared_ptr<IBitmapData> SubBlockCache::Get(int subblock_index)
 {
     lock_guard<mutex> lck(this->mutex_);
-    auto element = this->cache_.find(subblock_index);
+    const auto element = this->cache_.find(subblock_index);
     if (element != this->cache_.end())
     {
         element->second.last_used = this->usage_counter_.fetch_add(1);
         return element->second.bitmap;
     }
-    else
-    {
-        return {};
-    }
+
+    return {};
 }
 
 void SubBlockCache::Add(int subblock_index, std::shared_ptr<IBitmapData> bitmap)
 {
+    const auto size_in_bytes_of_added_bitmap = SubBlockCache::CalculateSizeInBytes(bitmap.get());
+    const auto entry_to_be_added = CacheEntry{ bitmap, this->usage_counter_.fetch_add(1) };
+
     lock_guard<mutex> lck(this->mutex_);
-    this->cache_[subblock_index] = { bitmap, this->usage_counter_.fetch_add(1) };
+    const auto result = this->cache_.insert({ subblock_index, entry_to_be_added });
+    if (result.second)
+    {
+        // New element inserted
+        this->cache_size_in_bytes_ += size_in_bytes_of_added_bitmap;
+        ++this->cache_subblock_count_;
+    }
+    else
+    {
+        // Element with the same key already existed
+        this->cache_size_in_bytes_ -= SubBlockCache::CalculateSizeInBytes(result.first->second.bitmap.get());
+        result.first->second = entry_to_be_added;
+        this->cache_size_in_bytes_ += size_in_bytes_of_added_bitmap;
+    }
+}
+
+/*static*/std::uint64_t SubBlockCache::CalculateSizeInBytes(const libCZI::IBitmapData* bitmap)
+{
+    const IntSize size = bitmap->GetSize();
+    return static_cast<uint64_t>(size.w) * size.h * Utils::GetBytesPerPixel(bitmap->GetPixelType());
 }

--- a/Src/libCZI/subblock_cache.cpp
+++ b/Src/libCZI/subblock_cache.cpp
@@ -12,13 +12,6 @@ std::shared_ptr<ISubBlockCache> libCZI::CreateSubBlockCache()
     return make_shared<SubBlockCache>();
 }
 
-SubBlockCache::SubBlockCache()
-{
-}
-
-SubBlockCache::~SubBlockCache()
-{}
-
 ISubBlockCacheStatistics::Statistics SubBlockCache::GetStatistics(std::uint8_t mask) const
 {
     Statistics result{ 0 };

--- a/Src/libCZI/subblock_cache.cpp
+++ b/Src/libCZI/subblock_cache.cpp
@@ -7,9 +7,13 @@
 using namespace libCZI;
 using namespace std;
 
-SubBlockCache::SubBlockCache(const libCZI::ISubBlockCache::PruneOptions& options)
+std::shared_ptr<ISubBlockCache> libCZI::CreateSubBlockCache()
 {
+    return make_shared<SubBlockCache>();
+}
 
+SubBlockCache::SubBlockCache()
+{
 }
 
 SubBlockCache::~SubBlockCache()
@@ -26,14 +30,14 @@ ISubBlockCacheStatistics::Statistics SubBlockCache::GetStatistics(std::uint8_t m
     else if (mask == ISubBlockCacheStatistics::kElementsCount)
     {
         result.validityMask = ISubBlockCacheStatistics::kElementsCount;
-        result.memoryUsage = this->cache_subblock_count_.load();
+        result.elementsCount = this->cache_subblock_count_.load();
     }
     else if (mask == (ISubBlockCacheStatistics::kMemoryUsage | ISubBlockCacheStatistics::kElementsCount))
     {
         result.validityMask = ISubBlockCacheStatistics::kMemoryUsage | ISubBlockCacheStatistics::kElementsCount;
         lock_guard<mutex> lck(this->mutex_);
         result.memoryUsage = this->cache_size_in_bytes_.load();
-        result.memoryUsage = this->cache_subblock_count_.load();
+        result.elementsCount = this->cache_subblock_count_.load();
     }
 
     return result;
@@ -76,7 +80,63 @@ void SubBlockCache::Add(int subblock_index, std::shared_ptr<IBitmapData> bitmap)
 
 void SubBlockCache::Prune(const PruneOptions& options)
 {
-    
+    if (options.maxMemoryUsage != numeric_limits<uint64_t>::max())
+    {
+        this->PruneToMemoryUsage(options.maxMemoryUsage);
+               lock_guard<mutex> lck(this->mutex_);
+        if (this->cache_size_in_bytes_ > options.maxMemoryUsage)
+        {
+                       // Sort the cache entries by LRU value
+                       //            vector<pair<int, CacheEntry>> sorted_cache_entries;
+                       //                       sorted_cache_entries.reserve(this->cache_.size());
+                       //                                  for (const auto& element : this->cache_)
+                       //                                             {
+                       //                                                            sorted_cache_entries.push_back(element);
+                       //                                                                       }
+                       //                                                                                  sort(sorted_cache_entries.begin(), sorted_cache_entries.end(), [](const auto& a, const auto& b) { return a.second.lru_value < b.second.lru_value; });
+                                  // Remove the oldest entries until the memory usage is below the threshold
+                                  //            for (const auto& element : sorted_cache_entries)
+                                  //                       {
+                                  //                                      this->cache_size_in_bytes_ -= SubBlockCache::CalculateSizeInBytes(element.second.bitmap.get());
+                                  //                                                     this->cache_.erase(element.first);
+                                  //                                                                    --this->cache_subblock_count_;
+                                  //                                                                                   if (this->cache_size_in_bytes_ <= options.maxMemoryUsage)
+                                  //                                                                                                  {
+                                  //                                                                                                                     break;
+                                  //                                                                                                                                    }
+                                  //                                                                                                                                               }
+                                  //                                                                                                                                                      }
+                                  //                                                                                                                                                         }
+        }
+    }
+}
+
+void SubBlockCache::PruneByMemoryUsage(std::uint64_t max_memory_usage)
+{
+    lock_guard<mutex> lck(this->mutex_);
+    if (this->cache_size_in_bytes_ > max_memory_usage)
+    {
+               // Sort the cache entries by LRU value
+               //        vector<pair<int, CacheEntry>> sorted_cache_entries;
+               //               sorted_cache_entries.reserve(this->cache_.size());
+               //                      for (const auto& element : this->cache_)
+               //                             {
+               //                                        sorted_cache_entries.push_back(element);
+               //                                               }
+               //                                                      sort(sorted_cache_entries.begin(), sorted_cache_entries.end(), [](const auto& a, const auto& b) { return a.second.lru_value < b.second.lru_value; });
+                      // Remove the oldest entries until the memory usage is below the threshold
+                      //        for (const auto& element : sorted_cache_entries)
+                      //               {
+                      //                          this->cache_size_in_bytes_ -= SubBlockCache::CalculateSizeInBytes(element.second.bitmap.get());
+                      //                                     this->cache_.erase(element.first);
+                      //                                                --this->cache_subblock_count_;
+                      //                                                           if (this->cache_size_in_bytes_ <= max_memory_usage)
+                      //                                                                      {
+                      //                                                                                     break;
+                      //                                                                                                }
+                      //                                                                                                       }
+                      //                                                                                                          }
+    }
 }
 
 /*static*/std::uint64_t SubBlockCache::CalculateSizeInBytes(const libCZI::IBitmapData* bitmap)

--- a/Src/libCZI/subblock_cache.cpp
+++ b/Src/libCZI/subblock_cache.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "subblock_cache.h"
+
+using namespace libCZI;
+using namespace std;
+
+SubBlockCache::SubBlockCache(const libCZI::ISubBlockCache::Options& options)
+{
+
+}
+
+SubBlockCache::~SubBlockCache()
+{}
+
+std::shared_ptr<IBitmapData> SubBlockCache::Get(int subblock_index)
+{
+    lock_guard<mutex> lck(this->mutex_);
+    auto element = this->cache_.find(subblock_index);
+    if (element != this->cache_.end())
+    {
+        element->second.last_used = this->usage_counter_.fetch_add(1);
+        return element->second.bitmap;
+    }
+    else
+    {
+        return {};
+    }
+}
+
+void SubBlockCache::Add(int subblock_index, std::shared_ptr<IBitmapData> bitmap)
+{
+    lock_guard<mutex> lck(this->mutex_);
+    this->cache_[subblock_index] = { bitmap, this->usage_counter_.fetch_add(1) };
+}

--- a/Src/libCZI/subblock_cache.cpp
+++ b/Src/libCZI/subblock_cache.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<IBitmapData> SubBlockCache::Get(int subblock_index)
     const auto element = this->cache_.find(subblock_index);
     if (element != this->cache_.end())
     {
-        element->second.last_used = this->usage_counter_.fetch_add(1);
+        element->second.lru_value = this->lru_counter_.fetch_add(1);
         return element->second.bitmap;
     }
 
@@ -31,7 +31,7 @@ std::shared_ptr<IBitmapData> SubBlockCache::Get(int subblock_index)
 void SubBlockCache::Add(int subblock_index, std::shared_ptr<IBitmapData> bitmap)
 {
     const auto size_in_bytes_of_added_bitmap = SubBlockCache::CalculateSizeInBytes(bitmap.get());
-    const auto entry_to_be_added = CacheEntry{ bitmap, this->usage_counter_.fetch_add(1) };
+    const auto entry_to_be_added = CacheEntry{ bitmap, this->lru_counter_.fetch_add(1) };
 
     lock_guard<mutex> lck(this->mutex_);
     const auto result = this->cache_.insert({ subblock_index, entry_to_be_added });

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <atomic>
 
+/// A simplistic sub-block cache implementation. It is thread-safe and uses a LRU eviction strategy.
 class SubBlockCache : public libCZI::ISubBlockCache
 {
 private:
@@ -25,18 +26,15 @@ private:
     std::atomic_uint64_t cache_size_in_bytes_{ 0 };
     std::atomic_uint32_t cache_subblock_count_{ 0 };
 public:
-    SubBlockCache();
-    ~SubBlockCache() override;
+    SubBlockCache() = default;
+    ~SubBlockCache() override = default;
 
     std::shared_ptr<libCZI::IBitmapData> Get(int subblock_index) override;
     void Add(int subblock_index, std::shared_ptr<libCZI::IBitmapData> bitmap) override;
     void Prune(const PruneOptions& options) override;
-
     Statistics GetStatistics(std::uint8_t mask) const override;
-
 private:
     void PruneByMemoryUsageAndElementCount(std::uint64_t max_memory_usage, std::uint32_t max_element_count);
     static std::uint64_t CalculateSizeInBytes(const libCZI::IBitmapData* bitmap);
-
     static bool CompareForLruValue(const std::pair<int, CacheEntry>& a, const std::pair<int, CacheEntry>& b);
 };

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -20,16 +20,19 @@ private:
     };
 
     std::map<int, CacheEntry> cache_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::atomic_uint64_t lru_counter_{ 0 };
     std::atomic_uint64_t cache_size_in_bytes_{ 0 };
     std::atomic_uint32_t cache_subblock_count_{ 0 };
 public:
-    SubBlockCache(const libCZI::ISubBlockCache::Options& options);
-    ~SubBlockCache();
+    SubBlockCache(const libCZI::ISubBlockCache::PruneOptions& options);
+    ~SubBlockCache() override;
 
     std::shared_ptr<libCZI::IBitmapData> Get(int subblock_index) override;
     void Add(int subblock_index, std::shared_ptr<libCZI::IBitmapData> bitmap) override;
+    void Prune(const PruneOptions& options) override;
+
+    Statistics GetStatistics(std::uint8_t mask) const override;
 
 private:
     static std::uint64_t CalculateSizeInBytes(const libCZI::IBitmapData* bitmap);

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "libCZI.h"
+#include <map>
+#include <cstdint>
+#include <mutex>
+#include <atomic>
+
+class SubBlockCache : public libCZI::ISubBlockCache
+{
+private:
+    struct CacheEntry
+    {
+        std::shared_ptr<libCZI::IBitmapData> bitmap;
+        std::uint64_t last_used;
+    };
+
+    std::map<int, CacheEntry> cache_;
+    std::mutex mutex_;
+    std::atomic_uint64_t usage_counter_{ 0 };
+public:
+    SubBlockCache(const libCZI::ISubBlockCache::Options& options);
+    ~SubBlockCache();
+
+    std::shared_ptr<libCZI::IBitmapData> Get(int subblock_index) override;
+    void Add(int subblock_index, std::shared_ptr<libCZI::IBitmapData> bitmap) override;
+};

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -16,15 +16,15 @@ class SubBlockCache : public libCZI::ISubBlockCache
 private:
     struct CacheEntry
     {
-        std::shared_ptr<libCZI::IBitmapData> bitmap;
-        std::uint64_t lru_value;
+        std::shared_ptr<libCZI::IBitmapData> bitmap;    ////< The cached bitmap.
+        std::uint64_t lru_value;                        ////< The "LRU value" - when marking a cache entry as "used", this value is set to the current value of the "LRU counter".
     };
 
     std::map<int, CacheEntry> cache_;
     mutable std::mutex mutex_;
-    std::atomic_uint64_t lru_counter_{ 0 };
-    std::atomic_uint64_t cache_size_in_bytes_{ 0 };
-    std::atomic_uint32_t cache_subblock_count_{ 0 };
+    std::atomic_uint64_t lru_counter_{ 0 }; ///< The "LRU counter" - when marking a cache entry as "used", this counter is incremented and the new value is stored in the cache entry.
+    std::atomic_uint64_t cache_size_in_bytes_{ 0 }; ////< The current size of the cache in bytes.
+    std::atomic_uint32_t cache_subblock_count_{ 0 }; ///< The current number of sub-blocks in the cache.
 public:
     SubBlockCache() = default;
     ~SubBlockCache() override = default;

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -22,10 +22,15 @@ private:
     std::map<int, CacheEntry> cache_;
     std::mutex mutex_;
     std::atomic_uint64_t usage_counter_{ 0 };
+    std::atomic_uint64_t cache_size_in_bytes_{ 0 };
+    std::atomic_uint32_t cache_subblock_count_{ 0 };
 public:
     SubBlockCache(const libCZI::ISubBlockCache::Options& options);
     ~SubBlockCache();
 
     std::shared_ptr<libCZI::IBitmapData> Get(int subblock_index) override;
     void Add(int subblock_index, std::shared_ptr<libCZI::IBitmapData> bitmap) override;
+
+private:
+    static std::uint64_t CalculateSizeInBytes(const libCZI::IBitmapData* bitmap);
 };

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -16,12 +16,12 @@ private:
     struct CacheEntry
     {
         std::shared_ptr<libCZI::IBitmapData> bitmap;
-        std::uint64_t last_used;
+        std::uint64_t lru_value;
     };
 
     std::map<int, CacheEntry> cache_;
     std::mutex mutex_;
-    std::atomic_uint64_t usage_counter_{ 0 };
+    std::atomic_uint64_t lru_counter_{ 0 };
     std::atomic_uint64_t cache_size_in_bytes_{ 0 };
     std::atomic_uint32_t cache_subblock_count_{ 0 };
 public:

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -25,7 +25,7 @@ private:
     std::atomic_uint64_t cache_size_in_bytes_{ 0 };
     std::atomic_uint32_t cache_subblock_count_{ 0 };
 public:
-    SubBlockCache(const libCZI::ISubBlockCache::PruneOptions& options);
+    SubBlockCache();
     ~SubBlockCache() override;
 
     std::shared_ptr<libCZI::IBitmapData> Get(int subblock_index) override;
@@ -35,5 +35,6 @@ public:
     Statistics GetStatistics(std::uint8_t mask) const override;
 
 private:
+    void PruneByMemoryUsage(std::uint64_t max_memory_usage);
     static std::uint64_t CalculateSizeInBytes(const libCZI::IBitmapData* bitmap);
 };

--- a/Src/libCZI/subblock_cache.h
+++ b/Src/libCZI/subblock_cache.h
@@ -35,6 +35,8 @@ public:
     Statistics GetStatistics(std::uint8_t mask) const override;
 
 private:
-    void PruneByMemoryUsage(std::uint64_t max_memory_usage);
+    void PruneByMemoryUsageAndElementCount(std::uint64_t max_memory_usage, std::uint32_t max_element_count);
     static std::uint64_t CalculateSizeInBytes(const libCZI::IBitmapData* bitmap);
+
+    static bool CompareForLruValue(const std::pair<int, CacheEntry>& a, const std::pair<int, CacheEntry>& b);
 };

--- a/Src/libCZI_UnitTests/CMakeLists.txt
+++ b/Src/libCZI_UnitTests/CMakeLists.txt
@@ -63,7 +63,8 @@ ADD_EXECUTABLE(libCZI_UnitTests
 										test_streamslib.cpp 
 										test_curlhttpstream.cpp
 										test_rectanglecoverage.cpp 
-										test_TileAccessorCoverageOptimization.cpp)
+										test_TileAccessorCoverageOptimization.cpp 
+										test_SubBlockCache.cpp)
 
 TARGET_LINK_LIBRARIES(libCZI_UnitTests PRIVATE libCZIStatic GTest::gtest GTest::gmock)
 

--- a/Src/libCZI_UnitTests/test_Accessors.cpp
+++ b/Src/libCZI_UnitTests/test_Accessors.cpp
@@ -670,3 +670,76 @@ TEST(Accessor, CreateDocumentAndCheckSingleChannelScalingAccessor1)
     EXPECT_EQ(pixel_x0_y1, 3);
     EXPECT_EQ(pixel_x1_y1, 4);
 }
+
+TEST(Accessor, CreateDocumentAndCheckSingleChannelScalingAccessorWithSubBlockCache)
+{
+    // we use the same CZI-document as before, but we use subblock-cache 
+    auto czi_document_as_blob = CreateCziWithFourSubblockInMosaicArragengement();
+
+    const auto memory_stream = make_shared<CMemInputOutputStream>(get<0>(czi_document_as_blob).get(), get<1>(czi_document_as_blob));
+    const auto reader = CreateCZIReader();
+    reader->Open(memory_stream);
+
+    const auto accessor = reader->CreateSingleChannelScalingTileAccessor();
+    const auto subblock_cache = CreateSubBlockCache();
+    const CDimCoordinate plane_coordinate{ {DimensionIndex::C, 0} };
+    ISingleChannelScalingTileAccessor::Options options;
+    options.Clear();
+    options.backGroundColor = RgbFloatColor{ 0,0,0 };   // request to have background cleared with black
+    options.subBlockCache = subblock_cache;
+    options.onlyUseSubBlockCacheForCompressedData = false;
+
+    // act
+    auto composite_bitmap = accessor->Get(
+        PixelType::Gray8,
+        IntRect{ 1,1,2,2 },
+        &plane_coordinate,
+        1,
+        &options);
+
+    // assert
+
+    // first, check that the result is correct
+    ASSERT_EQ(composite_bitmap->GetWidth(), 2);
+    ASSERT_EQ(composite_bitmap->GetHeight(), 2);
+    {
+        const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+        const uint8_t pixel_x0_y0 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + 0);
+        const uint8_t pixel_x1_y0 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + 1);
+        const uint8_t pixel_x0_y1 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + static_cast<size_t>(1) * lock_info_bitmap.stride + 0);
+        const uint8_t pixel_x1_y1 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + static_cast<size_t>(1) * lock_info_bitmap.stride + 1);
+
+        EXPECT_EQ(pixel_x0_y0, 1);
+        EXPECT_EQ(pixel_x1_y0, 2);
+        EXPECT_EQ(pixel_x0_y1, 3);
+        EXPECT_EQ(pixel_x1_y1, 4);
+    }
+
+    const auto cache_statistics = subblock_cache->GetStatistics(ISubBlockCacheStatistics::kMemoryUsage | ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_GE(cache_statistics.memoryUsage, 16);
+    EXPECT_EQ(cache_statistics.elementsCount, 4);
+
+    // now, we do the same request again, and this time we expect that the subblock-cache is used
+    composite_bitmap = accessor->Get(
+        PixelType::Gray8,
+        IntRect{ 1,1,2,2 },
+        &plane_coordinate,
+        1,
+        &options);
+
+    // we check that the result is the same as before
+    ASSERT_EQ(composite_bitmap->GetWidth(), 2);
+    ASSERT_EQ(composite_bitmap->GetHeight(), 2);
+    {
+        const ScopedBitmapLockerSP lock_info_bitmap{ composite_bitmap };
+        const uint8_t pixel_x0_y0 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + 0);
+        const uint8_t pixel_x1_y0 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + 1);
+        const uint8_t pixel_x0_y1 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + static_cast<size_t>(1) * lock_info_bitmap.stride + 0);
+        const uint8_t pixel_x1_y1 = *(static_cast<const uint8_t*>(lock_info_bitmap.ptrDataRoi) + static_cast<size_t>(1) * lock_info_bitmap.stride + 1);
+
+        EXPECT_EQ(pixel_x0_y0, 1);
+        EXPECT_EQ(pixel_x1_y0, 2);
+        EXPECT_EQ(pixel_x0_y1, 3);
+        EXPECT_EQ(pixel_x1_y1, 4);
+    }
+}

--- a/Src/libCZI_UnitTests/test_SubBlockCache.cpp
+++ b/Src/libCZI_UnitTests/test_SubBlockCache.cpp
@@ -85,6 +85,8 @@ TEST(SubBlockCache, GetStatistics)
 
 TEST(SubBlockCache, PruneCacheCase1)
 {
+    // We add two elements to the cache, making the last-added element the least recently used one. When then pruning the cache to 1 element,
+    // the first added element (with key=0) should be removed.
     const auto cache = CreateSubBlockCache();
     const auto bm1 = CreateTestBitmap(PixelType::Bgr24, 163, 128);
     cache->Add(0, bm1);
@@ -104,6 +106,8 @@ TEST(SubBlockCache, PruneCacheCase1)
 
 TEST(SubBlockCache, PruneCacheCase2)
 {
+    // We add two items to the cache (with key 0, 1). Then, we retrieve element 0 from the cache, which makes it the least recently used one.
+    // When then pruning the cache to 1 element, element 1 should be removed.
     const auto cache = CreateSubBlockCache();
     const auto bm1 = CreateTestBitmap(PixelType::Bgr24, 163, 128);
     cache->Add(0, bm1);
@@ -127,6 +131,9 @@ TEST(SubBlockCache, PruneCacheCase2)
 
 TEST(SubBlockCache, PruneCacheCase3)
 {
+    // We add three items to the cache (with key 0, 1, 2), each one byte in size. Then, we request to prune the cache
+    // to 1 byte max memory usage. This should remove the first two items from the cache (since they are the oldest entries), 
+    // and keep the last one.
     const auto cache = CreateSubBlockCache();
     const auto bm1 = CreateTestBitmap(PixelType::Gray8, 1, 1);
     cache->Add(0, bm1);

--- a/Src/libCZI_UnitTests/test_SubBlockCache.cpp
+++ b/Src/libCZI_UnitTests/test_SubBlockCache.cpp
@@ -124,3 +124,28 @@ TEST(SubBlockCache, PruneCacheCase2)
     bitmap_from_cache = cache->Get(1);
     EXPECT_TRUE(bitmap_from_cache == nullptr);
 }
+
+TEST(SubBlockCache, PruneCacheCase3)
+{
+    const auto cache = CreateSubBlockCache();
+    const auto bm1 = CreateTestBitmap(PixelType::Gray8, 1, 1);
+    cache->Add(0, bm1);
+    const auto bm2 = CreateTestBitmap(PixelType::Gray8, 1, 1);
+    cache->Add(1, bm2);
+    const auto bm3 = CreateTestBitmap(PixelType::Gray8, 1, 1);
+    cache->Add(2, bm3);
+
+    ISubBlockCache::PruneOptions prune_options;
+    prune_options.maxMemoryUsage = 1;
+    cache->Prune(prune_options);
+    const auto statistics_elements_count = cache->GetStatistics(ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.validityMask, ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.elementsCount, 1);
+
+    auto bitmap_from_cache = cache->Get(0);
+    EXPECT_TRUE(bitmap_from_cache == nullptr);
+    bitmap_from_cache = cache->Get(1);
+    EXPECT_TRUE(bitmap_from_cache == nullptr);
+    bitmap_from_cache = cache->Get(2);
+    EXPECT_TRUE(bitmap_from_cache != nullptr);
+}

--- a/Src/libCZI_UnitTests/test_SubBlockCache.cpp
+++ b/Src/libCZI_UnitTests/test_SubBlockCache.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2017-2022 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "include_gtest.h"
+#include "inc_libCZI.h"
+#include "utils.h"
+
+using namespace libCZI;
+using namespace std;
+
+TEST(SubBlockCache, SimpleUseCase1)
+{
+    const auto cache = CreateSubBlockCache();
+    const auto bm1 = CreateTestBitmap(PixelType::Bgr24, 163, 128);
+    cache->Add(0, bm1);
+    const auto bm2 = CreateTestBitmap(PixelType::Bgr24, 161, 114);
+    cache->Add(1, bm2);
+
+    const auto bitmap_from_cache_1 = cache->Get(0);
+    EXPECT_TRUE(AreBitmapDataEqual(bm1, bitmap_from_cache_1));
+
+    const auto bitmap_from_cache_2 = cache->Get(1);
+    EXPECT_TRUE(AreBitmapDataEqual(bm2, bitmap_from_cache_2));
+}
+
+TEST(SubBlockCache, SimpleUseCase2)
+{
+    const auto cache = CreateSubBlockCache();
+    const auto bm1 = CreateTestBitmap(PixelType::Bgr24, 163, 128);
+    cache->Add(0, bm1);
+    const auto bm2 = CreateTestBitmap(PixelType::Bgr24, 161, 114);
+    cache->Add(1, bm2);
+
+    const auto bitmap_from_cache_3 = cache->Get(3);
+    EXPECT_TRUE(!bitmap_from_cache_3);
+}
+
+TEST(SubBlockCache, OverwriteExisting)
+{
+    const auto cache = CreateSubBlockCache();
+    const auto bm1 = CreateTestBitmap(PixelType::Bgr24, 163, 128);
+    cache->Add(0, bm1);
+    const auto bm2 = CreateTestBitmap(PixelType::Bgr24, 161, 114);
+    cache->Add(1, bm2);
+    const auto bm3 = CreateTestBitmap(PixelType::Gray8, 11, 14);
+    cache->Add(1, bm3);
+
+    const auto bitmap_from_cache_1 = cache->Get(0);
+    EXPECT_TRUE(AreBitmapDataEqual(bm1, bitmap_from_cache_1));
+
+    const auto bitmap_from_cache_2 = cache->Get(1);
+    EXPECT_TRUE(AreBitmapDataEqual(bm3, bitmap_from_cache_2));
+
+    const auto statistics_memory_usage = cache->GetStatistics(ISubBlockCacheStatistics::kMemoryUsage);
+    EXPECT_EQ(statistics_memory_usage.validityMask, ISubBlockCacheStatistics::kMemoryUsage);
+    EXPECT_EQ(statistics_memory_usage.memoryUsage, 163 * 128 *3 + 11 * 14);
+
+    const auto statistics_elements_count = cache->GetStatistics(ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.validityMask, ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.elementsCount, 2);
+}
+
+TEST(SubBlockCache, GetStatistics)
+{
+    const auto cache = CreateSubBlockCache();
+    const auto bm1 = CreateTestBitmap(PixelType::Gray8, 4, 2);
+    cache->Add(0, bm1);
+    const auto bm2 = CreateTestBitmap(PixelType::Gray16, 2, 2);
+    cache->Add(1, bm2);
+
+    const auto statistics_memory_usage = cache->GetStatistics(ISubBlockCacheStatistics::kMemoryUsage);
+    EXPECT_EQ(statistics_memory_usage.validityMask, ISubBlockCacheStatistics::kMemoryUsage);
+    EXPECT_EQ(statistics_memory_usage.memoryUsage, 4 * 2 + 2 * 2 * 2);
+
+    const auto statistics_elements_count = cache->GetStatistics(ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.validityMask, ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_elements_count.elementsCount, 2);
+
+    const auto statistics_both = cache->GetStatistics(ISubBlockCacheStatistics::kMemoryUsage | ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_both.validityMask, ISubBlockCacheStatistics::kMemoryUsage | ISubBlockCacheStatistics::kElementsCount);
+    EXPECT_EQ(statistics_both.memoryUsage, 4 * 2 + 2 * 2 * 2);
+    EXPECT_EQ(statistics_both.elementsCount, 2);
+}
+

--- a/Src/libCZI_UnitTests/test_reader.cpp
+++ b/Src/libCZI_UnitTests/test_reader.cpp
@@ -10,6 +10,25 @@ using namespace std;
 
 TEST(DimCoordinate, ReaderException)
 {
+    class MyException : public std::exception
+    {
+    private:
+        std::string exception_text_;
+        std::error_code code_;
+    public:
+        MyException(const std::string& exceptionText, std::error_code code) :exception_text_(exceptionText), code_(code) {}
+
+        const char* what() const noexcept override
+        {
+            return this->exception_text_.c_str();
+        }
+
+        std::error_code code() const noexcept
+        {
+            return this->code_;
+        }
+    };
+
     class CTestStreamImp :public libCZI::IStream
     {
     private:
@@ -20,7 +39,7 @@ TEST(DimCoordinate, ReaderException)
 
         virtual void Read(std::uint64_t offset, void* pv, std::uint64_t size, std::uint64_t* ptrBytesRead) override
         {
-            throw std::ios_base::failure(this->exceptionText, this->code);
+            throw MyException(this->exceptionText, this->code);
         }
     };
 
@@ -39,7 +58,7 @@ TEST(DimCoordinate, ReaderException)
         {
             excp.rethrow_nested();
         }
-        catch (std::ios_base::failure& innerExcp)
+        catch (MyException& innerExcp)
         {
             // according to standard, the content of the what()-test is implementation-specific,
             // so it is not suited for checking - but it seems that the code goes unaltered


### PR DESCRIPTION
## Description

* adding the option to use a cache with the accessors
* an implementation of a simple cache
* adding an example of its usage to CZIcmd
* unrelated: updated CLI11 to latest version (c.f. [here](https://github.com/CLIUtils/CLI11/releases)), no changes in functionality expected for our usage
* added an option to enable/disable the"non-visible-tile-optimization" from #78 to CZICmd. 

The PR is addressing #77.

With the CZI-document mentioned in #73 I get the following runtimes for

| description | run-time | command line |
| ----  | ----  | ----- |
| with 50MB cache and w/o visibility-check-optimization | 3m 16s | `.\CZIcmd.exe "-c" "PlaneScan" "-p" "C0" "-s" "sample_from_73.czi" "-r" "rel(0,0,44296,36989)" "-o" "I:\scanplane\test" "-z" "1" "--cachesize" "50Mi" -b 0 --tilesize-for-plane-scan 512x512` |
| with 50MB cache and w/ visibility-check-optimization | 2m 47s | `.\CZIcmd.exe "-c" "PlaneScan" "-p" "C0" "-s" "sample_from_73.czi" "-r" "rel(0,0,44296,36989)" "-o" "I:\scanplane\test" "-z" "1" "--cachesize" "50Mi" -b 0 --tilesize-for-plane-scan 512x512 --use-visibility-check-optimization` |
| no cache and w/o visibility-check-optimization | 11m 50s | `.\CZIcmd.exe "-c" "PlaneScan" "-p" "C0" "-s" "sample_from_73.czi" "-r" "rel(0,0,44296,36989)" "-o" "I:\scanplane\test" "-z" "1" "--cachesize" "0Mi" -b 0 --tilesize-for-plane-scan 512x512` |
| no cache and w/ visibility-check-optimization | 10m 02s | `.\CZIcmd.exe "-c" "PlaneScan" "-p" "C0" "-s" "sample_from_73.czi" "-r" "rel(0,0,44296,36989)" "-o" "I:\scanplane\test" "-z" "1" "--cachesize" "0Mi" -b 0 --tilesize-for-plane-scan 512x512  --use-visibility-check-optimization |
 
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

* locally (using CZICmd and the newly added command)
* unittests

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
