### PR TITLE
small adjustment to how a system-provided libCURL is searched for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.57.0
+      VERSION 0.57.1
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -15,10 +15,14 @@ if (LIBCZI_BUILD_CURL_BASED_STREAM)
   if (LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL)
     find_package(CURL CONFIG QUIET)
     if (NOT CURL_FOUND)
-      message(FATAL_ERROR [=[
-        CURL library was not found, which is required for building. Consider installing it with a package manager, something
-        like 'sudo apt-get install libcurl4-openssl-dev', or disable the option 'LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL'.
-      ]=])
+      message(STATUS "Did not find a package configuration file provided by CURL, will try to locate CURL package by standard search procedure.")
+      find_package(CURL QUIET)
+      if (NOT CURL_FOUND)
+        message(FATAL_ERROR [=[
+          CURL library was not found, which is required for building. Consider installing it with a package manager, something
+          like 'sudo apt-get install libcurl4-openssl-dev', or disable the option 'LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL'.
+        ]=])
+      endif()
     endif()
 
     message(STATUS "Found CURL version: ${CURL_VERSION_STRING}")

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -13,3 +13,4 @@ version history                 {#version_history}
  0.55.1             | [80](https://github.com/ZEISS/libczi/pull/80)        | bugfix for above optimization
  0.56.0             | [82](https://github.com/ZEISS/libczi/pull/82)        | add option "kCurlHttp_CaInfo" & "kCurlHttp_CaInfoBlob", allow to retrieve properties from a stream-class
  0.57.0             | [84](https://github.com/ZEISS/libczi/pull/84)        | add caching for accessors, update CLI11 to version 2.3.2
+ 0.57.1             | [86](https://github.com/ZEISS/libczi/pull/86)        | small improvement for CMake-build: allow to use an apt-provided CURL-package


### PR DESCRIPTION
## Description

We used `find_package(CURL CONFIG QUIET)` to pull in an externally provided libcurl-library, which means that CMake is only looking for package configuration files (CURLConfig.cmake or curl-config.cmake file). However, those files are not provided e.g. by Debian's 'libcurl4-openssl-dev'-package. So, we fall back to CMake's standard search procedure if `find_package(CURL CONFIG QUIET)`  fails and try again with `find_package(CURL QUIET)`.
This allows us to use the apt-package without further ado in building libCZI, saving quite some time compared to otherwise having to build libcurl ourselves (with vcpkg or as part of libCZI-build).

I chose to bump the version number here, in order to be able to mention this change in the changelog.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In a codespace

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
