### PR TITLE
add SubBlockInfoForIndex extension for libCZIAPI 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.65.1
+      VERSION 0.66.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZIAPI/inc/libCZIApi.h
+++ b/Src/libCZIAPI/inc/libCZIApi.h
@@ -310,7 +310,7 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_SubBlockGetRawData(SubBlockObje
 /// \returns An error-code indicating success or failure of the operation.
 EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_ReleaseSubBlock(SubBlockObjectHandle sub_block_object);
 
-/// Get information about the sub-block at the specified index. The information is put into the 'sub_block_info_interop' structure.
+/// Get information about the sub-block with the specified index. The information is put into the 'sub_block_info_interop' structure.
 /// If the index is not valid, then the function returns 'LibCZIApi_ErrorCode_IndexOutOfRange'.
 ///
 /// \param          reader_object           The reader object.

--- a/Src/libCZIAPI/inc/libCZIApi.h
+++ b/Src/libCZIAPI/inc/libCZIApi.h
@@ -310,6 +310,16 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_SubBlockGetRawData(SubBlockObje
 /// \returns An error-code indicating success or failure of the operation.
 EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_ReleaseSubBlock(SubBlockObjectHandle sub_block_object);
 
+/// Get information about the sub-block at the specified index. The information is put into the 'sub_block_info_interop' structure.
+/// If the index is not valid, then the function returns 'LibCZIApi_ErrorCode_IndexOutOfRange'.
+///
+/// \param          reader_object           The reader object.
+/// \param          index                   The index of the attachment to query information for.
+/// \param [out]    sub_block_info_interop  If successful, the retrieved information is put here.
+///
+/// \returns An error-code indicating success or failure of the operation.
+EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_TryGetSubBlockInfoForIndex(CziReaderObjectHandle reader_object, std::int32_t index, SubBlockInfoInterop* sub_block_info_interop);
+
 // sub-block functions end here
 // ****************************************************************************************************
 
@@ -465,7 +475,7 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetScalingInfo(C
 /// \param [in,out] available_dimensions        If successful, the available dimensions are put here. The list is terminated with a value of 'kInvalidDimensionIndex'.
 ///
 /// \returns    An error-code indicating success or failure of the operation.
-EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetAvailableDimension(CziDocumentInfoHandle czi_document_info, std::uint32_t available_dimensions_count, std::uint32_t*  available_dimensions);
+EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CziDocumentInfoGetAvailableDimension(CziDocumentInfoHandle czi_document_info, std::uint32_t available_dimensions_count, std::uint32_t* available_dimensions);
 
 /// Get the display-settings from the document's XML-metadata. The display-settings are returned in the form of an object,
 /// for which a handle is returned.
@@ -682,7 +692,7 @@ EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_ReleaseCreateSingleChannelTileA
 ///
 /// \returns    An error-code indicating success or failure of the operation.
 EXTERNALLIBCZIAPI_API(LibCZIApiErrorCode) libCZI_CompositorFillOutCompositionChannelInfoInterop(
-                                                                    DisplaySettingsHandle display_settings_handle, 
+                                                                    DisplaySettingsHandle display_settings_handle,
                                                                     int channel_index,
                                                                     bool sixteen_or_eight_bits_lut,
                                                                     CompositionChannelInfoInterop* composition_channel_info_interop);

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -76,21 +76,6 @@ namespace
 
     void CopyFromSubBlockInfoToSubBlockInfoInterop(const libCZI::SubBlockInfo& source, SubBlockInfoInterop& destination)
     {
-       /* destination.compression_mode_raw = source.compressionModeRaw;
-
-        destination.pixel_type = static_cast<std::int32_t>(source.pixelType);
-
-        destination.coordinate.dimensions_valid = source.coordinate.GetValidDimensionsCount();
-
-        destination.logical_rect.x = source.logicalRect.x;
-        destination.logical_rect.y = source.logicalRect.y;
-        destination.logical_rect.h = source.logicalRect.h;
-        destination.logical_rect.w = source.logicalRect.w;
-
-        destination.physical_size.w = source.physicalSize.w;
-        destination.physical_size.h = source.physicalSize.h;
-
-        destination.m_index = source.mIndex;*/
         destination.compression_mode_raw = source.compressionModeRaw;
         destination.pixel_type = static_cast<int32_t>(source.pixelType);
         destination.coordinate = ParameterHelpers::ConvertIDimCoordinateToCoordinateInterop(&source.coordinate);
@@ -861,23 +846,6 @@ LibCZIApiErrorCode libCZI_SubBlockGetInfo(SubBlockObjectHandle sub_block_object,
     {
         const auto& sub_block_info_data = shared_sub_block_wrapping_object->shared_ptr_->GetSubBlockInfo();
         CopyFromSubBlockInfoToSubBlockInfoInterop(sub_block_info_data, *sub_block_info);
-        /*sub_block_info->compression_mode_raw = sub_block_info_data.compressionModeRaw;
-        sub_block_info->pixel_type = static_cast<int32_t>(sub_block_info_data.pixelType);
-        sub_block_info->coordinate = ParameterHelpers::ConvertIDimCoordinateToCoordinateInterop(&sub_block_info_data.coordinate);
-        sub_block_info->logical_rect.x = sub_block_info_data.logicalRect.x;
-        sub_block_info->logical_rect.y = sub_block_info_data.logicalRect.y;
-        sub_block_info->logical_rect.w = sub_block_info_data.logicalRect.w;
-        sub_block_info->logical_rect.h = sub_block_info_data.logicalRect.h;
-        sub_block_info->physical_size.w = sub_block_info_data.physicalSize.w;
-        sub_block_info->physical_size.h = sub_block_info_data.physicalSize.h;
-        if (sub_block_info_data.IsMindexValid())
-        {
-            sub_block_info->m_index = sub_block_info_data.mIndex;
-        }
-        else
-        {
-            sub_block_info->m_index = numeric_limits<int32_t>::min();
-        }*/
 
         return LibCZIApi_ErrorCode_OK;
     }

--- a/Src/libCZIAPI/src/libCZIApi.cpp
+++ b/Src/libCZIAPI/src/libCZIApi.cpp
@@ -76,7 +76,7 @@ namespace
 
     void CopyFromSubBlockInfoToSubBlockInfoInterop(const libCZI::SubBlockInfo& source, SubBlockInfoInterop& destination)
     {
-        destination.compression_mode_raw = source.compressionModeRaw;
+       /* destination.compression_mode_raw = source.compressionModeRaw;
 
         destination.pixel_type = static_cast<std::int32_t>(source.pixelType);
 
@@ -90,7 +90,24 @@ namespace
         destination.physical_size.w = source.physicalSize.w;
         destination.physical_size.h = source.physicalSize.h;
 
-        destination.m_index = source.mIndex;
+        destination.m_index = source.mIndex;*/
+        destination.compression_mode_raw = source.compressionModeRaw;
+        destination.pixel_type = static_cast<int32_t>(source.pixelType);
+        destination.coordinate = ParameterHelpers::ConvertIDimCoordinateToCoordinateInterop(&source.coordinate);
+        destination.logical_rect.x = source.logicalRect.x;
+        destination.logical_rect.y = source.logicalRect.y;
+        destination.logical_rect.w = source.logicalRect.w;
+        destination.logical_rect.h = source.logicalRect.h;
+        destination.physical_size.w = source.physicalSize.w;
+        destination.physical_size.h = source.physicalSize.h;
+        if (source.IsMindexValid())
+        {
+            destination.m_index = source.mIndex;
+        }
+        else
+        {
+            destination.m_index = numeric_limits<int32_t>::min();
+        }
     }
 }
 
@@ -843,7 +860,8 @@ LibCZIApiErrorCode libCZI_SubBlockGetInfo(SubBlockObjectHandle sub_block_object,
     try
     {
         const auto& sub_block_info_data = shared_sub_block_wrapping_object->shared_ptr_->GetSubBlockInfo();
-        sub_block_info->compression_mode_raw = sub_block_info_data.compressionModeRaw;
+        CopyFromSubBlockInfoToSubBlockInfoInterop(sub_block_info_data, *sub_block_info);
+        /*sub_block_info->compression_mode_raw = sub_block_info_data.compressionModeRaw;
         sub_block_info->pixel_type = static_cast<int32_t>(sub_block_info_data.pixelType);
         sub_block_info->coordinate = ParameterHelpers::ConvertIDimCoordinateToCoordinateInterop(&sub_block_info_data.coordinate);
         sub_block_info->logical_rect.x = sub_block_info_data.logicalRect.x;
@@ -859,7 +877,7 @@ LibCZIApiErrorCode libCZI_SubBlockGetInfo(SubBlockObjectHandle sub_block_object,
         else
         {
             sub_block_info->m_index = numeric_limits<int32_t>::min();
-        }
+        }*/
 
         return LibCZIApi_ErrorCode_OK;
     }

--- a/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
+++ b/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
@@ -238,3 +238,65 @@ TEST(CZIAPI_Reader, ConstructMultiSceneCziAndOpenCziAndCheckContent)
     ASSERT_EQ(1, input_stream_release_call_count) << "The 'external input-stream-object' is not released as expected.";
 };
 
+TEST(CZIAPI_Reader, ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex)
+{
+    CziReaderObjectHandle reader_object;
+    InputStreamObjectHandle stream_object;
+
+    LibCZIApiErrorCode error_code = libCZI_CreateReader(&reader_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    auto memory_input_stream_handler_object = new MemoryInputStream(CTestData::czi_with_subblock_of_size_t2, sizeof(CTestData::czi_with_subblock_of_size_t2));
+
+    int input_stream_release_call_count = 0;
+    ExternalInputStreamStructInterop external_input_stream_struct;
+    external_input_stream_struct.opaque_handle1 = reinterpret_cast<uintptr_t>(memory_input_stream_handler_object);
+    external_input_stream_struct.opaque_handle2 = reinterpret_cast<uintptr_t>(&input_stream_release_call_count);
+    external_input_stream_struct.read_function = [](uintptr_t opaque_handle1, uintptr_t opaque_handle2, uint64_t offset, void* pv, uint64_t size, uint64_t* ptrBytesRead, ExternalStreamErrorInfoInterop* error_info) -> int32_t
+        {
+            auto memory_input_stream_handler = reinterpret_cast<MemoryInputStream*>(opaque_handle1);
+            return memory_input_stream_handler->Read(offset, pv, size, ptrBytesRead, error_info);
+        };
+    external_input_stream_struct.close_function = [](uintptr_t opaque_handle1, uintptr_t opaque_handle2)->void
+        {
+            auto memory_input_stream_handler = reinterpret_cast<MemoryInputStream*>(opaque_handle1);
+            delete memory_input_stream_handler;
+            auto input_stream_release_call_count = reinterpret_cast<int*>(opaque_handle2);
+            ++(*input_stream_release_call_count);
+        };
+
+    error_code = libCZI_CreateInputStreamFromExternal(&external_input_stream_struct, &stream_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    ReaderOpenInfoInterop reader_open_info;
+    reader_open_info.streamObject = stream_object;
+    error_code = libCZI_ReaderOpen(reader_object, &reader_open_info);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    error_code = libCZI_ReleaseInputStream(stream_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    SubBlockInfoInterop info;
+    error_code = libCZI_TryGetSubBlockInfoForIndex(reader_object, 0, &info);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+    ASSERT_EQ(info.compression_mode_raw, 0);
+
+    ASSERT_EQ(info.coordinate.dimensions_valid, 2);
+
+    ASSERT_EQ(info.logical_rect.x, 0);
+    ASSERT_EQ(info.logical_rect.y, 0);
+    ASSERT_EQ(info.logical_rect.w, 1);
+    ASSERT_EQ(info.logical_rect.h, 1);
+
+    ASSERT_EQ(info.m_index, 0);
+
+    ASSERT_EQ(info.physical_size.w, 1);
+    ASSERT_EQ(info.physical_size.h, 1);
+
+    ASSERT_EQ(info.pixel_type, 0);
+
+    error_code = libCZI_ReleaseReader(reader_object);
+    ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
+
+    ASSERT_EQ(1, input_stream_release_call_count) << "The 'external input-stream-object' is not released as expected.";
+}

--- a/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
+++ b/Src/libCZIAPI_UnitTests/test_CZIReader.cpp
@@ -281,8 +281,6 @@ TEST(CZIAPI_Reader, ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex)
     ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);
     ASSERT_EQ(info.compression_mode_raw, 0);
 
-    ASSERT_EQ(info.coordinate.dimensions_valid, 2);
-
     ASSERT_EQ(info.logical_rect.x, 0);
     ASSERT_EQ(info.logical_rect.y, 0);
     ASSERT_EQ(info.logical_rect.w, 1);
@@ -294,6 +292,10 @@ TEST(CZIAPI_Reader, ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex)
     ASSERT_EQ(info.physical_size.h, 1);
 
     ASSERT_EQ(info.pixel_type, 0);
+
+    const libCZI::CDimCoordinate dim_coordinate = Utilities::ConvertCoordinateInterop(info.coordinate);
+    const auto dim_coordinate_as_string = libCZI::Utils::DimCoordinateToString(&dim_coordinate);
+    ASSERT_STREQ("C0T0", dim_coordinate_as_string.c_str());
 
     error_code = libCZI_ReleaseReader(reader_object);
     ASSERT_EQ(LibCZIApi_ErrorCode_OK, error_code);

--- a/Src/libCZIAPI_UnitTests/utilities.cpp
+++ b/Src/libCZIAPI_UnitTests/utilities.cpp
@@ -167,3 +167,20 @@ tuple<shared_ptr<void>, size_t> Utilities::CreateMosaicCzi(const MosaicInfo& mos
 
     return dim_bounds;
 }
+
+/*static*/libCZI::CDimCoordinate Utilities::ConvertCoordinateInterop(const CoordinateInterop& coordinate_interop)
+{
+    libCZI::CDimCoordinate coordinate;
+    int coordinate_index = 0;
+    for (int i = static_cast<int>(libCZI::DimensionIndex::MinDim); i <= static_cast<int>(libCZI::DimensionIndex::MaxDim); ++i)
+    {
+        const int index = i - static_cast<int>(libCZI::DimensionIndex::MinDim);
+        if (coordinate_interop.dimensions_valid & (1 << index))
+        {
+            coordinate.Set(static_cast<libCZI::DimensionIndex>(i), coordinate_interop.value[coordinate_index]);
+            ++coordinate_index;
+        }
+    }
+
+    return coordinate;
+}

--- a/Src/libCZIAPI_UnitTests/utilities.h
+++ b/Src/libCZIAPI_UnitTests/utilities.h
@@ -14,6 +14,7 @@ class Utilities
 public:
     static std::shared_ptr<libCZI::IBitmapData> CreateGray8BitmapAndFill(std::uint32_t width, std::uint32_t height, uint8_t value);
     static libCZI::CDimBounds ConvertDimBoundsInterop(const DimBoundsInterop& dim_bounds_interop);
+    static libCZI::CDimCoordinate ConvertCoordinateInterop(const CoordinateInterop& coordinate_interop);
 
     struct TileInfo
     {

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -40,3 +40,4 @@ Version history
  0.64.0             | [130](https://github.com/ZEISS/libczi/pull/130)      | define & implement "Resolution Protocol for Ambiguous or Contradictory Information"
  0.65.0             | [134](https://github.com/ZEISS/libczi/pull/134)      | introduce "libCZIAPI", use Sphinx for documentation
  0.65.1             | [136](https://github.com/ZEISS/libczi/pull/136)      | improve error handling in libCZIAPI (for "external streams")
+ 0.66.0				| [137](https://github.com/ZEISS/libczi/pull/137)	   | add TryGetSubBlockInfoForIndex in libCZIAPI

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -40,4 +40,4 @@ Version history
  0.64.0             | [130](https://github.com/ZEISS/libczi/pull/130)      | define & implement "Resolution Protocol for Ambiguous or Contradictory Information"
  0.65.0             | [134](https://github.com/ZEISS/libczi/pull/134)      | introduce "libCZIAPI", use Sphinx for documentation
  0.65.1             | [136](https://github.com/ZEISS/libczi/pull/136)      | improve error handling in libCZIAPI (for "external streams")
- 0.66.0				| [137](https://github.com/ZEISS/libczi/pull/137)	   | add TryGetSubBlockInfoForIndex in libCZIAPI
+ 0.66.0             | [138](https://github.com/ZEISS/libczi/pull/138)      | add TryGetSubBlockInfoForIndex in libCZIAPI


### PR DESCRIPTION
## Description

This pull request introduces a new method, TryGetSubBlockInfoForIndex, to the libCZI API, which allows users to retrieve information about sub-blocks at a specified index. The new function uses the TryGetSubBlockInfo function instead of the ReadSubBlock function to get the subblock information at the specified index.

This PR supersedes #137 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The test named "ConstructExternalInputStreamAndTryGetSubBlockInfoForIndex" was written to the test_CZIReader.cpp file.

This unit test checks the sub-block information at index 0.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
