### PR TITLE
Add JXRLIB_API macro to some forgotten jxrlib-functions

### DIFF
--- a/Src/JxrDecode/jxrlib/image/decode/segdec.c
+++ b/Src/JxrDecode/jxrlib/image/decode/segdec.c
@@ -778,7 +778,7 @@ static _FORCEINLINE Int DecodeSignificantAbsLevel(struct CAdaptiveHuffman* pAHex
     return iLevel;
 }
 
-U8 decodeQPIndex(BitIOInfo* pIO, U8 cBits)
+U8 JXRLIB_API(decodeQPIndex)(BitIOInfo* pIO, U8 cBits)
 {
     if (_getBit16(pIO, 1) == 0)
         return 0;
@@ -811,7 +811,7 @@ Int JXRLIB_API(DecodeMacroblockLowpass)(CWMImageStrCodec* pSC, CCodingContext* p
 
     readIS_L1(pSC, pIO);
     if ((pSC->WMISCP.bfBitstreamFormat != SPATIAL) && (pSC->pTile[pSC->cTileColumn].cBitsLP > 0))  // MB-based LP QP index
-        pMBInfo->iQIndexLP = decodeQPIndex(pIO, pSC->pTile[pSC->cTileColumn].cBitsLP);
+        pMBInfo->iQIndexLP = JXRLIB_API(decodeQPIndex)(pIO, pSC->pTile[pSC->cTileColumn].cBitsLP);
 
     // set arrays
     for (k = 0; k < (Int)pSC->m_param.cNumChannels; k++) {
@@ -1043,9 +1043,9 @@ Int JXRLIB_API(DecodeMacroblockDC)(CWMImageStrCodec* pSC, CCodingContext* pConte
 
     if (pSC->WMISCP.bfBitstreamFormat == SPATIAL && pSC->WMISCP.sbSubband != SB_DC_ONLY) {
         if (pTile->cBitsLP > 0)  // MB-based LP QP index
-            pMBInfo->iQIndexLP = decodeQPIndex(pIO, pTile->cBitsLP);
+            pMBInfo->iQIndexLP = JXRLIB_API(decodeQPIndex)(pIO, pTile->cBitsLP);
         if (pSC->WMISCP.sbSubband != SB_NO_HIGHPASS && pTile->cBitsHP > 0)  // MB-based HP QP index
-            pMBInfo->iQIndexHP = decodeQPIndex(pIO, pTile->cBitsHP);
+            pMBInfo->iQIndexHP = JXRLIB_API(decodeQPIndex)(pIO, pTile->cBitsHP);
     }
     if (pTile->cBitsHP == 0 && pTile->cNumQPHP > 1) // use LP QP
         pMBInfo->iQIndexHP = pMBInfo->iQIndexLP;
@@ -1149,7 +1149,7 @@ Int JXRLIB_API(DecodeMacroblockHighpass)(CWMImageStrCodec* pSC, CCodingContext* 
         }
     }
     if ((pSC->WMISCP.bfBitstreamFormat != SPATIAL) && (pSC->pTile[pSC->cTileColumn].cBitsHP > 0)) { // MB-based HP QP index
-        pSC->MBInfo.iQIndexHP = decodeQPIndex(pContext->m_pIOAC, pSC->pTile[pSC->cTileColumn].cBitsHP);
+        pSC->MBInfo.iQIndexHP = JXRLIB_API(decodeQPIndex)(pContext->m_pIOAC, pSC->pTile[pSC->cTileColumn].cBitsHP);
         if (pSC->MBInfo.iQIndexHP >= pSC->pTile[pSC->cTileColumn].cNumQPHP)
             goto ErrorExit;
     }

--- a/Src/JxrDecode/jxrlib/image/decode/strdec.c
+++ b/Src/JxrDecode/jxrlib/image/decode/strdec.c
@@ -1912,7 +1912,7 @@ Int JXRLIB_API(decodeThumbnailAlpha)(CWMImageStrCodec* pSC, const size_t nBits, 
     return ICERR_OK;
 }
 
-Int decodeThumbnail(CWMImageStrCodec* pSC)
+Int JXRLIB_API(decodeThumbnail)(CWMImageStrCodec* pSC)
 {
     const size_t tScale = pSC->m_Dparam->cThumbnailScale;
     const size_t cHeight = min((pSC->m_Dparam->bDecodeFullFrame ? pSC->WMII.cHeight : pSC->m_Dparam->cROIBottomY + 1) - (pSC->cRow - 1) * 16, 16);
@@ -3568,7 +3568,7 @@ Int JXRLIB_API(ImageStrDecDecode)(
             }
 
             if (pSC->m_Dparam->cThumbnailScale >= 2) // decode thumbnail
-                decodeThumbnail(pSC);
+                JXRLIB_API(decodeThumbnail)(pSC);
         }
 
         JXRLIB_API(advanceOneMBRow)(pSC);

--- a/Src/JxrDecode/jxrlib/image/encode/strenc.c
+++ b/Src/JxrDecode/jxrlib/image/encode/strenc.c
@@ -415,7 +415,7 @@ static _FORCEINLINE PixelI forwardHalf(PixelI hHalf)
 //#include <Windows.h>
 //#define _WINDOWS_ 1
 
-Int StrIOEncInit(CWMImageStrCodec* pSC)
+Int JXRLIB_API(StrIOEncInit)(CWMImageStrCodec* pSC)
 {
 //#if false   // TODO TODO TODO
     pSC->m_param.bIndexTable = !(pSC->WMISCP.bfBitstreamFormat == SPATIAL && pSC->WMISCP.cNumOfSliceMinus1H + pSC->WMISCP.cNumOfSliceMinus1V == 0);
@@ -1080,7 +1080,7 @@ Int JXRLIB_API(StrEncInit)(CWMImageStrCodec* pSC)
         JXRLIB_API(setBitIOPointers)(pSC);
     }
     else {
-        StrIOEncInit(pSC);
+        JXRLIB_API(StrIOEncInit)(pSC);
         JXRLIB_API(setBitIOPointers)(pSC);
         JXRLIB_API(WriteWMIHeader)(pSC);
     }


### PR DESCRIPTION
## Description

In previous PR #146  a few function were forgotten.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

-> https://github.com/ptahmose/libczi-vcpkg-test/actions/runs/16721353933/job/47326310641

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
