### PR TITLE
Update build options

### DIFF
--- a/docs/source/pages/building.rst
+++ b/docs/source/pages/building.rst
@@ -96,6 +96,11 @@ The CMake-file defines the following options for customizing the build:
 | PREFER\_EXTERNALPACKAGE\_        | present on the system.  Default  |
 | RAPIDJSON                        | is **ON**                        |
 +----------------------------------+----------------------------------+
+| LIBCZI\_BUILD\_LIBCZIAPI         | Build the **C** API bridge       |
+|                                  | which can be used as foreign     |
+|                                  | function interface between other |
+|                                  | languages.  Default is **OFF**   |
++----------------------------------+----------------------------------+
 
 If building CZICmd is desired, then running CMake with this command line will enable building CZICmd:
 

--- a/docs/source/pages/building.rst
+++ b/docs/source/pages/building.rst
@@ -47,27 +47,27 @@ The CMake-file defines the following options for customizing the build:
 +----------------------------------+----------------------------------+
 | option                           | description                      |
 +==================================+==================================+
-| LIBCZI\_BUILDUNITTESTS           | Whether to build the unit-tests  |
+| LIBCZI\_BUILD\_UNITTESTS         | Whether to build the unit-tests  |
 |                                  | for libCZI. Default is **ON**.   |
 +----------------------------------+----------------------------------+
-| LIBCZI\_BUILDCZICMD              | Whether to build the test- and   |
+| LIBCZI\_BUILD\_CZICMD            | Whether to build the test- and   |
 |                                  | sample-application CZICmd.       |
 |                                  | Default is **OFF**.              |
 +----------------------------------+----------------------------------+
-| LIBCZI\_BUILDDYNLIB              | Whether to build the dynamic     |
+| LIBCZI\_BUILD\_DYNLIB            | Whether to build the dynamic     |
 |                                  | link libaray for libczi. Default |
 |                                  | is **ON**.                       |
 +----------------------------------+----------------------------------+
-| LIBCZI\_BUILD                    | Whether to use an existing       |
-| PREFEREXTERNALPACKAGEEIGEN3      | Eigen3-library on the system     |
+| LIBCZI\_BUILD\_                  | Whether to use an existing       |
+| PREFER\_EXTERNALPACKAGE\_EIGEN3  | Eigen3-library on the system     |
 |                                  | (included via                    |
 |                                  | find_package). If this           |
 |                                  | is OFF, then a copy of Eigen3 is |
 |                                  | downloaded as part of the build. |
 |                                  | Default is **OFF**.              |
 +----------------------------------+----------------------------------+
-| LIBCZI\_                         | Whether to use an existing       |
-| BUILDPREFEREXTERNALPACKAGEZSTD   | zstd-library on the system       |
+| LIBCZI\_BUILD\_                  | Whether to use an existing       |
+| PREFER\_EXTERNALPACKAGE\_ZSTD    | zstd-library on the system       |
 |                                  | (included via                    |
 |                                  | find_package). If this           |
 |                                  | is OFF, then a copy of zstd is   |
@@ -75,23 +75,24 @@ The CMake-file defines the following options for customizing the build:
 |                                  | Default is **OFF**.              |
 +----------------------------------+----------------------------------+
 | LIBCZI\                          | Whether a curl-based stream      |
-| BUILDCURLBASEDSTREAM             | object should be built (and be   |
+| BUILD\_CURL\_BASED\_STREAM       | object should be built (and be   |
 |                                  | available in the stream          |
 |                                  | factory). Default is **OFF**.    |
 +----------------------------------+----------------------------------+
 | LIBCZI\_BUILD                    | Whether to use an existing       |
-| PREFEREXTERNALPACKAGELIBCURL     | libcurl-library on the system    |
-|                                  | (included via                    |
+| PREFER\_EXTERNAL\_PACKAGE\_      | libcurl-library on the system    |
+| LIBCURL                          | (included via                    |
 |                                  | find_package). If this           |
 |                                  | is OFF, then a copy of libcurl   |
 |                                  | is downloaded as part of the     |
 |                                  | build. Default is **OFF**.       |
 +----------------------------------+----------------------------------+
 | LIBCZI\_                         | Whether the Azure-SDK-based      |
-| BUILDAZURESDKBASEDSTREAM         | stream object should be built    |
+| BUILD\_AZURESDK\_BASED\_STREAM   | stream object should be built    |
 |                                  | (and be available in the stream  |
 |                                  | factory). Default is **OFF**.    |
 +----------------------------------+----------------------------------+
+
 
 If building CZICmd is desired, then running CMake with this command line will enable building CZICmd:
 

--- a/docs/source/pages/building.rst
+++ b/docs/source/pages/building.rst
@@ -92,7 +92,10 @@ The CMake-file defines the following options for customizing the build:
 |                                  | (and be available in the stream  |
 |                                  | factory). Default is **OFF**.    |
 +----------------------------------+----------------------------------+
-
+| LIBCZI\_BUILD\_                  | Prefer a RapidJSON-package       |
+| PREFER\_EXTERNALPACKAGE\_        | present on the system.  Default  |
+| RAPIDJSON                        | is **ON**                        |
++----------------------------------+----------------------------------+
 
 If building CZICmd is desired, then running CMake with this command line will enable building CZICmd:
 


### PR DESCRIPTION
# Build documentation fixes

## Description

I'm currently developing a Java library that wraps `libCZI` using the Foreign Function & Memory (FFM) API. While configuring my build, I noticed that the build option documentation seems to be slightly out of sync with the options defined in `CMakeLists.txt`.

It appears some option names in the documentation are missing an underscore (e.g., `LIBCZI_BUILDDYNLIB` should be `LIBCZI_BUILD_DYNLIB`), and at least one new option is not listed (`LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_RAPIDJSON`). 

Fixes #140 

## Type of change

- Updates documentation
- Makes no other changes
