### PR TITLE
Remove Eigen3 minimum version requirement in CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -138,7 +138,7 @@ jobs:
           # now use the CZIcmd executable to create a test CZI file
           "$czicmd" --command CreateCZI --createbounds "C0:2T0:2" --generatorpixeltype Gray8 --compressionopts "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack" --createsubblocksize "1024x1024" -o test --bitmapgenerator default
           # start Azurite in the background (we start only the blob-service, as we only need this for the tests)
-          azurite-blob --inMemoryPersistence --silent &
+          azurite-blob --inMemoryPersistence --silent --skipApiVersionCheck &
           # create a blob container "testcontainer"
           az storage container create --name testcontainer  --connection-string "$AZURE_BLOB_STORE_CONNECTION_STRING"
           # upload the test CZI file to the container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.67.3
+      VERSION 0.67.4
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -6,7 +6,7 @@ include(utilities)
 include(CheckCSourceCompiles)
 
 if (LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3)
- find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+ find_package (Eigen3 REQUIRED NO_MODULE)
 else()
  include(ExternalEIGEN3)
 endif()

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -52,3 +52,4 @@ Version history
  0.67.1             | [157](https://github.com/ZEISS/libczi/pull/157)      | fix compilation issue on macOS
  0.67.2             | [155](https://github.com/ZEISS/libczi/pull/155)      | code cleanup
  0.67.3             | [158](https://github.com/ZEISS/libczi/pull/158)      | have all internal code in its own namespace `libCZI::detail`, update vendored pugixml to version 1.15, fix issue with big-endian-machines
+ 0.67.4             | [158](https://github.com/ZEISS/libczi/pull/159)      | remove version requirement for external eigen3 package


### PR DESCRIPTION
## Description

Previously, CMakeLists.txt required Eigen3 version 3.3 or higher. Now, it will accept any available version of Eigen3 found. However - with version 5, there was a version mismatch required. This now removes the version requirement, proper operation with latest version 5 was checked for.
This is a build-system-only change.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
