### PR TITLE
fix for missing tiles in scaling-compositor in rare cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.66.6
+      VERSION 0.66.7
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/SingleChannelScalingTileAccessor.cpp
+++ b/Src/libCZI/SingleChannelScalingTileAccessor.cpp
@@ -6,6 +6,7 @@
 #include "utilities.h"
 #include "BitmapOperations.h"
 #include "Site.h"
+#include <algorithm>
 
 using namespace libCZI;
 using namespace std;
@@ -312,13 +313,15 @@ void CSingleChannelScalingTileAccessor::InternalGet(libCZI::IBitmapData* bmDest,
 
 void CSingleChannelScalingTileAccessor::Paint(libCZI::IBitmapData* bmDest, const libCZI::IntRect& roi, const SubSetSortedByZoom& sbSetSortedByZoom, float zoom, const libCZI::ISingleChannelScalingTileAccessor::Options& options)
 {
-    const int idxOf1stSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, zoom);
+    // make the pyramid-layer limit a bit smaller (5% smaller) so that right at the edge of a pyramid layer, we do not
+    //  exclude subblocks which happen to have an inaccurate zoom-level (e.g. due to quantization)
+    const int idxOf1stSubBlockOfZoomGreater = this->GetIdxOf1stSubBlockWithZoomGreater(sbSetSortedByZoom.subBlocks, sbSetSortedByZoom.sortedByZoom, min(zoom / 1.05f, 1.f));
     if (idxOf1stSubBlockOfZoomGreater < 0)
     {
         // this means that we would need to overzoom (i.e. the requested zoom is less than the lowest level we find in the subblock-repository)
         // TODO: this requires special consideration, for the time being -> bail out
-        // ...we end up here e. g. when lowest level does not cover all the range, so - this is not
-        //    something where we want to throw an excpetion
+        // ...we end up here e.g. when lowest level does not cover all the range, so - this is not
+        //    something where we want to throw an exception
         //throw LibCZIAccessorException("Overzoom not supported", LibCZIAccessorException::ErrorType::Unspecified);
         return;
     }

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -47,3 +47,4 @@ Version history
  0.66.4             | [145](https://github.com/ZEISS/libczi/pull/145)      | have embedded pugixml in its own namespace, replace md5sum implementation, update 3rd-party license texts
  0.66.5             | [146](https://github.com/ZEISS/libczi/pull/146)      | have jxrlib-symbols mangled to prevent conflicts with other libraries
  0.66.6             | [149](https://github.com/ZEISS/libczi/pull/149)      | prepare for vcpkg features
+ 0.66.7             | [150](https://github.com/ZEISS/libczi/pull/150)      | fix for missing tiles with scaling compositor in rare circumstances


### PR DESCRIPTION
## Description

This is addressing an issue where with the scaling-compositor, in rare cases tiles could be found missing in the resulting composition.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally (with a repro-case)

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
