### PR TITLE
fix error-handling for "external streams" in libCZIAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.65.0
+      VERSION 0.65.1
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZIAPI/inc/external_stream_error_information_struct.h
+++ b/Src/libCZIAPI/inc/external_stream_error_information_struct.h
@@ -17,7 +17,7 @@ const std::int32_t kStreamErrorCode_UnspecifiedError = 1;   ///< Error code for 
 struct ExternalStreamErrorInfoInterop
 {
     std::int32_t error_code;                        ///< The error code - possible values are the constants kStreamErrorCode_XXX.
-    MemoryAllocationObjectHandle error_message;     ///< The error message (zero-terminated UTF8-encoded string). This string must be allocated with 'libCZI_AllocateString'.
+    MemoryAllocationObjectHandle error_message;     ///< The error message (zero-terminated UTF8-encoded string). This string must be allocated with 'libCZI_AllocateMemory'.
 };
 
 #pragma pack(pop)

--- a/Src/libCZIAPI/inc/libCZIApi.h
+++ b/Src/libCZIAPI/inc/libCZIApi.h
@@ -33,6 +33,14 @@
 /// \param  data    Pointer to the memory to be freed.
 EXTERNALLIBCZIAPI_API(void) libCZI_Free(void* data);
 
+/// Allocate memory of the specified size.
+///
+/// \param          size    The size of the memory block to be allocated in bytes.
+/// \param [out]    data    If successful, a pointer to the allocated memory is put here. The memory must be freed using 'libCZI_Free'.
+///
+/// \returns    An error-code indicating success or failure of the operation.
+EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_AllocateMemory(std::uint64_t size, void** data);
+
 /// Get version information about the libCZIApi-library.
 ///
 /// \param [out] version_info    If successful, the version information is put here.

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -85,6 +85,28 @@ void libCZI_Free(void* data)
     ParameterHelpers::FreeMemory(data);
 }
 
+LibCZIApiErrorCode libCZI_AllocateMemory(std::uint64_t size, void** data)
+{
+    if (data == nullptr)
+    {
+        return LibCZIApi_ErrorCode_InvalidArgument;
+    }
+
+    *data = nullptr;
+    if (size == 0)
+    {
+        return LibCZIApi_ErrorCode_InvalidArgument;
+    }
+
+    if (size > std::numeric_limits<size_t>::max())
+    {
+        return LibCZIApi_ErrorCode_InvalidArgument;
+    }
+
+    *data = ParameterHelpers::AllocateMemory(size);
+    return LibCZIApi_ErrorCode_OK;
+}
+
 LibCZIApiErrorCode libCZI_GetLibCZIVersionInfo(LibCZIVersionInfoInterop* version_info)
 {
     if (version_info == nullptr)

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -717,6 +717,7 @@ namespace
                 {
                     ostringstream error_message;
                     error_message << "Error reading from external input stream. Error code: " << error_info.error_code << ". Error message: \"" << reinterpret_cast<const char*>(error_info.error_message) << "\"";
+                    libCZI_Free(reinterpret_cast<void*>(error_info.error_message));
                     throw runtime_error(error_message.str());
                 }
                 else

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -104,6 +104,11 @@ LibCZIApiErrorCode libCZI_AllocateMemory(std::uint64_t size, void** data)
     }
 
     *data = ParameterHelpers::AllocateMemory(size);
+    if (*data == nullptr)
+    {
+        return LibCZIApi_ErrorCode_OutOfMemory;
+    }
+
     return LibCZIApi_ErrorCode_OK;
 }
 
@@ -659,9 +664,9 @@ namespace
             {
                 if (error_info.error_message != kInvalidObjectHandle)
                 {
-                    // TODO(JBL): error handling needs to be looked into (and, probably, the memory must be released here)
                     ostringstream error_message;
                     error_message << "Error reading from external input stream. Error code: " << error_info.error_code << ". Error message: \"" << reinterpret_cast<const char*>(error_info.error_message) << "\"";
+                    libCZI_Free(error_info.error_message);
                     throw runtime_error(error_message.str());
                 }
                 else

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -98,12 +98,14 @@ LibCZIApiErrorCode libCZI_AllocateMemory(std::uint64_t size, void** data)
         return LibCZIApi_ErrorCode_InvalidArgument;
     }
 
