### PR TITLE
fix: add default componentbitcount when writing czi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.67.3
+      VERSION 0.67.4
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/CziMetadataBuilder.cpp
+++ b/Src/libCZI/CziMetadataBuilder.cpp
@@ -540,6 +540,14 @@ CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName, const std:
                 pixelTypeNode->SetValue(pixelTypeString.c_str());
             }
 
+            // Add ComponentBitCount information inferred from the pixel type
+            int componentBitCount;
+            if (CMetadataPrepareHelper::TryGetComponentBitCountFromPixelType(pxlType, componentBitCount))
+            {
+                auto componentBitCountNode = channelNode->AppendChildNode("ComponentBitCount");
+                componentBitCountNode->SetValueI32(componentBitCount);
+            }
+
             if (pxlType != PixelType::Invalid && pxlTypeForImagePixelType == PixelType::Invalid)
             {
                 pxlTypeForImagePixelType = pxlType;
@@ -598,6 +606,50 @@ CCZiMetadataBuilder::CCZiMetadataBuilder(const wchar_t* rootNodeName, const std:
     }
 
     return true;
+}
+
+/*static*/bool CMetadataPrepareHelper::TryGetComponentBitCountFromPixelType(libCZI::PixelType pxlType, int& componentBitCount)
+{
+    // ComponentBitCount represents the actual number of significant bits per component.
+    // For most pixel types, this is the full bit depth. However, Gray16 often uses 14 or 16 bits, but for now leave as default.
+    switch (pxlType)
+    {
+    case PixelType::Gray8:
+        componentBitCount = 8;
+        return true;
+    case PixelType::Gray16:
+        componentBitCount = 16;
+        return true;
+    case PixelType::Gray32Float:
+        componentBitCount = 32;
+        return true;
+    case PixelType::Bgr24:
+        componentBitCount = 8;
+        return true;
+    case PixelType::Bgr48:
+        componentBitCount = 16;
+        return true;
+    case PixelType::Bgr96Float:
+        componentBitCount = 32;
+        return true;
+    case PixelType::Bgra32:
+        componentBitCount = 8;
+        return true;
+    case PixelType::Gray32:
+        componentBitCount = 32;
+        return true;
+    case PixelType::Gray64Float:
+        componentBitCount = 64;
+        return true;
+    case PixelType::Gray64ComplexFloat:
+        componentBitCount = 32; // Complex float uses 32 bits per real/imaginary component
+        return true;
+    case PixelType::Bgr192ComplexFloat:
+        componentBitCount = 32; // Complex float uses 32 bits per component
+        return true;
+    default:
+        return false;
+    }
 }
 
 //**************************************************************************************************

--- a/Src/libCZI/CziMetadataBuilder.h
+++ b/Src/libCZI/CziMetadataBuilder.h
@@ -117,6 +117,7 @@ namespace libCZI
 
         private:
             static void FillImagePixelType(libCZI::ICziMetadataBuilder* builder, libCZI::PixelType pxlType);
+            static bool TryGetComponentBitCountFromPixelType(libCZI::PixelType pxlType, int& componentBitCount);
         };
 
     } // namespace detail

--- a/Src/libCZI_UnitTests/test_writer.cpp
+++ b/Src/libCZI_UnitTests/test_writer.cpp
@@ -2411,7 +2411,7 @@ TEST(CziWriter, CheckPreparedMetadataContainsComponentBitCountForBgr24)
     writer->Create(outStream, spWriterInfo);
 
     // Add a simple Bgr24 subblock
-    auto bitmap = CreateBgr24BitmapAndFill(4, 4, 100, 150, 200);
+    auto bitmap = CreateTestBitmap(PixelType::Bgr24, 4, 4);
     AddSubBlockInfoStridedBitmap addInfo;
     addInfo.Clear();
     addInfo.coordinate.Set(DimensionIndex::C, 0);

--- a/Src/libCZI_UnitTests/test_writer.cpp
+++ b/Src/libCZI_UnitTests/test_writer.cpp
@@ -696,6 +696,7 @@ TEST(CziWriter, WriteAndReadBitmapBgr24)
         "     <Channels>\n"
         "      <Channel Id=\"Channel:0\">\n"
         "       <PixelType>Bgr24</PixelType>\n"
+        "       <ComponentBitCount>8</ComponentBitCount>\n"
         "      </Channel>\n"
         "     </Channels>\n"
         "    </Dimensions>\n"


### PR DESCRIPTION
## Description

add default componentbitcount when writing czi

Fixes #156

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added unit tests

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
