### PR TITLE
add Azure-SDK-based stream-object

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           # find the CZIcmd executable (we just built it)
-          czicmd=$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) | xargs realpath)
+          czicmd=$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)
           mkdir -p azurite
           cd azurite
           # now use the CZIcmd executable to create a test CZI file
@@ -84,13 +84,18 @@ jobs:
           ls -l
           # start Azurite in the background
           azurite --inMemoryPersistence --silent  &
+          # this is the "default connection string" for Azurite
+          connectionstring="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           # create a blob container "testcontainer"
-          az storage container create --name testcontainer  --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          az storage container create --name testcontainer  --connection-string "$connectionstring"
           # upload the test CZI file to the container
-          az storage blob upload  --container-name testcontainer --file "./test.czi" --name testblob --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$connectionstring"
+          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=$(printf '%q' "$connectionstring")" >> $GITHUB_ENV
 
       - name: Test
         working-directory: ${{github.workspace}}/build
+        env:
+          AZURE_BLOB_STORE_CONNECTION_STRING: ${{ env.UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING }}
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         # Use debug flag to show all exeucted tests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,11 +80,18 @@ jobs:
           mkdir release
           name="CZICmd-windows-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd
-          #cp ./build/CZICheck/${{ matrix.build }}/*.exe "release/${name}/"
+          #ls -R Src/CZICmd
+          cp Src/CZICmd/Release/CZIcmd.exe "release/${name}/"
           #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=release/${name}" >> "$GITHUB_ENV"
+
+      - name: Upload artifacts
+        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Release') }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.artifactPath }}/
+          name: ${{ env.artifactName }}
 
       # Coverage collection based on https://about.codecov.io/blog/how-to-set-up-codecov-with-c-plus-plus-and-github-actions/
       - name: Prepare Coverage

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: ["main","jbl/azure_sdk_experimental"]
+    branches: ["main", "jbl/azure_sdk_experimental"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,9 +71,14 @@ jobs:
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build}} -j
 
-      - name: Setup Azurite
+      - name: Test
         shell: bash
-        working-directory: ${{github.workspace}}
+        working-directory: ${{github.workspace}}/build
+        env:
+          AZURE_BLOB_STORE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        # Use debug flag to show all exeucted tests
         run: |
           # find the CZIcmd executable (we just built it)
           czicmd="$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
@@ -84,24 +89,11 @@ jobs:
           ls -l
           # start Azurite in the background
           azurite --inMemoryPersistence --silent &
-          # this is the "default connection string" for Azurite
-          connectionstring="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           # create a blob container "testcontainer"
-          az storage container create --name testcontainer  --connection-string "$connectionstring"
+          az storage container create --name testcontainer  --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           # upload the test CZI file to the container
-          az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$connectionstring"
-          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=$connectionstring" >> $GITHUB_ENV
-
-      - name: Test
-        shell: bash
-        working-directory: ${{github.workspace}}/build
-        env:
-          AZURE_BLOB_STORE_CONNECTION_STRING: ${{ env.UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING }}
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        # Use debug flag to show all exeucted tests
-        run: |
-          echo "AZURE_BLOB_STORE_CONNECTION_STRING=$AZURE_BLOB_STORE_CONNECTION_STRING"
+          az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
+          cd ..
           ctest --debug -C ${{matrix.build}}
 
       - name: Upload CZICmd as artifact (Windows)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,9 +76,6 @@ jobs:
         working-directory: ${{github.workspace}}/build
         env:
           AZURE_BLOB_STORE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        # Use debug flag to show all exeucted tests
         run: |
           # find the CZIcmd executable (we just built it)
           czicmd="$(find . \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
@@ -94,11 +91,17 @@ jobs:
           # upload the test CZI file to the container
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           cd ..
-          az storage container list --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
-          echo "******* TESTING CZIcmd *******"
-          "$czicmd" --command PrintInformation --source-stream-class azure_blob_inputstream --source 'account=libczirwtestdata;containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;' --propbag-source-stream-creation  '{"AzureBlob_AuthenticationMode":"ConnectionString"}'
-          echo "####### TESTING CZIcmd #######"
+          #"$czicmd" --command PrintInformation --source-stream-class azure_blob_inputstream --source 'account=libczirwtestdata;containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;' --propbag-source-stream-creation  '{"AzureBlob_AuthenticationMode":"ConnectionString"}'
+          # Execute tests defined by the CMake configuration.
+          # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+          # Use debug flag to show all executed tests
           ctest --debug -C ${{matrix.build}}
+          # now, kill the Azurite process as we don't need it anymore
+          if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
+              pkill -f azurite  # Terminate on Linux
+          elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+              taskkill //IM node.exe //F  # Terminate on Windows
+          fi
 
       - name: Upload CZICmd as artifact (Windows)
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: ["main", "jbl/azure_sdk_experimental"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,7 +90,7 @@ jobs:
           az storage container create --name testcontainer  --connection-string "$connectionstring"
           # upload the test CZI file to the container
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$connectionstring"
-          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=$(printf '%q' "$connectionstring")" >> $GITHUB_ENV
+          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=\"$connectionstring\"" >> $GITHUB_ENV
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,7 +81,7 @@ jobs:
         # Use debug flag to show all exeucted tests
         run: |
           # find the CZIcmd executable (we just built it)
-          czicmd="$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
+          czicmd="$(find . \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
           mkdir -p azurite
           cd azurite
           # now use the CZIcmd executable to create a test CZI file

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,11 +76,11 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           # find the CZIcmd executable (we just built it)
-          czicmd=$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)
+          czicmd="$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
           mkdir -p azurite
           cd azurite
           # now use the CZIcmd executable to create a test CZI file
-          "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
+          "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack" --createsubblocksize "1024x1024" -o test --bitmapgenerator default
           ls -l
           # start Azurite in the background
           azurite --inMemoryPersistence --silent  &
@@ -91,7 +91,7 @@ jobs:
           az storage container create --name testcontainer  --connection-string "$connectionstring"
           # upload the test CZI file to the container
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$connectionstring"
-          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=\"$connectionstring\"" >> $GITHUB_ENV
+          echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=$connectionstring" >> $GITHUB_ENV
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,7 +81,12 @@ jobs:
           # now use the CZIcmd executable to create a test CZI file
           $czicmd --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
           ls -l
-          #azurite-blob --silent &
+          # start Azurite in the background
+          azurite --inMemoryPersistence --silent  &
+          # create a blob container "testcontainer"
+          az storage container create --name testcontainer  --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          # upload the test CZI file to the container
+          az storage blob upload  --container-name testcontainer --file ./test.czi" --name testblob --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
-        if: ${{ (github.ref == 'refs/heads/main') && (matrix.OS == 'windows-latest') && (matrix.build == 'Debug') }}
+        if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Debug') }}
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,10 +47,10 @@ jobs:
           sudo apt-get install libssl-dev -y
           vcpkg install azure-storage-blobs-cpp azure-identity-cpp
 
-      - name: Install Azurite (for Azure SDK based stream tests) 
-        shell: bash 
-        run: | 
-          npm install --location=global azurite@3.30.0 
+      - name: Install Azurite (for Azure SDK based stream tests)
+        shell: bash
+        run: |
+          npm install --location=global azurite@3.30.0
 
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}
@@ -87,7 +87,7 @@ jobs:
           # create a blob container "testcontainer"
           az storage container create --name testcontainer  --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           # upload the test CZI file to the container
-          az storage blob upload  --container-name testcontainer --file ./test.czi" --name testblob --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          az storage blob upload  --container-name testcontainer --file "./test.czi" --name testblob --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,6 +94,7 @@ jobs:
           # upload the test CZI file to the container
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           cd ..
+          az storage container list --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           ctest --debug -C ${{matrix.build}}
 
       - name: Upload CZICmd as artifact (Windows)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,11 +73,12 @@ jobs:
 
       - name: Setup Azurite
         shell: bash
+        working-directory: ${{github.workspace}}
         run: |
           # find the CZIcmd executable (we just built it)
-          czicmd=$(find ${{github.workspace}}/build \( -name CZIcmd -o -name CZIcmd.exe \) )
-          mkdir -p ${{github.workspace}}/azurite
-          cd ${{github.workspace}}/azurite
+          czicmd=$(find ./build \( -name CZIcmd -o -name CZIcmd.exe \) | xargs realpath)
+          mkdir -p azurite
+          cd azurite
           # now use the CZIcmd executable to create a test CZI file
           $czicmd --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
           ls -l

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,10 +80,11 @@ jobs:
           mkdir -p azurite
           cd azurite
           # now use the CZIcmd executable to create a test CZI file
-          $czicmd --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
+          "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
           ls -l
           # start Azurite in the background
           azurite --inMemoryPersistence --silent  &
+          disown # Disown the process so it persists after this step
           # this is the "default connection string" for Azurite
           connectionstring="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           # create a blob container "testcontainer"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,6 +85,19 @@ jobs:
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
 
+      - name: Upload CZICmd as artifact (Linux)
+        working-directory: ${{github.workspace}}/build
+        if: ${{ (matrix.OS == 'ubuntu-latest') && ( matrix.build == 'Release') }}
+        shell: bash
+        run: |
+          mkdir release
+          name="CZICmd-linux-x64-$(git describe --always)"
+          mkdir "release/${name}"
+          ls -R Src/CZICmd/Release
+          cp Src/CZICmd/Release/CZIcmd "release/${name}/"
+          echo "artifactName=${name}" >> "$GITHUB_ENV"
+          echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
+
       - name: Upload artifacts
         if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Release') }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -83,8 +83,7 @@ jobs:
           "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack" --createsubblocksize "1024x1024" -o test --bitmapgenerator default
           ls -l
           # start Azurite in the background
-          azurite --inMemoryPersistence --silent  &
-          disown # Disown the process so it persists after this step
+          azurite --inMemoryPersistence --silent &
           # this is the "default connection string" for Azurite
           connectionstring="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
           # create a blob container "testcontainer"
@@ -100,7 +99,9 @@ jobs:
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         # Use debug flag to show all exeucted tests
-        run: ctest --debug -C ${{matrix.build}}
+        run: |
+          ps -a
+          ctest --debug -C ${{matrix.build}}
 
       - name: Upload CZICmd as artifact (Windows)
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,7 +90,6 @@ jobs:
           cd azurite
           # now use the CZIcmd executable to create a test CZI file
           "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack" --createsubblocksize "1024x1024" -o test --bitmapgenerator default