+    // We defined the API using a uint64_t, and this type is larger than size_t on 32-bit systems. So, this
+    // check here is a no-op on 64-bit systems, but it is necessary on 32-bit systems.
     if (size > std::numeric_limits<size_t>::max())
     {
         return LibCZIApi_ErrorCode_InvalidArgument;
     }
 
-    *data = ParameterHelpers::AllocateMemory(size);
+    *data = ParameterHelpers::AllocateMemory(static_cast<size_t>(size));
     if (*data == nullptr)
     {
         return LibCZIApi_ErrorCode_OutOfMemory;

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -666,7 +666,7 @@ namespace
                 {
                     ostringstream error_message;
                     error_message << "Error reading from external input stream. Error code: " << error_info.error_code << ". Error message: \"" << reinterpret_cast<const char*>(error_info.error_message) << "\"";
-                    libCZI_Free(error_info.error_message);
+                    libCZI_Free(reinterpret_cast<void*>(error_info.error_message));
                     throw runtime_error(error_message.str());
                 }
                 else

--- a/Src/libCZIAPI/src/parameterhelpers.h
+++ b/Src/libCZIAPI/src/parameterhelpers.h
@@ -17,7 +17,14 @@
 class ParameterHelpers
 {
 public:
+
+    /// Allocate memory and return a void pointer to the allocated space, or NULL if there's insufficient memory available.
+    ///
+    /// \param  size    Bytes to allocate.
+    ///
+    /// \returns    Null if it fails, else a pointer to allocated memory.
     static void* AllocateMemory(size_t size);
+
     static void FreeMemory(void* ptr);
     static char* AllocString(const std::string& text);
 

--- a/Src/libCZIAPI/src/parameterhelpers.h
+++ b/Src/libCZIAPI/src/parameterhelpers.h
@@ -18,7 +18,7 @@ class ParameterHelpers
 {
 public:
 
-    /// Allocate memory and return a void pointer to the allocated space, or NULL if there's insufficient memory available.
+    /// Allocate memory and return a void pointer to the allocated memory, or NULL if there is insufficient memory available.
     ///
     /// \param  size    Bytes to allocate.
     ///

--- a/docs/source/pages/coordinate_systems.rst
+++ b/docs/source/pages/coordinate_systems.rst
@@ -14,6 +14,7 @@ As far as libCZI is concerned, there are two coordinate systems that are of inte
    unmodified with respect to the actual file content.
 
    Conceptually, the *raw-subblock-coordinate-system* has the following characteristics:
+
    * The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
    * Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
    * The origin of the coordinate system is arbitrary, there is no special geometric meaning to the origin.
@@ -26,6 +27,7 @@ As far as libCZI is concerned, there are two coordinate systems that are of inte
    The *CZI-Pixel-Coordinate-System* is the recommended way for relating to an X-Y-position in the CZI-document.
 
    The characteristics of the *CZI-Pixel-Coordinate-System* are:
+
    * The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
    * Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
    * The origin is such that the coordinate (of the logicalRect) of the top-most and left-most pyramid-layer0 subblock is (0,0).
@@ -39,6 +41,7 @@ Usage in libCZI
 libCZI at this point is using the *raw-subblock-coordinate-system* for all its operations. There are only a few
 operations where the choice of coordinate system is relevant: the accessor-functions which give tile-compositions.
 This includes:
+
 * `ISingleChannelTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_tile_accessor.html>`_
 * `ISingleChannelPyramidLayerTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_pyramid_layer_tile_accessor.html>`_
 * `ISingleChannelScalingTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_scaling_tile_accessor.html>`_

--- a/docs/source/pages/coordinate_systems.rst
+++ b/docs/source/pages/coordinate_systems.rst
@@ -6,7 +6,7 @@ Coordinate Systems
 
 As far as libCZI is concerned, there are two coordinate systems that are of interest:
 
-1. The *raw-subblock-coordinate-system* is the coordinate system in which the X-Y-positions of the subblocks
+#. The *raw-subblock-coordinate-system* is the coordinate system in which the X-Y-positions of the subblocks
    are physically stored in the file, and it is also the coordinate system which is used in libCZI.
    The API `ISubBlock::GetSubBlockInfo <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_sub_block.html#a557108549db08e25b1df1ef8fae37a07>`_
    is returning the X-Y-position of the subblock in this coordinate system
@@ -21,7 +21,7 @@ As far as libCZI is concerned, there are two coordinate systems that are of inte
    .. image:: ../_static/images/raw_subblock_coordinate_system_400x.png
       :alt: Raw SubBlock Coordinate System
 
-2. The *CZI-Pixel-Coordinate-System* is a coordinate system where the top-left subblock (of pyramid-layer 0) has the
+#. The *CZI-Pixel-Coordinate-System* is a coordinate system where the top-left subblock (of pyramid-layer 0) has the
    coordinate (0,0). It is related to the *raw-subblock-coordinate-system* by a translation.
    The *CZI-Pixel-Coordinate-System* is the recommended way for relating to an X-Y-position in the CZI-document.
 

--- a/docs/source/pages/coordinate_systems.rst
+++ b/docs/source/pages/coordinate_systems.rst
@@ -14,9 +14,9 @@ As far as libCZI is concerned, there are two coordinate systems that are of inte
    unmodified with respect to the actual file content.
 
    Conceptually, the *raw-subblock-coordinate-system* has the following characteristics:
-   - The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
-   - Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
-   - The origin of the coordinate system is arbitrary, there is no special geometric meaning to the origin.
+   * The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
+   * Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
+   * The origin of the coordinate system is arbitrary, there is no special geometric meaning to the origin.
 
    .. image:: ../_static/images/raw_subblock_coordinate_system_400x.png
       :alt: Raw SubBlock Coordinate System
@@ -26,9 +26,9 @@ As far as libCZI is concerned, there are two coordinate systems that are of inte
    The *CZI-Pixel-Coordinate-System* is the recommended way for relating to an X-Y-position in the CZI-document.
 
    The characteristics of the *CZI-Pixel-Coordinate-System* are:
-   - The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
-   - Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
-   - The origin is such that the coordinate (of the logicalRect) of the top-most and left-most pyramid-layer0 subblock is (0,0).
+   * The X and Y-axis are such that the subblock's logicalRect are axis-aligned.
+   * Orientation of the Y-axis is such that the Y-coordinate increases from top to bottom; X-coordinates increase from left to right.
+   * The origin is such that the coordinate (of the logicalRect) of the top-most and left-most pyramid-layer0 subblock is (0,0).
 
    .. image:: ../_static/images/CZI_pixel_coordinate_system_400x.png
       :alt: CZI Pixel Coordinate System
@@ -39,9 +39,9 @@ Usage in libCZI
 libCZI at this point is using the *raw-subblock-coordinate-system* for all its operations. There are only a few
 operations where the choice of coordinate system is relevant: the accessor-functions which give tile-compositions.
 This includes:
-- `ISingleChannelTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_tile_accessor.html>`_
-- `ISingleChannelPyramidLayerTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_pyramid_layer_tile_accessor.html>`_
-- `ISingleChannelScalingTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_scaling_tile_accessor.html>`_
+* `ISingleChannelTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_tile_accessor.html>`_
+* `ISingleChannelPyramidLayerTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_pyramid_layer_tile_accessor.html>`_
+* `ISingleChannelScalingTileAccessor <https://zeiss.github.io/libczi/classlib_c_z_i_1_1_i_single_channel_scaling_tile_accessor.html>`_
 
 The coordinates of the ROIs passed in here are in the *raw-subblock-coordinate-system*.
 

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -38,3 +38,5 @@ Version history
  0.63.1             | [128](https://github.com/ZEISS/libczi/pull/128)      | fix for CZICmd (command "ExtractAttachment"), improve UTF8-handling (on Windows)
  0.63.2             | [129](https://github.com/ZEISS/libczi/pull/129)      | update zstd to [version 1.5.7](https://github.com/facebook/zstd/releases/tag/v1.5.7)
  0.64.0             | [130](https://github.com/ZEISS/libczi/pull/130)      | define & implement "Resolution Protocol for Ambiguous or Contradictory Information"
+ 0.65.0             | [134](https://github.com/ZEISS/libczi/pull/134)      | introduce "libCZIAPI", use Sphinx for documentation
+ 0.65.1             | [136](https://github.com/ZEISS/libczi/pull/136)      | improve error handling in libCZIAPI (for "external streams")


### PR DESCRIPTION
## Description

* enable "proper error-handling" for "external stream"-functionality in libCZIAPI
* fix some formatting issues in the documentation

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally, and test code is included in the upcoming .NET-API

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
