### PR TITLE
fix build when using a private RapidJSON library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.62.3
+      VERSION 0.62.4
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -45,8 +45,7 @@ else()
     FetchContent_Declare(
             RapidJSON
             GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-            GIT_TAG        7c73dd7de7c4f14379b781418c6e947ad464c818 # master as of 2024-08-16
-            GIT_SHALLOW    TRUE
+            GIT_TAG        815e6e7e7e14be44a6c15d9aefed232ff064cad0 # master as of 2024-09-26
             PREFIX "${CMAKE_BINARY_DIR}/vendor/rapidjson"
     )
 

--- a/Src/libCZI/Doc/version-history.markdown
+++ b/Src/libCZI/Doc/version-history.markdown
@@ -30,3 +30,4 @@ version history                 {#version_history}
  0.62.1             | [114](https://github.com/ZEISS/libczi/pull/114)      | improve build system fixing issues with msys2 and mingw-w64, cosmetic changes
  0.62.2             | [115](https://github.com/ZEISS/libczi/pull/115)      | enabling building with clang on windows
  0.62.3             | [116](https://github.com/ZEISS/libczi/pull/116)      | enable long paths on Windows for CZIcmd, add Windows-ARM64 build
+ 0.62.4             | [117](https://github.com/ZEISS/libczi/pull/117)      | fix build with private RapidJSON library


### PR DESCRIPTION
## Description

The CMake-build failed when using a private RapidJSON-library (i.e. when LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_RAPIDJSON would be false) when attempting to clone the repository because when specifying "GIT_SHALLOW TRUE" it is not possible to use a git-hash as tag. C.f. [here](https://cmake.org/cmake/help/latest/module/ExternalProject.html).
This removes the GIT_SHALLOW specifier, and while at it, switches to the latest version.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
