### PR TITLE
replace bswap_32 with bswap32 and bswap_16 with bswap16 for consistency

### DIFF
--- a/Src/JxrDecode/jxrlib/image/decode/segdec.c
+++ b/Src/JxrDecode/jxrlib/image/decode/segdec.c
@@ -87,7 +87,7 @@ static U32 _FORCEINLINE _load4(void* pv)
     #elif JXRDECODE_HAS_BYTESWAP_IN_STDLIB
         return _byteswap_ulong(v);
     #elif JXRDECODE_HAS_BSWAP_LONG_IN_SYS_ENDIAN
-        return bswap_32(v);
+        return bswap32(v);
     #else
         return (((v & 0xff000000u) >> 24) |
                 ((v & 0x00ff0000u) >> 8) |

--- a/Src/JxrDecode/jxrlib/image/sys/strcodec.c
+++ b/Src/JxrDecode/jxrlib/image/sys/strcodec.c
@@ -814,7 +814,7 @@ static U32 jxr_byteswap_ulong(U32 bits)
 #elif JXRDECODE_HAS_BYTESWAP_IN_STDLIB
     return _byteswap_ulong(bits);
 #elif JXRDECODE_HAS_BSWAP_LONG_IN_SYS_ENDIAN
-    return bswap_32(bits);
+    return bswap32(bits);
 #else
     return (((bits & 0xff000000u) >> 24) |
         ((bits & 0x00ff0000u) >> 8) |
@@ -850,7 +850,7 @@ static U32 load4BE(void* pv)
 #elif JXRDECODE_HAS_BYTESWAP_IN_STDLIB
     return _byteswap_ulong(v);
 #elif JXRDECODE_HAS_BSWAP_LONG_IN_SYS_ENDIAN
-    return bswap_32(v);
+    return bswap32(v);
 #else
     return (((v & 0xff000000u) >> 24) |
         ((v & 0x00ff0000u) >> 8) |

--- a/Src/libCZI/BitmapOperationsBitonal.cpp
+++ b/Src/libCZI/BitmapOperationsBitonal.cpp
@@ -14,6 +14,16 @@
 #include <libCZI_Utilities.h>
 #include "utilities.h"
 
+#if LIBCZI_HAS_BUILTIN_BSWAP32
+ #include <byteswap.h>
+#endif
+#if LIBCZI_HAS_BYTESWAP_IN_STDLIB
+ #include <stdlib.h>
+#endif
+#if LIBCZI_HAS_BSWAP_LONG_IN_SYS_ENDIAN
+ #include <sys/endian.h>
+#endif
+
 using namespace std;
 using namespace libCZI;
 
@@ -30,7 +40,7 @@ namespace
 #elif LIBCZI_HAS_BYTESWAP_IN_STDLIB
             return _byteswap_ulong(dw);
 #elif LIBCZI_HAS_BSWAP_LONG_IN_SYS_ENDIAN
-            return bswap_32(dw);
+            return bswap32(dw);
 #else
             return (((dw & 0xff000000u) >> 24) |
                     ((dw & 0x00ff0000u) >> 8) |
@@ -45,7 +55,7 @@ namespace
 #elif LIBCZI_HAS_BYTESWAP_IN_STDLIB
             return _byteswap_ushort(us);
 #elif LIBCZI_HAS_BSWAP_LONG_IN_SYS_ENDIAN
-            return bswap_16(us);
+            return bswap16(us);
 #else
             return (((us & 0xff00u) >> 8) |
                     ((us & 0x00ffu) << 8));


### PR DESCRIPTION
# STOP - Read this First!
Reporting a security vulnerability?  
Check out the project's [security policy](https://github.com/zeiss/libczi/security/policy).

# Fill out and Adjust this Template

## Description

On macOS (with latest XCode) the build failed with error message
```
../Src/JxrDecode/jxrlib/image/decode/segdec.c:90:16: error: call to undeclared function 'bswap_32'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   90 |         return bswap_32(v);
```

It seems we checked for `bswap32` [here ](https://github.com/ZEISS/libczi/blob/a9961845f465412abf1e468851afc5e8c764202b/Src/CMakeLists.txt#L29) and later one used `bswap_32`, which seems wrong.

With this fix, the code builds on my Mac.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
