### PR TITLE
actions-upload-artifact-v3 obsolescence

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: "${{github.workspace}}/Src/Build/html/"

--- a/Src/libCZI/decoder_wic.cpp
+++ b/Src/libCZI/decoder_wic.cpp
@@ -292,10 +292,6 @@ static bool DeterminePixelType(const WICPixelFormatGUID& wicPxlFmt, GUID* destPi
         throw std::logic_error(ss.str());
     }
 
-    /*if (sizeBitmap.h != height || sizeBitmap.w != width) {
-        throw  std::logic_error("width and height don't match...");
-    }*/
-
     if (GetSite()->IsEnabled(LOGLEVEL_CHATTYINFORMATION))
     {
         stringstream ss; ss << " Requested Decoded PixelFormat:" << GetInformativeString(wicDestPxlFmt) << " Width:" << sizeBitmap.w << " Height:" << sizeBitmap.h;


### PR DESCRIPTION
## Description

* update GH-action to use v4 of upload-artifact action (c.f. [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))
* cosmetic (remove unused code)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Only CI/CD has changed.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
