### PR TITLE
add SubBlockInfoForIndex extension for libCZIAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.65.1
+      VERSION 0.66.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZIAPI/inc/libCZIApi.h
+++ b/Src/libCZIAPI/inc/libCZIApi.h
@@ -310,6 +310,16 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_SubBlockGetRawData(SubBlockObje
 /// \returns An error-code indicating success or failure of the operation.
 EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_ReleaseSubBlock(SubBlockObjectHandle sub_block_object);
 
+/// Get information about the sub-block at the specified index. The information is put into the 'sub_block_info_interop' structure.
+/// If the index is not valid, then the function returns 'LibCZIApi_ErrorCode_IndexOutOfRange'.
+///
+/// \param          reader_object           The reader object.
+/// \param          index                   The index of the attachment to query information for.
+/// \param [out]    sub_block_info_interop  If successful, the retrieved information is put here.
+///
+/// \returns An error-code indicating success or failure of the operation.
+EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_TryGetSubBlockInfoForIndex(CziReaderObjectHandle reader_object, std::int32_t index, SubBlockInfoInterop* sub_block_info_interop);
+
 // sub-block functions end here
 // ****************************************************************************************************
 
@@ -465,7 +475,7 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetScalingInfo(C
 /// \param [in,out] available_dimensions        If successful, the available dimensions are put here. The list is terminated with a value of 'kInvalidDimensionIndex'.
 ///
 /// \returns    An error-code indicating success or failure of the operation.
-EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetAvailableDimension(CziDocumentInfoHandle czi_document_info, std::uint32_t available_dimensions_count, std::uint32_t*  available_dimensions);
+EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetAvailableDimension(CziDocumentInfoHandle czi_document_info, std::uint32_t available_dimensions_count, std::uint32_t* available_dimensions);
 
 /// Get the display-settings from the document's XML-metadata. The display-settings are returned in the form of an object,
 /// for which a handle is returned.
@@ -682,7 +692,7 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_ReleaseCreateSingleChannelTileA
 ///
 /// \returns    An error-code indicating success or failure of the operation.
 EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CompositorFillOutCompositionChannelInfoInterop(
-                                                                    DisplaySettingsHandle display_settings_handle, 
+                                                                    DisplaySettingsHandle display_settings_handle,
                                                                     int channel_index,
                                                                     bool sixteen_or_eight_bits_lut,
                                                                     CompositionChannelInfoInterop* composition_channel_info_interop);

--- a/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
+++ b/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
@@ -238,3 +238,65 @@ TEST(CZIAPI_Reader, ConstructMultiSceneCziAndOpenCziAndCheckContent)
     ASSERT_EQ(1, input_stream_release_call_count) << "The 'external input-stream-object' is not released as expected.";
 };
 
+TEST(CZIAPI_Reader, ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex)
+{
+    CziReaderObjectHandle reader_object;
+    InputStreamObjectHandle stream_object;
+
+    LibCZIApiErrorCode error_code = libCZI_CreateReader(&reader_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    auto memory_input_stream_handler_object = new MemoryInputStream(CTestData::czi_with_subblock_of_size_t2, sizeof(CTestData::czi_with_subblock_of_size_t2));
+
+    int input_stream_release_call_count = 0;
+    ExternalInputStreamStructInterop external_input_stream_struct;
+    external_input_stream_struct.opaque_handle1 = reinterpret_cast<uintptr_t>(memory_input_stream_handler_object);
+    external_input_stream_struct.opaque_handle2 = reinterpret_cast<uintptr_t>(&input_stream_release_call_count);
+    external_input_stream_struct.read_function = [](uintptr_t opaque_handle1, uintptr_t opaque_handle2, uint64_t offset, void* pv, uint64_t size, uint64_t* ptrBytesRead, ExternalStreamErrorInfoInterop* error_info) -> int32_t
+        {
+            auto memory_input_stream_handler = reinterpret_cast<MemoryInputStream*>(opaque_handle1);
+            return memory_input_stream_handler->Read(offset, pv, size, ptrBytesRead, error_info);
+        };
+    external_input_stream_struct.close_function = [](uintptr_t opaque_handle1, uintptr_t opaque_handle2)->void
+        {
+            auto memory_input_stream_handler = reinterpret_cast<MemoryInputStream*>(opaque_handle1);
+            delete memory_input_stream_handler;
+            auto input_stream_release_call_count = reinterpret_cast<int*>(opaque_handle2);
+            ++(*input_stream_release_call_count);
+        };
+
+    error_code = libCZI_CreateInputStreamFromExternal(&external_input_stream_struct, &stream_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    ReaderOpenInfoInterop reader_open_info;
+    reader_open_info.streamObject = stream_object;
+    error_code = libCZI_ReaderOpen(reader_object, &reader_open_info);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    error_code = libCZI_ReleaseInputStream(stream_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    SubBlockInfoInterop info;
+    error_code = libCZI_TryGetSubBlockInfoForIndex(reader_object, 0, &info);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+    ASSERT_EQ(info.compression_mode_raw, 0);
+
+    ASSERT_EQ(info.coordinate.dimensions_valid, 2);
+
+    ASSERT_EQ(info.logical_rect.x, 0);
+    ASSERT_EQ(info.logical_rect.y, 0);
+    ASSERT_EQ(info.logical_rect.w, 1);
+    ASSERT_EQ(info.logical_rect.h, 1);
+
+    ASSERT_EQ(info.m_index, 0);
+
+    ASSERT_EQ(info.physical_size.w, 1);
+    ASSERT_EQ(info.physical_size.h, 1);
+
+    ASSERT_EQ(info.pixel_type, 0);
+
+    error_code = libCZI_ReleaseReader(reader_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    ASSERT_EQ(1, input_stream_release_call_count) << "The 'external input-stream-object' is not released as expected.";
+}

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -40,3 +40,4 @@ Version history
  0.64.0             | [130](https://github.com/ZEISS/libczi/pull/130)      | define & implement "Resolution Protocol for Ambiguous or Contradictory Information"
  0.65.0             | [134](https://github.com/ZEISS/libczi/pull/134)      | introduce "libCZIAPI", use Sphinx for documentation
  0.65.1             | [136](https://github.com/ZEISS/libczi/pull/136)      | improve error handling in libCZIAPI (for "external streams")
+ 0.66.0				| [137](https://github.com/ZEISS/libczi/pull/137)	   | add TryGetSubBlockInfoForIndex in libCZIAPI


### PR DESCRIPTION
## Description
This pull request introduces a new method, TryGetSubBlockInfoForIndex, to the libCZI API, which allows users to retrieve information about sub-blocks at a specified index. The new function uses the TryGetSubBlockInfo function instead of the ReadSubBlock function to get the subblock information at the specified index.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
The test named "ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex" was written to the test_CZIReader.cpp file.

This unit test checks the sub-block information at index 0.

During the test, the below informations are checked:
- compression_mode_raw
- logical_rect
- physical_size
- m_index
- pixel_type

## Checklist:

- [X] I followed the Contributing Guidelines.
- [X] I did a self-review.
- [X] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [X] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
