### PR TITLE
feat: Show path and ID of missing node when trying to find channel in…

### DIFF
--- a/Src/libCZI/CziMetadata.h
+++ b/Src/libCZI/CziMetadata.h
@@ -15,9 +15,14 @@ class CCziMetadata : public libCZI::ICziMetadata, public std::enable_shared_from
 private:
     struct XmlNodeWrapperThrowExcp
     {
-        [[noreturn]] static void ThrowInvalidPath()
+        [[noreturn]] static void ThrowInvalidPath(const char* path="")
         {
-            throw libCZI::LibCZIMetadataException("invalid path", libCZI::LibCZIMetadataException::ErrorType::InvalidPath);
+            std::string message = "invalid path";
+            if (path && *path != '\0') {
+                message += ": ";
+                message += path;
+            }
+            throw libCZI::LibCZIMetadataException(message.c_str(), libCZI::LibCZIMetadataException::ErrorType::InvalidPath);
         }
     };
 

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -5,7 +5,6 @@
 #include "CziMetadataBuilder.h"
 #include "utilities.h"
 #include <regex>
-#include <codecvt>
 #include <iomanip>
 #include <limits>
 #include "CziUtils.h"
@@ -15,9 +14,13 @@ using namespace pugi;
 using namespace libCZI;
 using namespace std;
 
-/*static*/void CNodeWrapper::MetadataBuilderXmlNodeWrapperThrowExcp::ThrowInvalidPath()
-{
-    throw libCZI::LibCZIMetadataBuilderException("invalid path", libCZI::LibCZIMetadataBuilderException::ErrorType::InvalidPath);
+/*static*/ void CNodeWrapper::MetadataBuilderXmlNodeWrapperThrowExcp::ThrowInvalidPath(const char* path){
+    std::string message = "invalid path";
+    if (path && *path != '\0') {
+        message += ": ";
+        message += path;
+    }
+    throw libCZI::LibCZIMetadataBuilderException(message.c_str(), libCZI::LibCZIMetadataBuilderException::ErrorType::InvalidPath);
 }
 
 /*virtual*/std::shared_ptr<libCZI::IXmlNodeRw> CNodeWrapper::AppendChildNode(const char* name)

--- a/Src/libCZI/CziMetadataBuilder.h
+++ b/Src/libCZI/CziMetadataBuilder.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <tuple>
 #include <string>
+#include <codecvt>
 #include "libCZI.h"
 #include "CziSubBlockDirectory.h"
 #include "pugixml.hpp"
@@ -36,7 +37,7 @@ private:
     std::shared_ptr<CCZiMetadataBuilder> builderRef;
     struct MetadataBuilderXmlNodeWrapperThrowExcp
     {
-        static void ThrowInvalidPath();
+        static void ThrowInvalidPath(const char* path="");
     };
 public:
     CNodeWrapper(std::shared_ptr<CCZiMetadataBuilder> builderRef, pugi::xml_node_struct* node_struct) :


### PR DESCRIPTION
## Description
This PR proposes to add more information to some error messages that re related to missing nodes in the XML metadata.
In the context of pylibczirw it is possible to provoke undefined states where the image metadata does not match the actual subblocks. For example, consider this code snippet:
```python
  with create_czi("test.czi")) as test_czi:
      # Write data to the CZI since behavior on empty images in not well-defined
      test_czi.write(data=np.zeros((100, 100), dtype=np.uint8), plane={"C": 0})
      ### THIS LINE IS ACTUALLY NEEDED test_czi.write(data=np.zeros((100, 100), dtype=np.uint8), plane={"C": 1})
      # Write metadata
      test_czi.write_metadata(
          document_name="TestWriteMetadata",
          scale_x=1.0,
          scale_y=2.0,
          scale_z=3.0,
          channel_names={0: "TestCh0", 1: "TestCh1"},
          display_settings={
                0: ChannelDisplaySettingsDataClass(
                    True,
                    TintingMode.Color,
                    Rgb8Color(np.uint8(0x01), np.uint8(0x02), np.uint8(0x03)),
                    0.2,
                    0.8,
                ),
                1: ChannelDisplaySettingsDataClass(
                    True,
                    TintingMode.Color,
                    Rgb8Color(np.uint8(0xFF), np.uint8(0xFE), np.uint8(0xFD)),
                    0.3,
                    0.7,
                ),
            },
      )
```

Note that the image is supposed to yield two channels (as defined in the display settings and the chanel names), but there is only written data for one channel since ` test_czi.write(data=np.zeros((100, 100), dtype=np.uint8), plane={"C": 1})` is commented.
Since libczi is fetching the channel ID and name from the metadata that is being written when writing the subblocks, it will, as expected, not be able to fetch the channel ID and name and rais an exception when writing the metadata. However, the error being raised is very generic and does not provide any information about what the underlying cause. This PR proposes to enable the error to show the path and index of the node such that the underlying issue is easier to understand.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run the code snippet above with pylibczirw baced by the PR version of libczi.

## Checklist:

- [x ] I followed the Contributing Guidelines.
- [x ] I did a self-review.
- [x ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x ] New and existing unit tests pass locally with my changes.
