### PR TITLE
add (experimental) support for building for UWP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,6 @@ message("check for open -> ${HAVE_FCNTL_H_OPEN_TEXT} ; check for pread -> ${HAVE
 # The meaning of this switch is: whether Win32-API can be used (and this affects not only compilation but e.g. also linking to the Win32-API, as
 # it is not automatically linked to when using MinGW or Cygwin).
 # TODO(JBL): check whether cross-compiling to Windows works
-##if (WIN32 OR CYGWIN OR MSYS OR MINGW OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
-##  set(LIBCZI_HAVE_WIN32_API ON)
-##else()
-##  set(LIBCZI_HAVE_WIN32_API OFF)
-##endif()
 
 include(detect_win32_api_mode)
 detect_win32_api_mode(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,17 @@ message("check for open -> ${HAVE_FCNTL_H_OPEN_TEXT} ; check for pread -> ${HAVE
 # The meaning of this switch is: whether Win32-API can be used (and this affects not only compilation but e.g. also linking to the Win32-API, as
 # it is not automatically linked to when using MinGW or Cygwin).
 # TODO(JBL): check whether cross-compiling to Windows works
-if (WIN32 OR CYGWIN OR MSYS OR MINGW OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  set(LIBCZI_HAVE_WIN32_API ON)
-else()
-  set(LIBCZI_HAVE_WIN32_API OFF)
-endif()
+##if (WIN32 OR CYGWIN OR MSYS OR MINGW OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
+##  set(LIBCZI_HAVE_WIN32_API ON)
+##else()
+##  set(LIBCZI_HAVE_WIN32_API OFF)
+##endif()
+
+include(detect_win32_api_mode)
+detect_win32_api_mode(
+    LIBCZI_HAVE_WIN32_API
+    LIBCZI_HAVE_WIN32UWP_API
+)
 
 # This option controls whether to build the curl-based http-/https-stream object. If this option is
 # "ON", the build will fail if the curl-library is not available (either as an external package or

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.66.2
+      VERSION 0.66.3
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 
@@ -75,12 +75,7 @@ check_cxx_symbol_exists(pwrite unistd.h HAVE_UNISTD_H_PWRITE)
 BoolToFoundNotFound(HAVE_UNISTD_H_PWRITE HAVE_UNISTD_H_PWRITE_TEXT)
 message("check for open -> ${HAVE_FCNTL_H_OPEN_TEXT} ; check for pread -> ${HAVE_UNISTD_H_PREAD_TEXT} ; check for pwrite -> ${HAVE_UNISTD_H_PWRITE_TEXT}")
 
-# Determine whether the Win32-API can be used (in other words: whether we are on a Windows-platform or targetting the Windows-platform).
-# Note that just checking for WIN32 is not sufficient here, as this is not defined with environments such as msys2. In those cases, UNIX is defined.
-# The meaning of this switch is: whether Win32-API can be used (and this affects not only compilation but e.g. also linking to the Win32-API, as
-# it is not automatically linked to when using MinGW or Cygwin).
-# TODO(JBL): check whether cross-compiling to Windows works
-
+# Determine whether we are building for the classic Win32-API or for UWP (Universal Windows Platform).
 include(detect_win32_api_mode)
 detect_win32_api_mode(
     LIBCZI_HAVE_WIN32_API

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -113,6 +113,8 @@ set(LIBCZISRCFILES
             StreamsLib/curlhttpinputstream.h
             StreamsLib/windowsfileinputstream.cpp
             StreamsLib/windowsfileinputstream.h
+            StreamsLib/uwpfileinputstream.cpp
+            StreamsLib/uwpfileinputstream.h
             StreamsLib/simplefileinputstream.cpp
             StreamsLib/simplefileinputstream.h
             StreamsLib/preadfileinputstream.cpp
@@ -283,6 +285,12 @@ if (LIBCZI_HAVE_WIN32_API)
   set(libCZI_WINDOWSAPIAVAILABLE 1)
 else()
   set(libCZI_WINDOWSAPIAVAILABLE 0)
+endif()
+
+if (LIBCZI_HAVE_WIN32UWP_API)
+  set(libCZI_WINDOWSAPI_UWP_AVAILABLE 1)
+else()
+  set(libCZI_WINDOWSAPI_UWP_AVAILABLE 0)
 endif()
 
 configure_file (

--- a/Src/libCZI/CziSubBlockDirectory.cpp
+++ b/Src/libCZI/CziSubBlockDirectory.cpp
@@ -269,7 +269,7 @@ const libCZI::PyramidStatistics& CSbBlkStatisticsUpdater::GetPyramidStatistics()
 
     static const MinificationFactorToPyramidLayerInfo MinFacToPLI_Factor3[] =
     {
-        { 3,.1,.1,1 },
+    { 3,.1,.1,1 },
     { 9,.2,.2,2 },
     { 27,.8,.8,3 },
     { 81,1.5,1.5,4 },

--- a/Src/libCZI/StreamsLib/streamsFactory.cpp
+++ b/Src/libCZI/StreamsLib/streamsFactory.cpp
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include "curlhttpinputstream.h"
 #include "windowsfileinputstream.h"
+#include "uwpfileinputstream.h"
 #include "simplefileinputstream.h"
 #include "preadfileinputstream.h"
 #include "azureblobinputstream.h"
@@ -64,6 +65,19 @@ static const struct
             [](const StreamsFactory::CreateStreamInfo& stream_info, const std::wstring& file_name) -> std::shared_ptr<libCZI::IStream>
             {
                 return std::make_shared<WindowsFileInputStream>(file_name.c_str());
+            }
+        },
+#endif  // LIBCZI_WINDOWSAPI_AVAILABLE
+#if LIBCZI_WINDOWS_UWPAPI_AVAILABLE
+        {
+            { "uwp_file_inputstream", "stream implementation based on UWP-API", nullptr, nullptr },
+            [](const StreamsFactory::CreateStreamInfo& stream_info, const std::string& file_name) -> std::shared_ptr<libCZI::IStream>
+            {
+                return std::make_shared<UwpFileInputStream>(file_name);
+            },
+            [](const StreamsFactory::CreateStreamInfo& stream_info, const std::wstring& file_name) -> std::shared_ptr<libCZI::IStream>
+            {
+                return std::make_shared<UwpFileInputStream>(file_name.c_str());
             }
         },
 #endif  // LIBCZI_WINDOWSAPI_AVAILABLE

--- a/Src/libCZI/StreamsLib/uwpfileinputstream.cpp
+++ b/Src/libCZI/StreamsLib/uwpfileinputstream.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "uwpfileinputstream.h"
+
+#if LIBCZI_WINDOWS_UWPAPI_AVAILABLE
+#include <limits>
+#include <iomanip>
+#include "../utilities.h"
+
+UwpFileInputStream::UwpFileInputStream(const std::string& filename)
+    : UwpFileInputStream(Utilities::convertUtf8ToWchar_t(filename.c_str()).c_str())
+{
+}
+
+UwpFileInputStream::UwpFileInputStream(const wchar_t* filename)
+    : handle(INVALID_HANDLE_VALUE)
+{
+    CREATEFILE2_EXTENDED_PARAMETERS params = {};
+    params.dwSize = sizeof(params);
+    params.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
+    params.dwFileFlags = FILE_FLAG_RANDOM_ACCESS;
+    params.dwSecurityQosFlags = 0;
+    params.lpSecurityAttributes = nullptr;
+    params.hTemplateFile = nullptr;
+
+    const HANDLE file_handle = CreateFile2(
+        filename,
+        GENERIC_READ,
+        FILE_SHARE_READ,
+        OPEN_EXISTING,
+        &params
+    );
+
+    if (file_handle == INVALID_HANDLE_VALUE)
+    {
+        std::stringstream ss;
+        ss << "Error opening the file \"" << Utilities::convertWchar_tToUtf8(filename) << "\"";
+        throw std::runtime_error(ss.str());
+    }
+
+    this->handle = file_handle;
+}
+
+UwpFileInputStream::~UwpFileInputStream()
+{
+    if (this->handle != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(this->handle);
+    }
+}
+
+void UwpFileInputStream::Read(std::uint64_t offset, void* pv, std::uint64_t size, std::uint64_t* ptrBytesRead)
+{
+    if (size > (std::numeric_limits<DWORD>::max)())
+    {
+        throw std::runtime_error("size is too large");
+    }
+
+    OVERLAPPED ol = {};
+    ol.Offset = static_cast<DWORD>(offset);
+    ol.OffsetHigh = static_cast<DWORD>(offset >> 32);
+    DWORD bytes_read;
+    const BOOL read_file_return_code = ReadFile(this->handle, pv, static_cast<DWORD>(size), &bytes_read, &ol);
+    if (!read_file_return_code)
+    {
+        const DWORD last_error = GetLastError();
+        std::stringstream ss;
+        ss << "Error reading from file (LastError=" << std::hex << std::setfill('0') << std::setw(8) << std::showbase << last_error << ")";
+        throw std::runtime_error(ss.str());
+    }
+
+    if (ptrBytesRead != nullptr)
+    {
+        *ptrBytesRead = bytes_read;
+    }
+}
+
+#endif

--- a/Src/libCZI/StreamsLib/uwpfileinputstream.h
+++ b/Src/libCZI/StreamsLib/uwpfileinputstream.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+#include <libCZI_Config.h>
+
+#if LIBCZI_WINDOWS_UWPAPI_AVAILABLE
+#include <string>
+#include "../libCZI.h"
+#include <Windows.h>
+
+/// Implementation of the IStream-interface for files based on the Win32-API.
+/// It leverages the Win32-API ReadFile passing in an offset, thus allowing for concurrent
+/// access without locking.
+class UwpFileInputStream : public libCZI::IStream
+{
+private:
+    HANDLE handle;
+public:
+    UwpFileInputStream() = delete;
+    explicit UwpFileInputStream(const wchar_t* filename);
+    explicit UwpFileInputStream(const std::string& filename);
+    ~UwpFileInputStream() override;
+public: // interface libCZI::IStream
+    void Read(std::uint64_t offset, void* pv, std::uint64_t size, std::uint64_t* ptrBytesRead) override;
+};
+
+#endif

--- a/Src/libCZI/libCZI_Config.h.in
+++ b/Src/libCZI/libCZI_Config.h.in
@@ -13,6 +13,9 @@
 // whether the libCZI library is built with support for the Windows-API, i.e. whether it is being built for a Windows-environment
 #define LIBCZI_WINDOWSAPI_AVAILABLE @libCZI_WINDOWSAPIAVAILABLE@
 
+// whether the libCZI library is built with support for the Windows-UWP-API, i.e. whether it is being built for an UWP-environment
+#define LIBCZI_WINDOWS_UWPAPI_AVAILABLE @libCZI_WINDOWSAPI_UWP_AVAILABLE@
+
 // if the host system is a big-endian system, this is "1", otherwise 0
 #define LIBCZI_ISBIGENDIANHOST @libCZI_ISBIGENDIANHOST@
 

--- a/Src/libCZI/utilities.cpp
+++ b/Src/libCZI/utilities.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <cstring>
 #include <array>
-#if LIBCZI_WINDOWSAPI_AVAILABLE
+#if LIBCZI_WINDOWSAPI_AVAILABLE || LIBCZI_WINDOWS_UWPAPI_AVAILABLE
 #include <Windows.h>
 #else
 #include <random>
@@ -93,7 +93,7 @@ tString trimImpl(const tString& str, const tString& whitespace)
 
 /*static*/std::wstring Utilities::convertUtf8ToWchar_t(const char* sz)
 {
-#if LIBCZI_WINDOWSAPI_AVAILABLE
+#if LIBCZI_WINDOWSAPI_AVAILABLE || LIBCZI_WINDOWS_UWPAPI_AVAILABLE
     if (*sz == '\0')
     {
         return {};
@@ -123,7 +123,7 @@ tString trimImpl(const tString& str, const tString& whitespace)
 
 /*static*/std::string Utilities::convertWchar_tToUtf8(const wchar_t* szw)
 {
-#if LIBCZI_WINDOWSAPI_AVAILABLE
+#if LIBCZI_WINDOWSAPI_AVAILABLE || LIBCZI_WINDOWS_UWPAPI_AVAILABLE
     if (*szw == L'\0')
     {
         return {};
@@ -171,7 +171,7 @@ tString trimImpl(const tString& str, const tString& whitespace)
 
 /*static*/libCZI::GUID Utilities::GenerateNewGuid()
 {
-#if LIBCZI_WINDOWSAPI_AVAILABLE
+#if LIBCZI_WINDOWSAPI_AVAILABLE || LIBCZI_WINDOWS_UWPAPI_AVAILABLE
     ::GUID guid;
     CoCreateGuid(&guid);
     libCZI::GUID guid_value

--- a/cmake/detect_win32_api_mode.cmake
+++ b/cmake/detect_win32_api_mode.cmake
@@ -1,0 +1,59 @@
+##
+# detect_win32_api_mode(<out_var_win32> <out_var_uwp>)
+#
+# Detects whether the current platform supports the classic Win32 API
+# or is targeting Universal Windows Platform (UWP). This function is designed
+# to be safe in cross-compilation environments and does not run any test executables.
+#
+# Motivation:
+# - Simply checking `WIN32` is not sufficient, as it is also defined for UWP.
+# - Cross-compilation scenarios (e.g., arm64-windows) cannot run executables,
+#   so `try_run()` or runtime detection is not an option.
+# - UWP builds do define `WIN32`, but are sandboxed and do not support many
+#   traditional Win32 APIs (e.g., `CreateFileW`, registry, console APIs).
+#
+# How it works:
+# - First checks if the target platform is some form of Windows
+#   (including MinGW, MSYS, Cygwin, or cross-compiling for Windows).
+# - Then uses `check_cxx_source_compiles()` to compile a snippet that tests
+#   for `WINAPI_FAMILY == WINAPI_FAMILY_APP` which is true for UWP targets.
+# - Outputs two mutually exclusive cache variables:
+#     <out_var_win32>: set to ON if classic Win32 APIs are available
+#     <out_var_uwp>:   set to ON if building for UWP
+#   Both are OFF on non-Windows platforms.
+#
+# Example usage:
+#   detect_win32_api_mode(LIBCZI_HAVE_WIN32_API LIBCZI_HAVE_WIN32UWP_API)
+#
+function(detect_win32_api_mode out_win32 out_uwp)
+    include(CheckCXXSourceCompiles)
+
+    # Assume no Win32/UWP support by default
+    set(${out_win32} OFF PARENT_SCOPE)
+    set(${out_uwp} OFF PARENT_SCOPE)
+
+    # Check if this is some variant of Windows
+    if (WIN32 OR CYGWIN OR MSYS OR MINGW OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        # Distinguish UWP from classic Win32
+        check_cxx_source_compiles("
+            #include <winapifamily.h>
+            int main() {
+            #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+                return 0;
+            #else
+                #error Not UWP
+            #endif
+            }
+        " IS_UWP)
+
+        if (IS_UWP)
+            message(STATUS "Detected UWP target.")
+            set(${out_uwp} ON PARENT_SCOPE)
+        else()
+            message(STATUS "Detected classic Win32 API target.")
+            set(${out_win32} ON PARENT_SCOPE)
+        endif()
+    else()
+        message(STATUS "Non-Windows platform — Win32 API not available.")
+    endif()
+endfunction()

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -43,3 +43,4 @@ Version history
  0.66.0             | [138](https://github.com/ZEISS/libczi/pull/138)      | add TryGetSubBlockInfoForIndex in libCZIAPI
  0.66.1             | [142](https://github.com/ZEISS/libczi/pull/142)      | update on CMake build system for vcpkg support
  0.66.2             | [143](https://github.com/ZEISS/libczi/pull/143)      | additional updates on CMake build system towards vcpkg support
+ 0.66.3             | [144](https://github.com/ZEISS/libczi/pull/144)      | add (initial and experimental) support for building for UWP (Universal Windows Platform)


### PR DESCRIPTION
## Description

This adds minimal and experimental support for building for UWP. In the vcpkg-submission of libCZI, the UWP-triplets had to be excluded - with this change the vcpkg-build for UWP succeeds.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

only by building UWP-triplets by vcpkg so far

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
