### PR TITLE
added missing time.h header

### DIFF
--- a/Src/libCZI_UnitTests/utils.cpp
+++ b/Src/libCZI_UnitTests/utils.cpp
@@ -5,6 +5,8 @@
 #include "utils.h"
 #include "../libCZI/bitmapData.h"
 
+#include <time.h>
+
 using namespace std;
 using namespace libCZI;
 


### PR DESCRIPTION
## Description

I have noticed that Microsoft Visual C++ 2017 fails to compile the Unit Tests (see error message below).

Adding this line will fix the error and likely cause no problems for other compilers.

[build]   utils.cpp
[build] C:\Users\Hendrik\dev\libczi\Src\libCZI_UnitTests\utils.cpp(325): error C2039: "time": Ist kein Element von "`global namespace'" [C:\Users\Hendrik\dev\libczi\build\Src\libCZI_UnitTests\libCZI_UnitTests.vcxproj]
[build] C:\Users\Hendrik\dev\libczi\Src\libCZI_UnitTests\utils.cpp(325): error C3861: "time": Bezeichner wurde nicht gefunden. [C:\Users\Hendrik\dev\libczi\build\Src\libCZI_UnitTests\libCZI_UnitTests.vcxproj]

### Type of change

Compilation fix

## How Has This Been Tested?

Compilation tested with bcc64x (Clang 15 derived) and MSVC 2017