-          ls -l
           # start Azurite in the background
           azurite --inMemoryPersistence --silent &
           # create a blob container "testcontainer"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,8 +93,8 @@ jobs:
           mkdir release
           name="CZICmd-linux-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd/Release
-          cp Src/CZICmd/Release/CZIcmd "release/${name}/"
+          ls -R Src/CZICmd/
+          cp Src/CZICmd/CZIcmd "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,7 +91,9 @@ jobs:
           # upload the test CZI file to the container
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           cd ..
-          #"$czicmd" --command PrintInformation --source-stream-class azure_blob_inputstream --source 'account=libczirwtestdata;containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;' --propbag-source-stream-creation  '{"AzureBlob_AuthenticationMode":"ConnectionString"}'
+          #"$czicmd" --command PrintInformation --source-stream-class azure_blob_inputstream --source 'account=libczirwtestdata;containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;'
+          #    --propbag-source-stream-creation '{"AzureBlob_AuthenticationMode":"ConnectionString"}'
+          #
           # Execute tests defined by the CMake configuration.
           # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
           # Use debug flag to show all executed tests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,11 +47,6 @@ jobs:
           sudo apt-get install libssl-dev -y
           vcpkg install azure-storage-blobs-cpp azure-identity-cpp
 
-      - name: Install Azurite (for Azure SDK based stream tests)
-        shell: bash
-        run: |
-          npm install --location=global azurite@3.30.0
-
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}
         shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Test
         shell: bash
         working-directory: ${{github.workspace}}/build
-        env:  
+        env:
           # This is the "default-Azurite-connection string", we put it here into the environment (so that it can be picked up by the unittest later on)
           AZURE_BLOB_STORE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
           mkdir release
           name="CZICmd-windows-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd/prosRelease/
+          ls -R Src/CZICmd/Release/
           cp Src/CZICmd/Release/CZIcmd.exe "release/${name}/"
           ls -R "release/${name}"
           #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Azurite (for Azure SDK based stream tests)
         shell: bash
         run: |
-          npm install --location=global azurite@3.30.0
+          npm install --location=global azurite
 
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -104,12 +104,7 @@ jobs:
           # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
           # Use debug flag to show all executed tests
           ctest --debug -C ${{matrix.build}}
-          # now, kill the Azurite process as we don't need it anymore
-          if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
-              pkill -f azurite  # Terminate on Linux
-          elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-              taskkill //IM node.exe //F  # Terminate on Windows
-          fi
+          # note that we leave the Azurite process running, as we want to use it with the code-coverage step as well
 
       - name: Upload CZICmd as artifact (Windows)
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main","jbl/azure_sdk_experimental"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,15 +80,12 @@ jobs:
           mkdir release
           name="CZICmd-windows-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd/Release/
           cp Src/CZICmd/Release/CZIcmd.exe "release/${name}/"
-          ls -R "release/${name}"
-          #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
 
       - name: Upload artifacts
-        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Release') }}
+        if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Release') }}
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.artifactPath }}/
@@ -96,20 +93,20 @@ jobs:
 
       # Coverage collection based on https://about.codecov.io/blog/how-to-set-up-codecov-with-c-plus-plus-and-github-actions/
       - name: Prepare Coverage
-        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}
+        if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Debug') }}
         run: |
           choco install OpenCppCoverage -y --no-progress
           echo "C:\Program Files\OpenCppCoverage" >> "$env:GITHUB_PATH"
 
       - name: Get Coverage
-        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}
+        if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Debug') }}
         working-directory: ${{github.workspace}}/build/Src/libCZI_UnitTests/${{matrix.build}}
         shell: cmd
         run: OpenCppCoverage.exe --export_type cobertura:${{github.workspace}}\coverage.xml --config_file "${{github.workspace}}\opencppcoverage.txt" -- libCZI_UnitTests.exe
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
-        if: ${{ (github.ref == 'refs/heads/main') && (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}
+        if: ${{ (github.ref == 'refs/heads/main') && (matrix.OS == 'windows-latest') && (matrix.build == 'Debug') }}
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,6 +47,11 @@ jobs:
           sudo apt-get install libssl-dev -y
           vcpkg install azure-storage-blobs-cpp azure-identity-cpp
 
+      - name: Install Azurite (for Azure SDK based stream tests) 
+        shell: bash 
+        run: | 
+          npm install --location=global azurite@3.30.0 
+
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}
         shell: bash
@@ -65,6 +70,18 @@ jobs:
       - name: Build
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build}}
+
+      - name: Setup Azurite
+        shell: bash
+        run: |
+          # find the CZIcmd executable (we just built it)
+          czicmd=$(find ${{github.workspace}}/build \( -name CZIcmd -o -name CZIcmd.exe \) )
+          mkdir -p ${{github.workspace}}/azurite
+          cd ${{github.workspace}}/azurite
+          # now use the CZIcmd executable to create a test CZI file
+          $czicmd --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"  --createsubblocksize "1024x1024" -o test  --bitmapgenerator default
+          ls -l
+          #azurite-blob --silent &
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,8 +80,9 @@ jobs:
           mkdir release
           name="CZICmd-windows-x64-$(git describe --always)"
           mkdir "release/${name}"
-          #ls -R Src/CZICmd
+          ls -R Src/CZICmd/Release/
           cp Src/CZICmd/Release/CZIcmd.exe "release/${name}/"
+          ls -R "release/${name}"
           #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=release/${name}" >> "$GITHUB_ENV"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -74,7 +74,8 @@ jobs:
       - name: Test
         shell: bash
         working-directory: ${{github.workspace}}/build
-        env:
+        env:  
+          # This is the "default-Azurite-connection string", we put it here into the environment (so that it can be picked up by the unittest later on)
           AZURE_BLOB_STORE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
         run: |
           # What we do here:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build
         # Build your program with the given configuration
-        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build}}
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.build}} -j
 
       - name: Setup Azurite
         shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,12 +80,12 @@ jobs:
           mkdir release
           name="CZICmd-windows-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd/Release/
+          ls -R Src/CZICmd/prosRelease/
           cp Src/CZICmd/Release/CZIcmd.exe "release/${name}/"
           ls -R "release/${name}"
           #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
-          echo "artifactPath=release/${name}" >> "$GITHUB_ENV"
+          echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
 
       - name: Upload artifacts
         if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Release') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -95,6 +95,9 @@ jobs:
           az storage blob upload --container-name testcontainer --file "./test.czi" --name testblob --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           cd ..
           az storage container list --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          echo "******* TESTING CZIcmd *******"
+          "$czicmd" --command PrintInformation --source-stream-class azure_blob_inputstream --source 'account=libczirwtestdata;containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;' --propbag-source-stream-creation  '{"AzureBlob_AuthenticationMode":"ConnectionString"}'
+          echo "####### TESTING CZIcmd #######"
           ctest --debug -C ${{matrix.build}}
 
       - name: Upload CZICmd as artifact (Windows)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,13 +93,12 @@ jobs:
           mkdir release
           name="CZICmd-linux-x64-$(git describe --always)"
           mkdir "release/${name}"
-          ls -R Src/CZICmd/
           cp Src/CZICmd/CZIcmd "release/${name}/"
           echo "artifactName=${name}" >> "$GITHUB_ENV"
           echo "artifactPath=${{github.workspace}}/build/release/${name}" >> "$GITHUB_ENV"
 
       - name: Upload artifacts
-        if: ${{ (matrix.OS == 'windows-latest') && (matrix.build == 'Release') }}
+        if: ${{ ( (matrix.OS == 'windows-latest') || (matrix.OS == 'ubuntu-latest') ) && (matrix.build == 'Release') }}
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.artifactPath }}/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           vcpkg install azure-storage-blobs-cpp:x64-windows-static
           vcpkg install azure-identity-cpp:x64-windows-static
-          vcpkg install rapidjson 'curl[ssl]' --triplet x64-windows
+          vcpkg install rapidjson 'curl[ssl]' --triplet x64-windows-static
 
       - name: Install dependencies (Linux)
         if: ${{ (matrix.OS == 'ubuntu-latest') }}
@@ -53,7 +53,7 @@ jobs:
           # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
           # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
           # on Windows, we need to point CMake to the vcpkg-toolchain-file
