### PR TITLE
Explicitly disable the configure command for eigen (ext)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.62.1
+      VERSION 0.62.2
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -28,4 +28,4 @@ version history                 {#version_history}
  0.61.2             | [111](https://github.com/ZEISS/libczi/pull/111)      | update libcurl to 8.9.1 (for build with `LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF`), enable SChannel (on Windows) by default
  0.62.0             | [112](https://github.com/ZEISS/libczi/pull/112)      | add Azure-SDK based reader for reading from Azure Blob Storage, raise requirement to C++14 for building libCZI (previously C++11 was sufficient) because Azure-SDK requires C++14
  0.62.1             | [114](https://github.com/ZEISS/libczi/pull/114)      | improve build system fixing issues with msys2 and mingw-w64, cosmetic changes
- 0.62.1             | [115](https://github.com/ZEISS/libczi/pull/115)      | enabling building with clang on windows
+ 0.62.2             | [115](https://github.com/ZEISS/libczi/pull/115)      | enabling building with clang on windows

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -28,3 +28,4 @@ version history                 {#version_history}
  0.61.2             | [111](https://github.com/ZEISS/libczi/pull/111)      | update libcurl to 8.9.1 (for build with `LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=OFF`), enable SChannel (on Windows) by default
  0.62.0             | [112](https://github.com/ZEISS/libczi/pull/112)      | add Azure-SDK based reader for reading from Azure Blob Storage, raise requirement to C++14 for building libCZI (previously C++11 was sufficient) because Azure-SDK requires C++14
  0.62.1             | [114](https://github.com/ZEISS/libczi/pull/114)      | improve build system fixing issues with msys2 and mingw-w64, cosmetic changes
+ 0.62.1             | [115](https://github.com/ZEISS/libczi/pull/115)      | enabling building with clang on windows

--- a/cmake/ExternalEIGEN3.cmake
+++ b/cmake/ExternalEIGEN3.cmake
@@ -16,6 +16,7 @@ ExternalProject_Add(
     "-DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}"
     "-DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}"
   UPDATE_COMMAND ""
+  CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON   # redirect output to log-file (so that we have less clutter)

--- a/cmake/ExternalEIGEN3.cmake
+++ b/cmake/ExternalEIGEN3.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     "-DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}"
     "-DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}"
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND ""
+  CONFIGURE_COMMAND ""  # w/o this the build step fails with clang on windows
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON   # redirect output to log-file (so that we have less clutter)


### PR DESCRIPTION
## Description

Building with clang (tested with version 18.1.0rc) yields an error in the configuration step of the external eigen package.
Explicitly disabling this (it is implicitly skipped when building with msvc) solves this problem and the project builds fine with clang on windows.

Fixes # (issue)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally tested using clang from the official [LLVM releases](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.0). Configuring the project with `export CC=$(which clang) && export CXX=$(which clang++) && cmake -B build -S . -G Ninja` (ensuring the `which clang` and `which clang++` calls point to the correct locations of the compilers).
I've tested both, Release and Debug configurations + used this fork in an external project that includes libczi via `FetchContent_Declare`. 

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