-          cmake -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=${{matrix.build}} -DLIBCZI_BUILD_CZICMD=ON -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
+          cmake -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=${{matrix.build}} -DLIBCZI_BUILD_CZICMD=ON -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static
 
       - name: Configure CMake (Linux)
         if: ${{ (matrix.OS == 'ubuntu-latest') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,6 +93,7 @@ jobs:
           echo "UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING=$connectionstring" >> $GITHUB_ENV
 
       - name: Test
+        shell: bash
         working-directory: ${{github.workspace}}/build
         env:
           AZURE_BLOB_STORE_CONNECTION_STRING: ${{ env.UNITTEST_AZUREBLOBSTORE_CONNECTIONSTRING }}
@@ -100,7 +101,7 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         # Use debug flag to show all exeucted tests
         run: |
-          ps -a
+          echo "AZURE_BLOB_STORE_CONNECTION_STRING=$AZURE_BLOB_STORE_CONNECTION_STRING"
           ctest --debug -C ${{matrix.build}}
 
       - name: Upload CZICmd as artifact (Windows)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,6 +45,7 @@ jobs:
           sudo apt-get install libfreetype6-dev -y
           sudo apt-get install rapidjson-dev -y
           sudo apt-get install libssl-dev -y
+          vcpkg install azure-storage-blobs-cpp azure-identity-cpp
 
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}
@@ -59,7 +60,7 @@ jobs:
         if: ${{ (matrix.OS == 'ubuntu-latest') }}
         shell: bash
         run: |
-          cmake -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=${{matrix.build}} -DLIBCZI_BUILD_CZICMD=ON -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF
+          cmake -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=${{matrix.build}} -DLIBCZI_BUILD_CZICMD=ON -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -72,6 +72,20 @@ jobs:
         # Use debug flag to show all exeucted tests
         run: ctest --debug -C ${{matrix.build}}
 
+      - name: Upload CZICmd as artifact (Windows)
+        working-directory: ${{github.workspace}}/build
+        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Release') }}
+        shell: bash
+        run: |
+          mkdir release
+          name="CZICmd-windows-x64-$(git describe --always)"
+          mkdir "release/${name}"
+          ls -R Src/CZICmd
+          #cp ./build/CZICheck/${{ matrix.build }}/*.exe "release/${name}/"
+          #cp ./build/CZICheck/THIRD_PARTY_LICENSES.txt "release/${name}/"
+          echo "artifactName=${name}" >> "$GITHUB_ENV"
+          echo "artifactPath=release/${name}" >> "$GITHUB_ENV"
+
       # Coverage collection based on https://about.codecov.io/blog/how-to-set-up-codecov-with-c-plus-plus-and-github-actions/
       - name: Prepare Coverage
         if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,6 +77,13 @@ jobs:
         env:
           AZURE_BLOB_STORE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
         run: |
+          # What we do here:
+          # - we create a test CZI file (using the CZIcmd executable)
+          # - we start Azurite (in the background)
+          # - we then upload the test CZI file to Azurite as a blob in the container "testcontainer" with name "testblob"
+          # - we then run the unit-tests - the environment variable AZURE_BLOB_STORE_CONNECTION_STRING is used to configure the Azure SDK based stream tests
+          # - finally, we kill the Azurite process
+          #
           # find the CZIcmd executable (we just built it)
           czicmd="$(find . \( -name CZIcmd -o -name CZIcmd.exe \) -print0 | xargs -0 realpath)"
           mkdir -p azurite

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
           # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-          # on Windows, we need to point CMake to the vcpkg-toolchain-file
+          # Note that we need to point CMake to the vcpkg-toolchain-file
           cmake -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=${{matrix.build}} -DLIBCZI_BUILD_CZICMD=ON -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static
 
       - name: Configure CMake (Linux)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
-        if: ${{ (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}
+        if: ${{ (github.ref == 'refs/heads/main') && (matrix.OS == 'windows-latest') && ( matrix.build == 'Debug') }}
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,6 +47,11 @@ jobs:
           sudo apt-get install libssl-dev -y
           vcpkg install azure-storage-blobs-cpp azure-identity-cpp
 
+      - name: Install Azurite (for Azure SDK based stream tests)
+        shell: bash
+        run: |
+          npm install --location=global azurite@3.30.0
+
       - name: Configure CMake (Windows)
         if: ${{ (matrix.OS == 'windows-latest') }}
         shell: bash

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -8,6 +8,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # MegaLinter
       - name: MegaLinter
@@ -38,7 +38,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,7 +5,7 @@ name: MegaLinter
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main","jbl/azure_sdk_experimental"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,7 +5,7 @@ name: MegaLinter
 
 on:
   push:
-    branches: ["main","jbl/azure_sdk_experimental"]
+    branches: ["main", "jbl/azure_sdk_experimental"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -5,7 +5,7 @@ name: MegaLinter
 
 on:
   push:
-    branches: ["main", "jbl/azure_sdk_experimental"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL "Prefer a libcurl package pre
 # This option controls whether to build the Azure-SDK-based-reader object. The Azure-SDK must be externally
 # available (and accessible to CMake's find_package()-command). If using vcpkg, the packages "azure-storage-blobs-cpp"
 # and "azure-identity-cpp" need to be available.
-option(LIBCZI_BUILD_AZURESDK_BASED_STREAM "include AzureSDK-based http-/https-stream object" OFF)
+option(LIBCZI_BUILD_AZURESDK_BASED_STREAM "include AzureSDK-based stream object for accessing Azure-Blob-Store" OFF)
 
 # This option allows to exclude the unit-tests from the build. The unit-tests are using the
 # Google-Test-framework which is downloaded from GitHub during the CMake-run.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.61.2
+      VERSION 0.62.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,10 @@ option(LIBCZI_BUILD_CURL_BASED_STREAM "include curl-based http-/https-stream obj
 # during the CMake-run (and build and use this one).
 option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL "Prefer a libcurl package present on the system" OFF)
 
-
+# This option controls whether to build the Azure-SDK-based-reader object. The Azure-SDK must be externally
+# available (and accessible to CMake's find_package()-command). If using vcpkg, the packages "azure-storage-blobs-cpp"
+# and "azure-identity-cpp" need to be available.
 option(LIBCZI_BUILD_AZURESDK_BASED_STREAM "include AzureSDK-based http-/https-stream object" OFF)
-
-option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_AZURESDK "include AzureSDK-based http-/https-stream object" ON)
-
 
 # This option allows to exclude the unit-tests from the build. The unit-tests are using the
 # Google-Test-framework which is downloaded from GitHub during the CMake-run.

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -67,104 +67,10 @@ endif(LIBCZI_BUILD_CURL_BASED_STREAM)
 if(LIBCZI_BUILD_AZURESDK_BASED_STREAM)
   # -> https://github.com/Azure/azure-sdk-for-cpp#azure-sdk-for-c
   # -> https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal
-  if (LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_AZURESDK)
-    find_package(azure-identity-cpp CONFIG REQUIRED)
-    find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
-    set(LIBCZI_AZURESDK_VERSION_STRING "core:${azure-core-cpp_VERSION} identity:${azure-identity-cpp_VERSION} storage-blobs:${azure-storage-blobs-cpp_VERSION}")
-    message(STATUS "******************** ${LIBCZI_AZURESDK_VERSION_STRING} ********************")
-  else()
-    include(FetchContent)
-
-    # -> https://github.com/Azure/azure-sdk-for-cpp/tree/main/samples/integration/cmake-fetch-content/
-
-    #find_package(azure_macro_utils_c REQUIRED CONFIG)
-
-        # Fetch the WIL repository
-    FetchContent_Declare(
-        wil
-        GIT_REPOSITORY https://github.com/microsoft/wil.git
-       # GIT_TAG        master  # Or specify a specific version/commit
-    )
-    # Make the content available
-    set(WIL_BUILD_TESTS OFF)
-    set(WIL_BUILD_PACKAGING OFF)
-    set(FAST_BUILD ON)
-    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_SOURCE_DIR}/external/wil")
-    FetchContent_MakeAvailable(wil)
-    message(STATUS "********** ${wil_SOURCE_DIR} **********")
-
-    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${CMAKE_SOURCE_DIR}/cmake/dummy")
-
-
-    FetchContent_Declare(azure_macro_utils_c
-        # Set the SDK URL path and release tag
-        GIT_REPOSITORY      https://github.com/Azure/macro-utils-c.git
-        #GIT_TAG             azure-storage-files-datalake_12.0.0-beta.6)
-        GIT_TAG             552dfadfca17c2fb3bd81c44bcbb44ce205817af)
-    FetchContent_MakeAvailable(azure_macro_utils_c)
-    message(STATUS "$$$$$$$$$$ ${azure_macro_utils_c_SOURCE_DIR} $$$$$$$$$$")
-    set(azure_c_shared_utility_DIR  "D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/azure-c-shared-utility-build")
-
-
-    
-    FetchContent_Declare(umock-c
-        # Set the SDK URL path and release tag
-        GIT_REPOSITORY      https://github.com/Azure/umock-c.git
-        GIT_TAG             master)
-    FetchContent_MakeAvailable(umock-c)
-    message(STATUS "########## ${umock-c_SOURCE_DIR} ##########")
-
-    FetchContent_Declare(azure-c-shared-utility
-        # Set the SDK URL path and release tag
-        GIT_REPOSITORY    https://github.com/Azure/azure-c-shared-utility.git
-        GIT_TAG             master)
-    FetchContent_MakeAvailable(azure-c-shared-utility)
-    message(STATUS "++++++++++ ${azure-c-shared-utility_SOURCE_DIR} ++++++++++")
-   # set(azure_c_shared_utility_DIR "D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/azure-c-shared-utility-src")
-   set(azure_c_shared_utility_DIR  "D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/azure-c-shared-utility-src/configs")
-
-
-    set(BUILD_TESTING OFF)
-    FetchContent_Declare(opentelemetry-cpp
-      GIT_REPOSITORY    https://github.com/open-telemetry/opentelemetry-cpp.git
-      GIT_TAG           main)
-    FetchContent_MakeAvailable(opentelemetry-cpp)
-    message(STATUS "&&&&&&&&&& ${opentelemetry-cpp_SOURCE_DIR} &&&&&&&&&&")
-
-
-    #FetchContent_GetProperties(azure_macro_utils_c)
-    #if(NOT azure_macro_utils_c_POPULATED)
-    #    #FetchContent_Populate(azure_macro_utils_c)
-    #    #add_subdirectory(${MACRO_UTILS_INC_FOLDER} )
-    #    #add_subdirectory(deps/macro-utils-c)
-    #    include_directories(${MACRO_UTILS_INC_FOLDER})
-    #endif()
-
-
-
-
-   # find_package(umock_c REQUIRED CONFIG)
-   # find_package(azure_c_shared_utility REQUIRED CONFIG)
-
-    set(MSVC_USE_STATIC_CRT  ON CACHE BOOL "" FORCE)
-    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
-    set(BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
-    set(BUILD_PERFORMANCE_TESTS OFF CACHE BOOL "" FORCE)
-    set(AZURE_SDK_DISABLE_AUTO_VCPKG ON CACHE BOOL "" FORCE)
-    #set(FETCH_SOURCE_DEPS ON CACHE BOOL "" FORCE)
-    set(AZ_ALL_LIBRARIES OFF CACHE BOOL "" FORCE)
-    FetchContent_Declare(azuresdkforcpp
-        # Set the SDK URL path and release tag
-        GIT_REPOSITORY      https://github.com/Azure/azure-sdk-for-cpp.git
-        #GIT_TAG             azure-storage-files-datalake_12.0.0-beta.6)
-        GIT_TAG             azure-storage-blobs_12.10.0)
-    FetchContent_MakeAvailable(azuresdkforcpp)
-#    FetchContent_GetProperties(azuresdkforcpp)
-#    if(NOT azuresdkforcpp_POPULATED)
-#        FetchContent_Populate(azuresdkforcpp)
-#        add_subdirectory(${azuresdkforcpp_SOURCE_DIR} ${azuresdkforcpp_BINARY_DIR} EXCLUDE_FROM_ALL)
-#    endif()
-  endif()
+  find_package(azure-identity-cpp CONFIG REQUIRED)
+  find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+  set(LIBCZI_AZURESDK_VERSION_STRING "core:${azure-core-cpp_VERSION} identity:${azure-identity-cpp_VERSION} storage-blobs:${azure-storage-blobs-cpp_VERSION}")
+  message(STATUS "AZURE-SDK available, version-info: ${LIBCZI_AZURESDK_VERSION_STRING}")
 endif()
 
 

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -63,7 +63,6 @@ if (LIBCZI_BUILD_CURL_BASED_STREAM)
   endif(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL)
 endif(LIBCZI_BUILD_CURL_BASED_STREAM)
 
-
 if(LIBCZI_BUILD_AZURESDK_BASED_STREAM)
   # -> https://github.com/Azure/azure-sdk-for-cpp#azure-sdk-for-c
   # -> https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal
@@ -72,8 +71,6 @@ if(LIBCZI_BUILD_AZURESDK_BASED_STREAM)
   set(LIBCZI_AZURESDK_VERSION_STRING "core:${azure-core-cpp_VERSION} identity:${azure-identity-cpp_VERSION} storage-blobs:${azure-storage-blobs-cpp_VERSION}")
   message(STATUS "AZURE-SDK available, version-info: ${LIBCZI_AZURESDK_VERSION_STRING}")
 endif()
-
-
 
 add_subdirectory(libCZI)
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -102,7 +102,7 @@ set (CZICMDSRCFILES
 
 add_executable(CZIcmd ${CZICMDSRCFILES})
 
-set_target_properties(CZIcmd PROPERTIES CXX_STANDARD 11)
+set_target_properties(CZIcmd PROPERTIES CXX_STANDARD 14)
 target_compile_definitions(CZIcmd PRIVATE _LIBCZISTATICLIB)
 
 target_link_libraries(CZIcmd PRIVATE ${ZLIB_LIBRARIES}  ${PNG_LIBRARIES} CLI11::CLI11 libCZIStatic)

--- a/Src/Doxyfile
+++ b/Src/Doxyfile
@@ -966,6 +966,7 @@ INPUT                  = ./libCZI/libCZI.h \
                          ./libCZI/Doc/using_libCZI.markdown \
                          ./libCZI/Doc/accessors.markdown \
                          ./libCZI/Doc/multichannelcomposition.markdown \
+                         ./libCZI/Doc/stream_objects.markdown \
                          ./libCZI/Doc/CZICmd_usage.markdown \
                          ./libCZI/Doc/write_czi.markdown \
                          ./libCZI/Doc/Todos.markdown \

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -276,7 +276,7 @@ set(libCZIPublicHeaders "ImportExport.h" "libCZI.h" "libCZI_Compositor.h" "libCZ
 if (LIBCZI_BUILD_DYNLIB)
   add_library(libCZI SHARED ${LIBCZISRCFILES} $<TARGET_OBJECTS:JxrDecodeStatic>)
  
-  set_target_properties(libCZI PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES) # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
+  set_target_properties(libCZI PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED YES) # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
   SET_TARGET_PROPERTIES (libCZI PROPERTIES DEFINE_SYMBOL  "LIBCZI_EXPORTS" )
   set_target_properties(libCZI PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 1)
   # add the binary tree to the search path for include files so that we will find libCZI_Config.h
@@ -311,7 +311,7 @@ endif(LIBCZI_BUILD_DYNLIB)
 #
 # Notes: -we use JxrDecode as an "object-library" in order have it "embedded" into libCZI.a
 add_library(libCZIStatic STATIC ${LIBCZISRCFILES} $<TARGET_OBJECTS:JxrDecodeStatic>)
-set_target_properties(libCZIStatic PROPERTIES CXX_STANDARD 11)
+set_target_properties(libCZIStatic PROPERTIES CXX_STANDARD 14)
 target_compile_definitions(libCZIStatic PRIVATE _LIBCZISTATICLIB)
 set_target_properties(libCZIStatic PROPERTIES VERSION ${PROJECT_VERSION})
 # add the binary tree to the search path for include files so that we will find libCZI_Config.h

--- a/Src/libCZI/Doc/building_libCZI.markdown
+++ b/Src/libCZI/Doc/building_libCZI.markdown
@@ -47,6 +47,7 @@ LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3 | Whether to use an existing Eigen3-l
 LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_ZSTD   | Whether to use an existing zstd-library on the system (included via find_package). If this is OFF, then a copy of zstd is downloaded as part of the build. Default is **OFF**.
 LIBCZI_BUILD_CURL_BASED_STREAM             | Whether a curl-based stream object should be built (and be available in the stream factory). Default is **OFF**.
 LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL| Whether to use an existing libcurl-library on the system (included via find_package). If this is OFF, then a copy of libcurl is downloaded as part of the build. Default is **OFF**.
+LIBCZI_BUILD_AZURESDK_BASED_STREAM         | Whether the Azure-SDK-based stream object should be built (and be available in the stream factory). Default is **OFF**.
 
 If building CZICmd is desired, then running CMake with this command line will enable building CZICmd:
     

--- a/Src/libCZI/Doc/stream_objects.markdown
+++ b/Src/libCZI/Doc/stream_objects.markdown
@@ -1,0 +1,45 @@
+stream objects                 {#stream_objects_}
+==============
+
+# stream objects
+
+All input/output operations in libCZI are done through stream objects. Stream objects are used by the CZIReader to access the data in a CZI-file.
+The stream object is an abstraction of a random-access stream.   
+libCZI defines three different stream objects - read-only streams, write-only streams and read-write streams. The respective 
+interfaces are: IStream, IOutputStream and IInputOutputStream.
+libCZI provides implementations for reading from a file and for writing to a file in the file-system.  
+In addition, there is an experimental implementation for reading from an http(s)-server. This implementation is based on [libcurl](https://curl.se/libcurl/) and allows 
+reading from a CZI-file which is located on a web-server.
+
+For creating a stream object for reading, a class factory is provided (in the file libCZI_StreamsLib.h).
+
+## Azure-SDK reader
+
+This reader implementation is based on the [Azure-SDK C++ library](https://github.com/Azure/azure-sdk-for-cpp). It allows 
+reading from a CZI-file which is located on an Azure Blob Storage.
+This azure-input-stream is intended to manage authentication with the functionality provided by the
+Azure-SDK. Please see https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=connection-string%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
+for the concepts followed in this implementation.
+The idea is:
+* For this stream object, the uri-string provided by the user contains the necessary information to identify the blob  
+   to operate on in an Azure Blob Storage account.
+* For this uri-string, we define a syntax (detailed below) that gives the information in a key-value form.  
+* In addition, the property-bag is used to provide additional information controlling the operation.    
+
+The syntax for the uri-string is: `<key1>=<value1>;<key2>=<value2>`.  
+The following rules apply:
+* Key-value pairs are separated by a semicolon ';'.
+* A equal sign '=' separates the key from the value.
+* Spaces are significant, they are part of the key or value. So, the key "key" is different from the key " key".  
+* A semicolon or an equal sign can be part of the key or value if it is escaped by a backslash '\\'.  
+* Empty keys or values are not allowed.  
+
+The reader has multiple modes of operation - mainly differing in how the authentication is done:
+
+  mode of operation            |  description
+--------------------------------|------------------------------------------------------------
+| DefaultAzureCredential        | This method uses the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage.  
+| EnvironmentCredential         | This method uses the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage.
+| AzureCliCredential            | 
+| ManagedIdentityCredential     |   
+| ConnectionStringCredential    | Use a connection string (which includes the storage account access keys) to authorize requests to Azure Blob Storage.

--- a/Src/libCZI/Doc/stream_objects.markdown
+++ b/Src/libCZI/Doc/stream_objects.markdown
@@ -50,7 +50,7 @@ The reader has multiple modes of operation - mainly differing in how the authent
 
    key              | description
  -------------------|---------------------------------------------------
-  account           | The storage-account name. It will be used to create the account-URL as https://<acount>.blob.core.windows.net". This key is relevant for all authentication modes except "ConnectionString".
+  account           | The storage-account name. It will be used to create the account-URL as https://<account>.blob.core.windows.net". This key is relevant for all authentication modes except "ConnectionString".
   acountURL         | The complete base-URL for the storage account. If this is given, then the key 'account' is ignored (and this URL is used instead). This key is relevant for all authentication modes except  "ConnectionString".
   containername     | The container name.
   blobname          | The name of the blob.

--- a/Src/libCZI/Doc/stream_objects.markdown
+++ b/Src/libCZI/Doc/stream_objects.markdown
@@ -8,17 +8,18 @@ The stream object is an abstraction of a random-access stream.
 libCZI defines three different stream objects - read-only streams, write-only streams and read-write streams. The respective 
 interfaces are: IStream, IOutputStream and IInputOutputStream.
 libCZI provides implementations for reading from a file and for writing to a file in the file-system.  
-In addition, there is an experimental implementation for reading from an http(s)-server. This implementation is based on [libcurl](https://curl.se/libcurl/) and allows 
-reading from a CZI-file which is located on a web-server.
+There is an experimental implementation for reading from an http(s)-server. This implementation is based on [libcurl](https://curl.se/libcurl/) and allows 
+reading from a CZI-file which is located on a web-server.  
+In addition, there is another experimental implementation for reading from an Azure Blob Storage. This implementation is based on the [Azure-SDK C++ library](https://github.com/Azure/azure-sdk-for-cpp).
 
 For creating a stream object for reading, a class factory is provided (in the file libCZI_StreamsLib.h).
 
 ## Azure-SDK reader
 
-This reader implementation is based on the [Azure-SDK C++ library](https://github.com/Azure/azure-sdk-for-cpp). It allows 
+This reader's implementation is based on the [Azure-SDK C++ library](https://github.com/Azure/azure-sdk-for-cpp). It allows 
 reading from a CZI-file which is located on an Azure Blob Storage.
 This azure-input-stream is intended to manage authentication with the functionality provided by the
-Azure-SDK. Please see https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=connection-string%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
+Azure-SDK. Please see [here](https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=connection-string%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data)
 for the concepts followed in this implementation.
 The idea is:
 * For this stream object, the uri-string provided by the user contains the necessary information to identify the blob  
@@ -36,10 +37,28 @@ The following rules apply:
 
 The reader has multiple modes of operation - mainly differing in how the authentication is done:
 
-  mode of operation            |  description
+  mode of operation             |  description
 --------------------------------|------------------------------------------------------------
-| DefaultAzureCredential        | This method uses the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage.  
-| EnvironmentCredential         | This method uses the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage.
-| AzureCliCredential            | 
-| ManagedIdentityCredential     |   
-| ConnectionStringCredential    | Use a connection string (which includes the storage account access keys) to authorize requests to Azure Blob Storage.
+ DefaultAzureCredential         | This method uses the Azure SDK's [DefaultAzureCredential](https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_default_azure_credential.html) to authenticate with Azure Blob Storage.
+ EnvironmentCredential          | This method uses the Azure SDK's [EnvironmentCredential](https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_environment_credential.html) to authenticate with Azure Blob Storage.
+ AzureCliCredential             | This method uses the Azure SDK's [AzureCliCredential](https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_azure_cli_credential.html) to authenticate with Azure Blob Storage.
+ ManagedIdentityCredential      | This method uses the Azure SDK's [ManagedIdentityCredential](https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_managed_identity_credential.html) to authenticate with Azure Blob Storage.
+ WorkloadIdentityCredential     | This method uses the Azure SDK's [WorkloadIdentityCredential](https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_workload_identity_credential.html) to authenticate with Azure Blob Storage.
+ ConnectionStringCredential     | Use a connection string (which includes the storage account access keys) to authorize requests to Azure Blob Storage.
+
+ For the uri-string, the following keys are defined:
+
+   key              | description
+ -------------------|---------------------------------------------------
+  account           | The storage-account name. It will be used to create the account-URL as https://<acount>.blob.core.windows.net". This key is relevant for all authentication modes except "ConnectionString".
+  acountURL         | The complete base-URL for the storage account. If this is given, then the key 'account' is ignored (and this URL is used instead). This key is relevant for all authentication modes except  "ConnectionString".
+  containername     | The container name.
+  blobname          | The name of the blob.
+  connectionstring  | The connection string to access the blob store. This key is relevant only for authentication mode "ConnectionString".
+
+  In the property-bag, the following keys are used:
+
+ Property                      | ID  | Type   | Description
+-------------------------------|-----|--------|---------------------------------------------------
+ kAzureBlob_AuthenticationMode | 200 | string | Choose the authentication mode. Possible values are: `DefaultAzureCredential`, `EnvironmentCredential`, `AzureCliCredential`, `ManagedIdentityCredential`, `WorkloadIdentityCredential`, `ConnectionString`. The default is : `DefaultAzureCredential`.
+

--- a/Src/libCZI/Doc/stream_objects.markdown
+++ b/Src/libCZI/Doc/stream_objects.markdown
@@ -6,7 +6,7 @@ stream objects                 {#stream_objects_}
 All input/output operations in libCZI are done through stream objects. Stream objects are used by the CZIReader to access the data in a CZI-file.
 The stream object is an abstraction of a random-access stream.   
 libCZI defines three different stream objects - read-only streams, write-only streams and read-write streams. The respective 
-interfaces are: IStream, IOutputStream and IInputOutputStream.
+interfaces are: IStream, IOutputStream and IInputOutputStream.  
 libCZI provides implementations for reading from a file and for writing to a file in the file-system.  
 There is an experimental implementation for reading from an http(s)-server. This implementation is based on [libcurl](https://curl.se/libcurl/) and allows 
 reading from a CZI-file which is located on a web-server.  

--- a/Src/libCZI/Doc/stream_objects.markdown
+++ b/Src/libCZI/Doc/stream_objects.markdown
@@ -51,7 +51,7 @@ The reader has multiple modes of operation - mainly differing in how the authent
    key              | description
  -------------------|---------------------------------------------------
   account           | The storage-account name. It will be used to create the account-URL as https://<account>.blob.core.windows.net". This key is relevant for all authentication modes except "ConnectionString".
-  acountURL         | The complete base-URL for the storage account. If this is given, then the key 'account' is ignored (and this URL is used instead). This key is relevant for all authentication modes except  "ConnectionString".
+  accountURL         | The complete base-URL for the storage account. If this is given, then the key 'account' is ignored (and this URL is used instead). This key is relevant for all authentication modes except  "ConnectionString".
   containername     | The container name.
   blobname          | The name of the blob.
   connectionstring  | The connection string to access the blob store. This key is relevant only for authentication mode "ConnectionString".

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -26,3 +26,4 @@ version history                 {#version_history}
  0.61.0             | [109](https://github.com/ZEISS/libczi/pull/109)      | fix behaviour of `IXmlNodeRead::GetChildNodeReadonly` (for non-existing nodes), new method `ICziWriter::GetStatistics` added
  0.61.1             | [110](https://github.com/ZEISS/libczi/pull/110)      | some code cleanup
  0.61.2             | [111](https://github.com/ZEISS/libczi/pull/111)      | update libcurl to 8.9.1 (for build with `LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF`), enable SChannel (on Windows) by default
+ 0.62.0             | to be added                                          | add Azure-SDK based reader for reading from Azure Blob Storage, raise requirement to C++14 for building libCZI (previously C++11 was sufficient) because Azure-SDK requires C++14

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -26,4 +26,4 @@ version history                 {#version_history}
  0.61.0             | [109](https://github.com/ZEISS/libczi/pull/109)      | fix behaviour of `IXmlNodeRead::GetChildNodeReadonly` (for non-existing nodes), new method `ICziWriter::GetStatistics` added
  0.61.1             | [110](https://github.com/ZEISS/libczi/pull/110)      | some code cleanup
  0.61.2             | [111](https://github.com/ZEISS/libczi/pull/111)      | update libcurl to 8.9.1 (for build with `LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF`), enable SChannel (on Windows) by default
- 0.62.0             | to be added                                          | add Azure-SDK based reader for reading from Azure Blob Storage, raise requirement to C++14 for building libCZI (previously C++11 was sufficient) because Azure-SDK requires C++14
+ 0.62.0             | [112](https://github.com/ZEISS/libczi/pull/112)      | add Azure-SDK based reader for reading from Azure Blob Storage, raise requirement to C++14 for building libCZI (previously C++11 was sufficient) because Azure-SDK requires C++14

--- a/Src/libCZI/StreamsLib/azureblobinputstream.cpp
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.cpp
@@ -1,5 +1,6 @@
 #include "azureblobinputstream.h"
 
+#if LIBCZI_AZURESDK_BASED_STREAM_AVAILABLE
 #include <azure/storage/blobs.hpp>
 #include <azure/identity/default_azure_credential.hpp>
 #include "../utilities.h"
@@ -139,6 +140,9 @@ void AzureBlobInputStream::Read(std::uint64_t offset, void* pv, std::uint64_t si
     options.Range = Azure::Core::Http::HttpRange{ static_cast<int64_t>(offset), static_cast<int64_t>(size) };
     auto download_response = this->block_blob_client_->DownloadTo(static_cast<uint8_t*>(pv), static_cast<size_t>(size), options);
     const Azure::Core::Http::HttpStatusCode code = download_response.RawResponse->GetStatusCode();
+
+    // TODO(JBL): I am not sure about what we can expect here as return code. The Azure SDK documentation is not very clear about this,
+    //             at least I am not aware of an authorative text on this.
     if (code == Azure::Core::Http::HttpStatusCode::Ok || code == Azure::Core::Http::HttpStatusCode::PartialContent)
     {
         // the reported position should match the requested offset
@@ -178,7 +182,6 @@ AzureBlobInputStream::~AzureBlobInputStream()
 {
     return libCZI::StreamsFactory::Property();
 }
-
 
 /*static*/AzureBlobInputStream::AuthenticationMode AzureBlobInputStream::DetermineAuthenticationMode(const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
 {
@@ -222,3 +225,4 @@ AzureBlobInputStream::~AzureBlobInputStream()
     string_stream << "The specified uri-string must specify a value for '" << Utilities::convertWchar_tToUtf8(AzureBlobInputStream::kUriKey_Account) << "' or '" << Utilities::convertWchar_tToUtf8(AzureBlobInputStream::kUriKey_AccountUrl) << "'.";
     throw std::runtime_error(string_stream.str());
 }
+#endif  

--- a/Src/libCZI/StreamsLib/azureblobinputstream.cpp
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.cpp
@@ -4,7 +4,9 @@
 #include <azure/storage/blobs.hpp>
 #include <azure/identity/default_azure_credential.hpp>
 #include <azure/identity/environment_credential.hpp>
-#include <azure/identity/azure_cli_credential.hpp>    
+#include <azure/identity/azure_cli_credential.hpp>
+#include <azure/identity/workload_identity_credential.hpp>
+#include <azure/identity/managed_identity_credential.hpp>
 #include "../utilities.h"
 
 using namespace std;
@@ -36,6 +38,12 @@ AzureBlobInputStream::AzureBlobInputStream(const std::wstring& url, const std::m
         break;
     case AuthenticationMode::AzureCliCredential:
         this->CreateWithCreateAzureCliCredential(key_value_uri, property_bag);
+        break;
+    case AuthenticationMode::WorkloadIdentityCredential:
+        this->CreateWithWorkloadIdentityCredential(key_value_uri, property_bag);
+        break;
+    case AuthenticationMode::ManagedIdentityCredential:
+        this->CreateWithManagedIdentityCredential(key_value_uri, property_bag);
         break;
     case AuthenticationMode::ConnectionString:
         this->CreateWithConnectionString(key_value_uri, property_bag);
@@ -101,6 +109,16 @@ void AzureBlobInputStream::CreateWithEnvironmentCredential(const std::map<std::w
 void AzureBlobInputStream::CreateWithCreateAzureCliCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
 {
     this->CreateWithCredential(tokenized_file_name, property_bag, AzureBlobInputStream::CreateAzureCliCredential);
+}
+
+void AzureBlobInputStream::CreateWithWorkloadIdentityCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
+{
+    this->CreateWithCredential(tokenized_file_name, property_bag, AzureBlobInputStream::CreateAzureCliCredential);
+}
+
+void AzureBlobInputStream::CreateWithManagedIdentityCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
+{
+    this->CreateWithCredential(tokenized_file_name, property_bag, AzureBlobInputStream::CreateManagedIdentityCredential);
 }
 
 void AzureBlobInputStream::CreateWithConnectionString(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag)
@@ -222,6 +240,8 @@ AzureBlobInputStream::~AzureBlobInputStream()
             { "DefaultAzureCredential", AuthenticationMode::DefaultAzureCredential },
             { "EnvironmentCredential", AuthenticationMode::EnvironmentCredential },
             { "AzureCliCredential", AuthenticationMode::AzureCliCredential },
+            { "ManagedIdentityCredential", AuthenticationMode::ManagedIdentityCredential },
+            { "WorkloadIdentityCredential", AuthenticationMode::WorkloadIdentityCredential },
             { "ConnectionString", AuthenticationMode::ConnectionString }
         };
 
@@ -273,5 +293,15 @@ AzureBlobInputStream::~AzureBlobInputStream()
 /*static*/std::shared_ptr<Azure::Core::Credentials::TokenCredential> AzureBlobInputStream::CreateAzureCliCredential()
 {
     return make_shared<Azure::Identity::AzureCliCredential>();
+}
+
+/*static*/std::shared_ptr<Azure::Core::Credentials::TokenCredential> AzureBlobInputStream::CreateWorkloadIdentityCredential()
+{
+    return make_shared<Azure::Identity::WorkloadIdentityCredential>();
+}
+
+/*static*/std::shared_ptr<Azure::Core::Credentials::TokenCredential> AzureBlobInputStream::CreateManagedIdentityCredential()
+{
+    return std::make_shared<Azure::Identity::ManagedIdentityCredential>();
 }
 #endif  

--- a/Src/libCZI/StreamsLib/azureblobinputstream.cpp
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "azureblobinputstream.h"
 
 #if LIBCZI_AZURESDK_BASED_STREAM_AVAILABLE

--- a/Src/libCZI/StreamsLib/azureblobinputstream.cpp
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.cpp
@@ -210,18 +210,9 @@ void AzureBlobInputStream::Read(std::uint64_t offset, void* pv, std::uint64_t si
     }
 }
 
-AzureBlobInputStream::~AzureBlobInputStream()
-{
-}
-
 /*static*/std::string AzureBlobInputStream::GetBuildInformation()
 {
     return { LIBCZI_AZURESDK_VERSION_INFO };
-}
-
-/*static*/libCZI::StreamsFactory::Property AzureBlobInputStream::GetClassProperty(const char* property_name)
-{
-    return libCZI::StreamsFactory::Property();
 }
 
 /*static*/AzureBlobInputStream::AuthenticationMode AzureBlobInputStream::DetermineAuthenticationMode(const std::map<int, libCZI::StreamsFactory::Property>& property_bag)

--- a/Src/libCZI/StreamsLib/azureblobinputstream.cpp
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.cpp
@@ -59,8 +59,6 @@ void AzureBlobInputStream::CreateWithCredential(const std::map<std::wstring, std
     //
     // 1. containername and blobname are required in any case
     // 2. then, either account or accounturl must be present. If accounturl and account are present, account is ignored.
-    //
-    // Test-URI: account=libczirwtestdata;containername=$web;blobname=libczi/DCV_30MB.czi
     auto iterator = tokenized_file_name.find(AzureBlobInputStream::kUriKey_ContainerName);
     if (iterator == tokenized_file_name.end())
     {

--- a/Src/libCZI/StreamsLib/azureblobinputstream.h
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.h
@@ -16,8 +16,13 @@
 class AzureBlobInputStream : public libCZI::IStream
 {
 private:
-    //std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> serviceClient_;
-    std::unique_ptr<Azure::Storage::Blobs::BlockBlobClient> blockBlobClient_;
+    static const wchar_t* kUriKey_ContainerName;
+    static const wchar_t* kUriKey_BlobName;
+    static const wchar_t* kUriKey_Account;
+    static const wchar_t* kUriKey_AccountUrl;
+    static const wchar_t* kUriKey_ConnectionString;
+
+    std::unique_ptr<Azure::Storage::Blobs::BlockBlobClient> block_blob_client_;
 
     enum class AuthenticationMode
     {
@@ -32,14 +37,13 @@ public:
 
     ~AzureBlobInputStream() override;
 
-
     static std::string GetBuildInformation();
     static libCZI::StreamsFactory::Property GetClassProperty(const char* property_name);
-
 private:
     static AuthenticationMode DetermineAuthenticationMode(const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     static std::string DetermineServiceUrl(const std::map<std::wstring, std::wstring>& tokenized_file_name);
     void CreateWithDefaultAzureCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithConnectionString(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     // https ://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
 };
 

--- a/Src/libCZI/StreamsLib/azureblobinputstream.h
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.h
@@ -117,10 +117,7 @@ public:
 
     void Read(std::uint64_t offset, void* pv, std::uint64_t size, std::uint64_t* ptrBytesRead) override;
 
-    ~AzureBlobInputStream() override;
-
     static std::string GetBuildInformation();
-    static libCZI::StreamsFactory::Property GetClassProperty(const char* property_name);
 private:
     static AuthenticationMode DetermineAuthenticationMode(const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     static std::string DetermineServiceUrl(const std::map<std::wstring, std::wstring>& tokenized_file_name);

--- a/Src/libCZI/StreamsLib/azureblobinputstream.h
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.h
@@ -32,11 +32,42 @@
 /// * Empty keys or values are not allowed.  
 ///
 /// There are multiple ways to authenticate with Azure Blob Storage. This stream object supports the following methods:
-/// +-------------------------------+
-/// | DefaultAzureCredential        | This method uses the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage.  
-/// | EnvironmentCredential         | This method uses the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage.
-/// | AzureCliCredential            | 
-/// | ManagedIdentityCredential     |   
+/// * DefaultAzureCredential
+/// * EnvironmentCredential
+/// * AzureCliCredential
+/// * ManagedIdentityCredential  
+/// * WorkloadIdentityCredential  
+/// * ConnectionString  
+/// 
+/// For the uri-string, the following keys are defined:
+/// +------------------+---------------------------------------------------
+/// | account          | The storage-account name. It will be used to create the account-URL as
+/// |                  | https://<acount>.blob.core.windows.net".
+/// |                  | This key is relevant for all authentication modes except
+/// |                  | "ConnectionString".
+/// +------------------+--------------------------------------------------------------------------
+/// | acountURL        | The complete base-URL for the storage account. If this is given, then the
+/// |                  | key 'account' is ignored (and this URL is used instead).
+/// |                  | This key is relevant for all authentication modes except 
+/// |                  | "ConnectionString".
+/// +------------------+--------------------------------------------------------------------------
+/// | containername    | The container name.
+/// +------------------+--------------------------------------------------------------------------
+/// | blobname         | The name of the blob.
+/// +------------------+--------------------------------------------------------------------------
+/// | connectionstring | The connection string to access the blob store. 
+/// |                  | This key is relevant only for authentication mode "ConnectionString".
+/// +------------------+--------------------------------------------------------------------------
+/// 
+/// In the property-bag, the following keys are used:
+/// 
+/// | Property                      | ID  | Type   | Description
+/// +-------------------------------+-----+--------+---------------------------------------------------
+/// | kAzureBlob_AuthenticationMode | 200 | string | Choose the authentication mode. Possible values are:
+/// |                               |     |        | DefaultAzureCredential, EnvironmentCredential, AzureCliCredential,
+/// |                               |     |        | ManagedIdentityCredential, WorkloadIdentityCredential,
+/// |                               |     |        | ConnectionString.
+/// |                               |     |        | The default is : DefaultAzureCredential.
 class AzureBlobInputStream : public libCZI::IStream
 {
 private:
@@ -48,6 +79,7 @@ private:
 
     std::unique_ptr<Azure::Storage::Blobs::BlockBlobClient> block_blob_client_;
 
+    /// Values that represent authentication modes.
     enum class AuthenticationMode
     {
         /// Use the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_default_azure_credential.html.
@@ -55,17 +87,28 @@ private:
         /// This credential is intended to be used at the early stages of development, to allow the developer some time to work with the other aspects 
         /// of the SDK, and later to replace this credential with the exact credential that is the best fit for the application. It is not intended 
         /// to be used in a production environment.
+        /// This will try the following authentication methods (in this order) and stop when one succeeds:
+        /// EnvironmentCredential, WorkloadIdentityCredential, AzureCliCredential, ManagedIdentityCredential.
         DefaultAzureCredential,
 
         /// Use the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_environment_credential.html.
+        /// This will read account information specified via environment variables and use it to authenticate - c.f. https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/identity/azure-identity/README.md#environment-variables.
         EnvironmentCredential,
 
         /// Use the Azure SDK's AzureCliCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_azure_cli_credential.html.
         AzureCliCredential,
 
-        //ManagedIdentityCredential,
-        //WorkloadIdentityCredential,
-        
+        /// Use the Azure SDK's ManagedIdentityCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_managed_identity_credential.html.
+        /// Attempts authentication using a managed identity that has been assigned to the deployment environment. This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell. More information about configuring 
+        /// managed identities can be found here: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview.
+        ManagedIdentityCredential,
+
+        /// Use the Azure SDK's WorkloadIdentityCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_workload_identity_credential.html.
+        /// This authenticates using a Kubernetes service account token.
+        WorkloadIdentityCredential,
+
+        /// Use authentication via a connection string. A connection string includes the storage account access key and uses it to authorize requests. Always be careful to never expose the 
+        /// keys in an unsecure location.
         ConnectionString,
     };
 public:
@@ -84,13 +127,16 @@ private:
     void CreateWithDefaultAzureCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     void CreateWithEnvironmentCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     void CreateWithCreateAzureCliCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithWorkloadIdentityCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithManagedIdentityCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     void CreateWithCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag, const std::function<std::shared_ptr<Azure::Core::Credentials::TokenCredential>()>& create_credentials_functor);
     void CreateWithConnectionString(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
 
     static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateDefaultAzureCredential();
     static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateEnvironmentCredential();
     static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateAzureCliCredential();
-    // https ://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
+    static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateWorkloadIdentityCredential();
+    static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateManagedIdentityCredential();
 };
 
 #endif

--- a/Src/libCZI/StreamsLib/azureblobinputstream.h
+++ b/Src/libCZI/StreamsLib/azureblobinputstream.h
@@ -13,6 +13,30 @@
 #include "../libCZI.h"
 #include <azure/storage/blobs.hpp>
 
+/// Implementation of stream object based on Azure-SDK C++ (https://github.com/Azure/azure-sdk-for-cpp).
+/// This azure-input-stream is intended to manage authentication with the functionality provided by the
+/// Azure-SDK. Please see https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=connection-string%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
+/// for the concepts followed in this implementation.
+/// The idea is:
+/// * For this stream object, the uri-string provided by the user contains the necessary information to identify the blob  
+///    to operate on in an Azure Blob Storage account.
+/// * For this uri-string, we define a syntax (detailed below) that gives the information in a key-value form.  
+/// * In addition, the property-bag is used to provide additional information controlling the operation.    
+/// 
+/// The syntax for the uri-string is: <key1>=<value1>;<key2>=<value2>.
+/// The following rules apply:
+/// * Key-value pairs are separated by a semicolon ';'.  
+/// * A equal sign '=' separates the key from the value.  
+/// * Spaces are significant, they are part of the key or value. So, the key "key" is different from the key " key".  
+/// * A semicolon or an equal sign can be part of the key or value if it is escaped by a backslash '\'.  
+/// * Empty keys or values are not allowed.  
+///
+/// There are multiple ways to authenticate with Azure Blob Storage. This stream object supports the following methods:
+/// +-------------------------------+
+/// | DefaultAzureCredential        | This method uses the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage.  
+/// | EnvironmentCredential         | This method uses the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage.
+/// | AzureCliCredential            | 
+/// | ManagedIdentityCredential     |   
 class AzureBlobInputStream : public libCZI::IStream
 {
 private:
@@ -26,7 +50,22 @@ private:
 
     enum class AuthenticationMode
     {
+        /// Use the Azure SDK's DefaultAzureCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_default_azure_credential.html.
+        /// Note that the documentation states:
+        /// This credential is intended to be used at the early stages of development, to allow the developer some time to work with the other aspects 
+        /// of the SDK, and later to replace this credential with the exact credential that is the best fit for the application. It is not intended 
+        /// to be used in a production environment.
         DefaultAzureCredential,
+
+        /// Use the Azure SDK's EnvironmentCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_environment_credential.html.
+        EnvironmentCredential,
+
+        /// Use the Azure SDK's AzureCliCredential to authenticate with Azure Blob Storage. C.f. https://azuresdkdocs.blob.core.windows.net/$web/cpp/azure-identity/1.9.0/class_azure_1_1_identity_1_1_azure_cli_credential.html.
+        AzureCliCredential,
+
+        //ManagedIdentityCredential,
+        //WorkloadIdentityCredential,
+        
         ConnectionString,
     };
 public:
@@ -43,7 +82,14 @@ private:
     static AuthenticationMode DetermineAuthenticationMode(const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
     static std::string DetermineServiceUrl(const std::map<std::wstring, std::wstring>& tokenized_file_name);
     void CreateWithDefaultAzureCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithEnvironmentCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithCreateAzureCliCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+    void CreateWithCredential(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag, const std::function<std::shared_ptr<Azure::Core::Credentials::TokenCredential>()>& create_credentials_functor);
     void CreateWithConnectionString(const std::map<std::wstring, std::wstring>& tokenized_file_name, const std::map<int, libCZI::StreamsFactory::Property>& property_bag);
+
+    static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateDefaultAzureCredential();
+    static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateEnvironmentCredential();
+    static std::shared_ptr<Azure::Core::Credentials::TokenCredential> CreateAzureCliCredential();
     // https ://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data
 };
 

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -46,7 +46,7 @@ static const struct
 #endif  // LIBCZI_CURL_BASED_STREAM_AVAILABLE
 #if LIBCZI_AZURESDK_BASED_STREAM_AVAILABLE
         {
-            { "azure_blob_inputstream", "Azure-SDK-based stream", AzureBlobInputStream::GetBuildInformation, AzureBlobInputStream::GetClassProperty },
+            { "azure_blob_inputstream", "Azure-SDK-based stream", AzureBlobInputStream::GetBuildInformation, nullptr },
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<AzureBlobInputStream>(file_name, stream_info.property_bag);

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -121,6 +121,10 @@ void libCZI::StreamsFactory::Initialize()
         {"CurlHttp_MaxRedirs", StreamsFactory::StreamProperties::kCurlHttp_MaxRedirs, StreamsFactory::Property::Type::Int32},
         {"CurlHttp_CaInfo", StreamsFactory::StreamProperties::kCurlHttp_CaInfo, StreamsFactory::Property::Type::String},
         {"CurlHttp_CaInfoBlob", StreamsFactory::StreamProperties::kCurlHttp_CaInfoBlob, StreamsFactory::Property::Type::String},
+        {"AzureBlob_AuthenticationMode", StreamsFactory::StreamProperties::kCurlHttp_CaInfoBlob, StreamsFactory::Property::Type::String},
+#endif
+#if LIBCZI_AZURESDK_BASED_STREAM_AVAILABLE
+        {"AzureBlob_AuthenticationMode", StreamsFactory::StreamProperties::kAzureBlob_AuthenticationMode, StreamsFactory::Property::Type::String},
 #endif
         {nullptr, 0, StreamsFactory::Property::Type::Invalid},
     };

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -121,7 +121,6 @@ void libCZI::StreamsFactory::Initialize()
         {"CurlHttp_MaxRedirs", StreamsFactory::StreamProperties::kCurlHttp_MaxRedirs, StreamsFactory::Property::Type::Int32},
         {"CurlHttp_CaInfo", StreamsFactory::StreamProperties::kCurlHttp_CaInfo, StreamsFactory::Property::Type::String},
         {"CurlHttp_CaInfoBlob", StreamsFactory::StreamProperties::kCurlHttp_CaInfoBlob, StreamsFactory::Property::Type::String},
-        {"AzureBlob_AuthenticationMode", StreamsFactory::StreamProperties::kCurlHttp_CaInfoBlob, StreamsFactory::Property::Type::String},
 #endif
 #if LIBCZI_AZURESDK_BASED_STREAM_AVAILABLE
         {"AzureBlob_AuthenticationMode", StreamsFactory::StreamProperties::kAzureBlob_AuthenticationMode, StreamsFactory::Property::Type::String},

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -233,8 +233,9 @@ namespace libCZI
 
                 kCurlHttp_CaInfoBlob = 111, ///< For CurlHttpInputStream, type string: give PEM encoded content holding one or more certificates to verify the HTTPS server with, c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html for more information.
 
-                kAzureBlob_AuthenticationMode = 200,  ///< For AzureBlobInputStream, type string: specifies how authentication is to be done (c.f. https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data).
-                                                      ///< Possible values are: "DefaultAzureCredential" and "ConnectionString".
+                /// For AzureBlobInputStream, type string: specifies how authentication is to be done (c.f. https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data).
+                /// Possible values are: "DefaultAzureCredential" and "ConnectionString".
+                kAzureBlob_AuthenticationMode = 200,
             };
         };
 

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -234,7 +234,8 @@ namespace libCZI
                 kCurlHttp_CaInfoBlob = 111, ///< For CurlHttpInputStream, type string: give PEM encoded content holding one or more certificates to verify the HTTPS server with, c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html for more information.
 
                 /// For AzureBlobInputStream, type string: specifies how authentication is to be done (c.f. https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data).
-                /// Possible values are: "DefaultAzureCredential" and "ConnectionString".
+                /// Possible values are: "DefaultAzureCredential", "EnvironmentCredential", "AzureCliCredential", "ManagedIdentityCredential", "WorkloadIdentityCredential", "ConnectionString".
+                /// The default is: "DefaultAzureCredential".
                 kAzureBlob_AuthenticationMode = 200,
             };
         };

--- a/Src/libCZI/libCZI_StreamsLib.h
+++ b/Src/libCZI/libCZI_StreamsLib.h
@@ -232,6 +232,9 @@ namespace libCZI
                 kCurlHttp_CaInfo = 110, ///< For CurlHttpInputStream, type string: gives the directory to check for CA certificate bundle , c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO.html for more information.
 
                 kCurlHttp_CaInfoBlob = 111, ///< For CurlHttpInputStream, type string: give PEM encoded content holding one or more certificates to verify the HTTPS server with, c.f. https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html for more information.
+
+                kAzureBlob_AuthenticationMode = 200,  ///< For AzureBlobInputStream, type string: specifies how authentication is to be done (c.f. https://learn.microsoft.com/en-us/azure/storage/blobs/quickstart-blobs-c-plus-plus?tabs=managed-identity%2Croles-azure-portal#authenticate-to-azure-and-authorize-access-to-blob-data).
+                                                      ///< Possible values are: "DefaultAzureCredential" and "ConnectionString".
             };
         };
 

--- a/Src/libCZI/utilities.cpp
+++ b/Src/libCZI/utilities.cpp
@@ -330,84 +330,109 @@ tString trimImpl(const tString& str, const tString& whitespace)
     bool inValue = false;                         // Flag to track if we are processing the value part
     bool foundEquals = false;                     // Track if we've encountered an '=' for a valid key-value pair
 
-    for (size_t i = 0; i < input.length(); ++i) {
-        wchar_t c = input[i];
+    for (size_t i = 0; i < input.length(); ++i)
+    {
+        const wchar_t c = input[i];
 
         // Handle escape sequences for semicolons (\;) and equals signs (\=)
-        if (c == L'\\' && i + 1 < input.length()) {
-            wchar_t next = input[i + 1];
-            if (next == L';') {
+        if (c == L'\\' && i + 1 < input.length())
+        {
+            const wchar_t next = input[i + 1];
+            if (next == L';')
+            {
                 // Escaped semicolon (\;)
-                if (inValue) {
+                if (inValue)
+                {
                     value += L';';
                 }
-                else {
+                else
+                {
                     key += L';';
                 }
+
                 ++i;  // Skip the semicolon after the backslash
             }
-            else if (next == L'=') {
+            else if (next == L'=')
+            {
                 // Escaped equals sign (\=)
-                if (inValue) {
+                if (inValue)
+                {
                     value += L'=';
                 }
-                else {
+                else
+                {
                     key += L'=';
                 }
+
                 ++i;  // Skip the equals sign after the backslash
             }
-            else {
+            else
+            {
                 // If it's not an escape sequence we care about, treat the backslash literally
-                if (inValue) {
+                if (inValue)
+                {
                     value += c;  // Add the backslash to the value
                 }
-                else {
+                else
+                {
                     key += c;    // Add the backslash to the key
                 }
             }
         }
-        else if (c == L'=' && !inValue) {
+        else if (c == L'=' && !inValue)
+        {
             // Start processing the value part when we hit an unescaped '='
             inValue = true;
             foundEquals = true;
         }
-        else if (c == L';' && inValue) {
+        else if (c == L';' && inValue)
+        {
             // If we hit ';' while processing the value, it's the end of the current key-value pair
-            if (key.empty()) {
+            if (key.empty())
+            {
                 throw std::invalid_argument("Found a value without a corresponding key.");
             }
+
             tokens[key] = value;  // Store the key-value pair
             key.clear();          // Reset key and value for the next pair
             value.clear();
             inValue = false;
             foundEquals = false;
         }
-        else {
+        else
+        {
             // Collect characters for the key or value depending on the state
-            if (inValue) {
+            if (inValue)
+            {
                 value += c;
             }
-            else {
+            else
+            {
                 key += c;
             }
         }
     }
 
     // Handle the case where no '=' was found in the input (invalid input)
-    if (!foundEquals) {
+    if (!foundEquals)
+    {
         throw std::invalid_argument("Input does not contain a valid key-value pair.");
     }
 
     // Add the last key-value pair (if any exists after the loop)
-    if (!key.empty()) {
-        if (value.empty() && inValue) {
+    if (!key.empty())
+    {
+        if (value.empty() && inValue)
+        {
             throw std::invalid_argument("Found a key without a corresponding value.");
         }
+
         tokens[key] = value;
     }
 
     // Check if we have at least one valid key-value pair; if not, it's an error
-    if (tokens.empty()) {
+    if (tokens.empty())
+    {
         throw std::invalid_argument("No complete key-value pair found in the input.");
     }
 
@@ -497,7 +522,7 @@ tString trimImpl(const tString& str, const tString& whitespace)
             ++pSrc;
         }
     }
-}
+        }
 
 #if !LIBCZI_HAS_NEOININTRINSICS && !LIBCZI_HAS_AVXINTRINSICS
 /*static*/void LoHiBytePackUnpack::LoHiByteUnpackStrided(const void* ptrSrc, std::uint32_t wordCount, std::uint32_t stride, std::uint32_t lineCount, void* ptrDst)

--- a/Src/libCZI/utilities.cpp
+++ b/Src/libCZI/utilities.cpp
@@ -522,7 +522,7 @@ tString trimImpl(const tString& str, const tString& whitespace)
             ++pSrc;
         }
     }
-        }
+}
 
 #if !LIBCZI_HAS_NEOININTRINSICS && !LIBCZI_HAS_AVXINTRINSICS
 /*static*/void LoHiBytePackUnpack::LoHiByteUnpackStrided(const void* ptrSrc, std::uint32_t wordCount, std::uint32_t stride, std::uint32_t lineCount, void* ptrDst)

--- a/Src/libCZI_UnitTests/CMakeLists.txt
+++ b/Src/libCZI_UnitTests/CMakeLists.txt
@@ -68,6 +68,7 @@ ADD_EXECUTABLE(libCZI_UnitTests
 										test_azureblobstream.cpp)
 
 TARGET_LINK_LIBRARIES(libCZI_UnitTests PRIVATE libCZIStatic GTest::gtest GTest::gmock)
+set_target_properties(libCZI_UnitTests PROPERTIES CXX_STANDARD 14)
 
 target_compile_definitions(libCZI_UnitTests PRIVATE _LIBCZISTATICLIB)
 

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -110,7 +110,7 @@ TEST(AzureBlobStream, GetStatisticsFromBlobUsingConnectionString)
 {
     if (!IsAzureBlobInputStreamAvailable())
     {
-        GTEST_SKIP() << "The stream-class 'azure_blob_inputstream' is not available/configured, skipping this test therefore.";
+        GTEST_SKIP() << "The stream-class 'azure_blob_inputstream' is not available/configured, therefore skipping this test.";
     }
 
     const char* azure_blob_store_connection_string = GetAzureBlobStoreConnectionString();

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -128,7 +128,34 @@ TEST(AzureBlobStream, ReadFromBlobConnectionString)
     ASSERT_TRUE(stream);
 
     const auto reader = CreateCZIReader();
-    reader->Open(stream);
+
+    try
+    {
+        reader->Open(stream);
+    }
+    catch (libCZI::LibCZIIOException& libCZI_io_exception)
+    {
+        std::stringstream ss;
+        string what(libCZI_io_exception.what() != nullptr ? libCZI_io_exception.what() : "");
+        ss << "LibCZIIOException caught -> \"" << what << "\"";
+        try
+        {
+            libCZI_io_exception.rethrow_nested();
+        }
+        catch (std::exception& inner_exception)
+        {
+            what = inner_exception.what() != nullptr ? inner_exception.what() : "";
+            ss << endl << " nested exception -> \"" << what << "\"";
+        }
+
+        cout << ss.str() << endl;
+    }
+    catch (std::exception& excp)
+    {
+        std::stringstream ss;
+        ss << "Exception caught -> \"" << excp.what() << "\"";
+        cout << ss.str() << endl;
+    }
 
     const auto statistics = reader->GetStatistics();
     EXPECT_EQ(statistics.subBlockCount, 4);

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -59,16 +59,21 @@ static bool IsAzureBlobInputStreamAvailable()
 {
     StreamsFactory::CreateStreamInfo create_info;
     create_info.class_name = "azure_blob_inputstream";
-    for (int i=0;i< StreamsFactory::GetStreamClassesCount();++i)
+    bool IsAzureBlobInputStreamAvailable()
     {
-        StreamsFactory::StreamClassInfo info;
-        if (StreamsFactory::GetStreamInfoForClass(i, info))
+        StreamsFactory::CreateStreamInfo create_info;
+        create_info.class_name = "azure_blob_inputstream";
+
+        for (int i = 0; i < StreamsFactory::GetStreamClassesCount(); ++i)
         {
-            if (info.class_name == create_info.class_name)
+            StreamsFactory::StreamClassInfo info;
+            if (StreamsFactory::GetStreamInfoForClass(i, info) && info.class_name == create_info.class_name)
             {
                 return true;
             }
         }
+
+        return false;
     }
 
     return false;
@@ -96,6 +101,13 @@ static string EscapeForUri(const char* str)
     return result;
 }
 
+static const char* GetAzureBlobStoreConnectionString()
+{
+    // return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;)";
+    const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
+    return azure_blob_store_connection_string;
+}
+
 TEST(AzureBlobStream, ReadFromBlobConnectionString)
 {
     if (!IsAzureBlobInputStreamAvailable())
@@ -103,7 +115,7 @@ TEST(AzureBlobStream, ReadFromBlobConnectionString)
         GTEST_SKIP() << "The stream-class 'azure_blob_inputstream' is not available/configured, skipping this test therefore.";
     }
 
-    const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
+    const char* azure_blob_store_connection_string = GetAzureBlobStoreConnectionString();
     if (!azure_blob_store_connection_string)
     {
         GTEST_SKIP() << "The environment variable 'AZURE_BLOB_STORE_CONNECTION_STRING' is not set, skipping this test therefore.";
@@ -119,7 +131,6 @@ TEST(AzureBlobStream, ReadFromBlobConnectionString)
     const auto stream = StreamsFactory::CreateStream(
         create_info,
         string_stream_uri.str());
-        // LR"(containername=testcontainer;blobname=testblob;connectionstring=DefaultEndpointsProtocol\=http\;AccountName\=devstoreaccount1\;AccountKey\=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw\=\=\;BlobEndpoint\=http://127.0.0.1:10000/devstoreaccount1\;)");
 
     ASSERT_TRUE(stream);
 

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -96,9 +96,9 @@ static string EscapeForUri(const char* str)
 
 static const char* GetAzureBlobStoreConnectionString()
 {
-    // return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;)";
-    const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
-    return azure_blob_store_connection_string;
+     return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;)";
+    //const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
+    //return azure_blob_store_connection_string;
 }
 
 TEST(AzureBlobStream, ReadFromBlobConnectionString)

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -98,12 +98,10 @@ static const char* GetAzureBlobStoreConnectionString()
 {
     // We use the environment variable 'AZURE_BLOB_STORE_CONNECTION_STRING' to communicate a connection string.
 
-    //const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
-    //return azure_blob_store_connection_string;
-
+    const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
+    return azure_blob_store_connection_string;
     
-    return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;)";
-    
+    //return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;)";
 }
 
 TEST(AzureBlobStream, GetStatisticsFromBlobUsingConnectionString)

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -59,21 +59,14 @@ static bool IsAzureBlobInputStreamAvailable()
 {
     StreamsFactory::CreateStreamInfo create_info;
     create_info.class_name = "azure_blob_inputstream";
-    bool IsAzureBlobInputStreamAvailable()
+
+    for (int i = 0; i < StreamsFactory::GetStreamClassesCount(); ++i)
     {
-        StreamsFactory::CreateStreamInfo create_info;
-        create_info.class_name = "azure_blob_inputstream";
-
-        for (int i = 0; i < StreamsFactory::GetStreamClassesCount(); ++i)
+        StreamsFactory::StreamClassInfo info;
+        if (StreamsFactory::GetStreamInfoForClass(i, info) && info.class_name == create_info.class_name)
         {
-            StreamsFactory::StreamClassInfo info;
-            if (StreamsFactory::GetStreamInfoForClass(i, info) && info.class_name == create_info.class_name)
-            {
-                return true;
-            }
+            return true;
         }
-
-        return false;
     }
 
     return false;

--- a/Src/libCZI_UnitTests/test_azureblobstream.cpp
+++ b/Src/libCZI_UnitTests/test_azureblobstream.cpp
@@ -96,7 +96,7 @@ static string EscapeForUri(const char* str)
 
 static const char* GetAzureBlobStoreConnectionString()
 {
-     return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;)";
+     return R"(DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;)";
     //const char* azure_blob_store_connection_string = std::getenv("AZURE_BLOB_STORE_CONNECTION_STRING");
     //return azure_blob_store_connection_string;
 }

--- a/cmake/dummy/azure_c_shared_utilityConfig.cmake
+++ b/cmake/dummy/azure_c_shared_utilityConfig.cmake
@@ -1,3 +1,0 @@
-# Dummy wilConfig.cmake to satisfy find_package(wil)
-#include_directories(${CMAKE_CURRENT_LIST_DIR}/path/to/wil/include)
-include_directories("D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/azure-c-shared-utility-src")

--- a/cmake/dummy/azure_macro_utils_cConfig.cmake
+++ b/cmake/dummy/azure_macro_utils_cConfig.cmake
@@ -1,4 +1,0 @@
-
- # Dummy wilConfig.cmake to satisfy find_package(wil)
-#include_directories(${CMAKE_CURRENT_LIST_DIR}/path/to/wil/include)
-include_directories("D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/azure_macro_utils_c-src")

--- a/cmake/dummy/opentelemetry-cppConfig.cmake
+++ b/cmake/dummy/opentelemetry-cppConfig.cmake
@@ -1,3 +1,0 @@
-# Dummy wilConfig.cmake to satisfy find_package(wil)
-#include_directories(${CMAKE_CURRENT_LIST_DIR}/path/to/wil/include)
-include_directories("D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/opentelemetry-cpp-src")

--- a/cmake/dummy/umock_cConfig.cmake
+++ b/cmake/dummy/umock_cConfig.cmake
@@ -1,3 +1,0 @@
-# Dummy wilConfig.cmake to satisfy find_package(wil)
-#include_directories(${CMAKE_CURRENT_LIST_DIR}/path/to/wil/include)
-include_directories("D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/umock-c-src")

--- a/cmake/dummy/wilConfig.cmake
+++ b/cmake/dummy/wilConfig.cmake
@@ -1,3 +1,0 @@
-# Dummy wilConfig.cmake to satisfy find_package(wil)
-#include_directories(${CMAKE_CURRENT_LIST_DIR}/path/to/wil/include)
-include_directories("D:/dev/Github/libczi-zeiss-ptahmose/build/_deps/wil-src")


### PR DESCRIPTION
## Description

* adding an input-stream-object based on Azure-SDK for reading data from Azure-Blob-store
* adding unittests for new functionality
* the required C++ version had to be raised to C++14, because that's required by the Azure-SDK-headers

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

locally, with CZIcmd, unittests and by beta-users

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
