### PR TITLE
Add JPEG XL Lossless format to czi file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,7 +299,7 @@ __pycache__/
 # exclude "cmake-build-directory"
 /cmake-build-*/
 
-/build
+/build*
 /Src/Build/VS
 /out/Src/Build/Doxygen/
 /out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,9 @@ option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3 "Prefer an Eigen3-package pres
 #  See here: https://discourse.cmake.org/t/findzstd/3506
 option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_ZSTD "Prefer a ZSTD-package present on the system" OFF)
 
+# When this option is ON, libCZI is built with libjxl (JPEG XL) for provisional subblock compression id 7 (lossless).
+option(LIBCZI_BUILD_WITH_LIBJXL "Build with libjxl for JPEG XL lossless subblocks (experimental)" OFF)
+
 # When this option is ON, we try to use an existing RapidJSON-library. Otherwise, we download a private
 #  copy of RapidJSON during the CMake-run. This option is only relevant if building CZICmd.
 option(LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_RAPIDJSON "Prefer an RapidJSON-package present on the system" ON)

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -50,6 +50,8 @@ set (CZICMDSRCFILES
          BitmapGenFreeType.h    
          cmdlineoptions.h    
          executeCreateCzi.cpp     
+         executeReEncodeCzi.cpp
+         executeReEncodeCzi.h
          IBitmapGen.h         
          SaveBitmap.h    
          utils.h
@@ -67,6 +69,8 @@ set (CZICMDSRCFILES
          CZIcmd.cpp          
          executePlaneScan.h
          executePlaneScan.cpp
+         executeCompareImages.h
+         executeCompareImages.cpp
          executeBase.h
          executeBase.cpp
          CZIcmd.manifest    # the manifest is needed to allow long paths on windows, see https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -539,7 +539,9 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         { "ScalingChannelComposite",            Command::ScalingChannelComposite },
         { "ExtractAttachment",                  Command::ExtractAttachment},
         { "CreateCZI",                          Command::CreateCZI },
+        { "ReEncodeCZI",                        Command::ReEncodeCZI },
         { "PlaneScan",                          Command::PlaneScan },
+        { "CompareImages",                      Command::CompareImages },
     };
 
     const static PlaneCoordinateValidator plane_coordinate_validator;
@@ -567,6 +569,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
     Command argument_command;
     string argument_source_filename;
     string argument_output_filename;
+    string argument_compare_filename;
     string argument_plane_coordinate;
     string argument_rect;
     string argument_display_settings;
@@ -602,7 +605,7 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
     // editorconfig-checker-disable
     cli_app.add_option("-c,--command", argument_command,
         R"(COMMAND can be one of 'PrintInformation', 'ExtractSubBlock', 'SingleChannelTileAccessor', 'ChannelComposite',
-           'SingleChannelPyramidTileAccessor', 'SingleChannelScalingTileAccessor', 'ScalingChannelComposite', 'ExtractAttachment' and 'CreateCZI'.
+           'SingleChannelPyramidTileAccessor', 'SingleChannelScalingTileAccessor', 'ScalingChannelComposite', 'ExtractAttachment', 'CreateCZI', 'ReEncodeCZI' and 'CompareImages'.
            \N'PrintInformation' will print information about the CZI-file to the console. The argument 'info-level' can be used
            to specify which information is to be printed.
            \N'ExtractSubBlock' will write the bitmap contained in the specified sub-block to the OUTPUTFILE.
@@ -618,7 +621,9 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
            \N'ScalingChannelComposite' operates like the previous command, but in addition gets all channels and creates a multi-channel-composite from them
            using display-settings.
            \N'ExtractAttachment' allows to extract (and save to a file) the contents of attachments.)
-           \N'CreateCZI' is used to demonstrate the CZI-creation capabilities of libCZI.)
+           \N'CreateCZI' is used to demonstrate the CZI-creation capabilities of libCZI (synthetic tiles; use --createbounds; -s is not used for pixels).
+           \N'ReEncodeCZI' reads the CZI given with -s and writes a new CZI to -o with the same metadata, attachments, subblock layout, and per-subblock metadata/attachments; only the pixel payload is re-encoded per --compressionopts (e.g. jxl:, zstd1:, uncompressed:).)
+           \N'CompareImages' reads two CZIs (-s and --compare), pairs subblocks by tile layout (dimension coordinate, logical rect, physical size, pixel type, M-index), decodes each pair, and reports RMSD over all scalar samples. Directory index order may differ between files.)
            \N'PlaneScan' does the following: over a ROI given with the --rect option a rectangle of size given with 
            the --tilesize-for-plane-scan option is moved, and the image content of this rectangle is written out to
            files. The operation takes place on a plane which is given with the --plane-coordinate option. The filenames of the
@@ -641,6 +646,9 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
     cli_app.add_option("-o,--output", argument_output_filename,
         "Specifies the output-filename. A suffix will be appended to the name given here depending on the type of the file.")
         ->option_text("OUTPUTFILE");
+    cli_app.add_option("--compare", argument_compare_filename,
+        "Second CZI file for 'CompareImages' (decoded pixels are compared to -s in subblock order). Uses the same stream class and property bag as -s when set.")
+        ->option_text("COMPAREFILE");
     // editorconfig-checker-disable
     cli_app.add_option("-p,--plane-coordinate", argument_plane_coordinate,
         R"(Uniquely select a 2D-plane from the document. It is given in the form [DimChar][number], where 'DimChar' specifies a dimension and 
@@ -715,7 +723,8 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         ->option_text("CHANNELCOMPOSITIONFORMAT")
         ->check(channelcompositionformat_validator);
     cli_app.add_option("--createbounds", arguments_createbounds,
-        "Only used for 'CreateCZI': specify the range of coordinates used to create a CZI. Format is e.g. 'T0:3Z0:3C0:2'.")
+        "Required for 'CreateCZI': dimension ranges for which synthetic tiles are written. Format is e.g. 'T0:3Z0:3C0:2' "
+        "(dimension letter, start index, colon, count). CreateCZI does not copy image data from -s.")
         ->option_text("BOUNDS")
         ->check(createbounds_validator);
     cli_app.add_option("--createsubblocksize", arguments_createsubblocksize,
@@ -752,9 +761,10 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         ->option_text("KEY_VALUE_SUBBLOCKMETADATA")
         ->check(createsubblockmetadata_validator);
     cli_app.add_option("--compressionopts", argument_compressionoptions,
-        "Only used for 'CreateCZI': a string in a defined format which states the compression-method and (compression-method specific) "
+        "Used for 'CreateCZI' and 'ReEncodeCZI': a string in a defined format which states the compression-method and (compression-method specific) "
         "parameters. The format is \"compression_method: key=value; ...\". It starts with the name of the compression-method, followed by a colon, "
-        "then followed by a list of key-value pairs which are separated by a semicolon. Examples: \"zstd0:ExplicitLevel=3\", \"zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack\".")
+        "then followed by a list of key-value pairs which are separated by a semicolon. Examples: \"zstd0:ExplicitLevel=3\", \"zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack\", "
+        "\"jxl:\" or \"jxl:Effort=7;Modular=true;DecodingSpeed=0;Responsive=0\" for JPEG XL (requires LIBCZI_BUILD_WITH_LIBJXL), \"uncompressed:\" for raw pixels on ReEncodeCZI.")
         ->option_text("COMPRESSIONDESCRIPTION")
         ->check(compressionoptions_validator);
     cli_app.add_option("--generatorpixeltype", argument_generatorpixeltype,
@@ -834,6 +844,11 @@ CCmdLineOptions::ParseResult CCmdLineOptions::Parse(int argc, char** argv)
         if (!argument_output_filename.empty())
         {
             this->SetOutputFilename(convertUtf8ToWide(argument_output_filename));
+        }
+
+        if (!argument_compare_filename.empty())
+        {
+            this->compareCziFilename = convertUtf8ToWide(argument_compare_filename);
         }
 
         if (!argument_plane_coordinate.empty())
@@ -1023,7 +1038,7 @@ bool CCmdLineOptions::CheckArgumentConsistency() const
         return false;
     }
 
-    if (cmd != Command::PrintInformation)
+    if (cmd != Command::PrintInformation && cmd != Command::CompareImages)
     {
         auto str = this->MakeOutputFilename(nullptr, nullptr);
         if (str.empty())
@@ -1032,6 +1047,13 @@ bool CCmdLineOptions::CheckArgumentConsistency() const
             this->GetLog()->WriteLineStdErr(ss.str());
             return false;
         }
+    }
+
+    if (cmd == Command::CompareImages && this->compareCziFilename.empty())
+    {
+        ss << ERRORPREFIX << "CompareImages requires --compare <second CZI file>";
+        this->GetLog()->WriteLineStdErr(ss.str());
+        return false;
     }
 
     switch (cmd)
@@ -1084,6 +1106,22 @@ bool CCmdLineOptions::CheckArgumentConsistency() const
         break;
     }
 
+    if (cmd == Command::CreateCZI && this->createBounds.IsEmpty())
+    {
+        ss << ERRORPREFIX << "CreateCZI requires --createbounds (for example: --createbounds \"C0:1\" or \"C0:1T0:3\"). "
+              "If bounds are empty, no subblocks are written. The source file (-s) is not read for CreateCZI; "
+              "tiles are generated only by the bitmap generator for the coordinate ranges you specify.";
+        this->GetLog()->WriteLineStdErr(ss.str());
+        return false;
+    }
+
+    if (cmd == Command::ReEncodeCZI && this->compressionMode == libCZI::CompressionMode::Invalid)
+    {
+        ss << ERRORPREFIX << "ReEncodeCZI requires --compressionopts (for example: \"jxl:\", \"jxl:Effort=5\", \"zstd1:ExplicitLevel=3\", or \"uncompressed:\").";
+        this->GetLog()->WriteLineStdErr(ss.str());
+        return false;
+    }
+
     // TODO: there is probably more to be checked
 
     return true;
@@ -1092,6 +1130,7 @@ bool CCmdLineOptions::CheckArgumentConsistency() const
 void CCmdLineOptions::Clear()
 {
     this->command = Command::Invalid;
+    this->compareCziFilename.clear();
     this->useDisplaySettingsFromDocument = true;
     this->calcHashOfResult = false;
     this->drawTileBoundaries = false;

--- a/Src/CZICmd/cmdlineoptions.h
+++ b/Src/CZICmd/cmdlineoptions.h
@@ -32,9 +32,13 @@ enum class Command
 
     CreateCZI,
 
+    ReEncodeCZI,
+
     ReadWriteCZI,
 
     PlaneScan,
+
+    CompareImages,
 };
 
 enum class InfoLevel : std::uint32_t
@@ -143,6 +147,7 @@ private:
 
     Command command;
     std::wstring cziFilename;
+    std::wstring compareCziFilename;
     std::string source_stream_class;
     std::map<int, libCZI::StreamsFactory::Property> property_bag_for_stream_class;
     libCZI::CDimCoordinate planeCoordinate;
@@ -224,6 +229,7 @@ public:
     std::shared_ptr<ILog> GetLog() const { return this->log; }
     Command GetCommand() const { return this->command; }
     const std::wstring& GetCZIFilename() const { return this->cziFilename; }
+    const std::wstring& GetCompareCziFilename() const { return this->compareCziFilename; }
     const std::string& GetInputStreamClassName() const { return this->source_stream_class; }
     const std::map<int, libCZI::StreamsFactory::Property>& GetInputStreamPropertyBag() const { return this->property_bag_for_stream_class; }
     const libCZI::CDimCoordinate& GetPlaneCoordinate() const { return this->planeCoordinate; }

--- a/Src/CZICmd/execute.cpp
+++ b/Src/CZICmd/execute.cpp
@@ -6,7 +6,9 @@
 #include "execute.h"
 #include "executeBase.h"
 #include "executeCreateCzi.h"
+#include "executeReEncodeCzi.h"
 #include "executePlaneScan.h"
+#include "executeCompareImages.h"
 #include "inc_libCZI.h"
 #include "SaveBitmap.h"
 #include "utils.h"
@@ -1141,8 +1143,14 @@ bool execute(const CCmdLineOptions& options)
         case Command::CreateCZI:
             success = executeCreateCzi(options);
             break;
+        case Command::ReEncodeCZI:
+            success = executeReEncodeCzi(options);
+            break;
         case Command::PlaneScan:
             success = executePlaneScan(options);
+            break;
+        case Command::CompareImages:
+            success = executeCompareImages(options);
             break;
         default:
             break;

--- a/Src/CZICmd/executeBase.cpp
+++ b/Src/CZICmd/executeBase.cpp
@@ -11,15 +11,20 @@ using namespace libCZI;
 
 std::shared_ptr<ICZIReader> CExecuteBase::CreateAndOpenCziReader(const CCmdLineOptions& options)
 {
+    return CreateAndOpenCziReaderForPath(options.GetCZIFilename().c_str(), options);
+}
+
+std::shared_ptr<ICZIReader> CExecuteBase::CreateAndOpenCziReaderForPath(const wchar_t* path, const CCmdLineOptions& options)
+{
     shared_ptr<IStream> stream;
     if (options.GetInputStreamClassName().empty())
     {
-        stream = CExecuteBase::CreateStandardFileBasedStreamObject(options.GetCZIFilename().c_str());
+        stream = CExecuteBase::CreateStandardFileBasedStreamObject(path);
     }
     else
     {
         stream = CExecuteBase::CreateInputStreamObject(
-                                options.GetCZIFilename().c_str(),
+                                path,
                                 options.GetInputStreamClassName(),
                                 &options.GetInputStreamPropertyBag());
     }

--- a/Src/CZICmd/executeBase.h
+++ b/Src/CZICmd/executeBase.h
@@ -16,6 +16,7 @@ class CExecuteBase
 {
 protected:
     static std::shared_ptr<libCZI::ICZIReader> CreateAndOpenCziReader(const CCmdLineOptions& options);
+    static std::shared_ptr<libCZI::ICZIReader> CreateAndOpenCziReaderForPath(const wchar_t* path, const CCmdLineOptions& options);
     static std::shared_ptr<libCZI::IStream> CreateStandardFileBasedStreamObject(const wchar_t* fileName);
     static std::shared_ptr<libCZI::IStream> CreateInputStreamObject(const wchar_t* uri, const std::string& class_name, const std::map<int, libCZI::StreamsFactory::Property>* property_bag);
     static libCZI::IntRect GetRoiFromOptions(const CCmdLineOptions& options, const libCZI::SubBlockStatistics& subBlockStatistics);

--- a/Src/CZICmd/executeCompareImages.cpp
+++ b/Src/CZICmd/executeCompareImages.cpp
@@ -1,0 +1,602 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "executeCompareImages.h"
+#include "cmdlineoptions.h"
+#include "executeBase.h"
+#include "inc_libCZI.h"
+#include "utils.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+using namespace libCZI;
+using namespace std;
+
+namespace
+{
+/// Identifies a subblock for pairing across two CZIs. Omits pyramidType (legacy; writers may differ)
+/// and raw compression id (decoded pixels are compared).
+struct SubBlockLayoutKey
+{
+    int logicalX;
+    int logicalY;
+    int logicalW;
+    int logicalH;
+    int physicalW;
+    int physicalH;
+    PixelType pixelType;
+    bool mIndexValid;
+    int mIndex;
+    std::string coordinateText;
+
+    bool operator<(const SubBlockLayoutKey& o) const
+    {
+        if (logicalX != o.logicalX)
+        {
+            return logicalX < o.logicalX;
+        }
+
+        if (logicalY != o.logicalY)
+        {
+            return logicalY < o.logicalY;
+        }
+
+        if (logicalW != o.logicalW)
+        {
+            return logicalW < o.logicalW;
+        }
+
+        if (logicalH != o.logicalH)
+        {
+            return logicalH < o.logicalH;
+        }
+
+        if (physicalW != o.physicalW)
+        {
+            return physicalW < o.physicalW;
+        }
+
+        if (physicalH != o.physicalH)
+        {
+            return physicalH < o.physicalH;
+        }
+
+        if (pixelType != o.pixelType)
+        {
+            return static_cast<int>(pixelType) < static_cast<int>(o.pixelType);
+        }
+
+        if (mIndexValid != o.mIndexValid)
+        {
+            return mIndexValid < o.mIndexValid;
+        }
+
+        if (mIndex != o.mIndex)
+        {
+            return mIndex < o.mIndex;
+        }
+
+        return coordinateText < o.coordinateText;
+    }
+};
+
+SubBlockLayoutKey MakeLayoutKey(const SubBlockInfo& s)
+{
+    SubBlockLayoutKey k{};
+    k.logicalX = s.logicalRect.x;
+    k.logicalY = s.logicalRect.y;
+    k.logicalW = s.logicalRect.w;
+    k.logicalH = s.logicalRect.h;
+    k.physicalW = s.physicalSize.w;
+    k.physicalH = s.physicalSize.h;
+    k.pixelType = s.pixelType;
+    k.mIndexValid = s.IsMindexValid();
+    k.mIndex = s.mIndex;
+    k.coordinateText = Utils::DimCoordinateToString(&s.coordinate);
+    return k;
+}
+
+std::string DescribeSubBlockShort(const SubBlockInfo& s)
+{
+    stringstream ss;
+    ss << "coord=" << Utils::DimCoordinateToString(&s.coordinate)
+       << " rect=" << s.logicalRect.x << "," << s.logicalRect.y << "+" << s.logicalRect.w << "x" << s.logicalRect.h
+       << " phys=" << s.physicalSize.w << "x" << s.physicalSize.h
+       << " pixel=" << static_cast<int>(s.pixelType);
+    if (s.IsMindexValid())
+    {
+        ss << " M=" << s.mIndex;
+    }
+    else
+    {
+        ss << " M=invalid";
+    }
+
+    return ss.str();
+}
+
+/// For each directory index i in A, sets partnerIndexOut[i] to the index in B with the same layout key.
+void BuildSubBlockPartners(
+    const ICZIReader& readerA,
+    const ICZIReader& readerB,
+    int subBlockCount,
+    std::vector<int>* partnerIndexOut)
+{
+    partnerIndexOut->assign(static_cast<size_t>(subBlockCount), -1);
+    std::map<SubBlockLayoutKey, std::deque<int>> poolB;
+    for (int j = 0; j < subBlockCount; ++j)
+    {
+        SubBlockInfo infoB;
+        if (!readerB.TryGetSubBlockInfo(j, &infoB))
+        {
+            stringstream ss;
+            ss << "CompareImages: TryGetSubBlockInfo(B, " << j << ") failed.";
+            throw runtime_error(ss.str());
+        }
+
+        poolB[MakeLayoutKey(infoB)].push_back(j);
+    }
+
+    for (int i = 0; i < subBlockCount; ++i)
+    {
+        SubBlockInfo infoA;
+        if (!readerA.TryGetSubBlockInfo(i, &infoA))
+        {
+            stringstream ss;
+            ss << "CompareImages: TryGetSubBlockInfo(A, " << i << ") failed.";
+            throw runtime_error(ss.str());
+        }
+
+        const SubBlockLayoutKey keyA = MakeLayoutKey(infoA);
+        auto it = poolB.find(keyA);
+        if (it == poolB.end() || it->second.empty())
+        {
+            stringstream ss;
+            ss << "CompareImages: no matching subblock in file B for A index " << i << " (" << DescribeSubBlockShort(infoA) << ").";
+            throw runtime_error(ss.str());
+        }
+
+        (*partnerIndexOut)[static_cast<size_t>(i)] = it->second.front();
+        it->second.pop_front();
+    }
+
+    for (const auto& e : poolB)
+    {
+        if (!e.second.empty())
+        {
+            SubBlockInfo leftover;
+            readerB.TryGetSubBlockInfo(e.second.front(), &leftover);
+            stringstream ss;
+            ss << "CompareImages: " << static_cast<int>(e.second.size())
+               << " subblock(s) in file B have no counterpart in file A (e.g. B index " << e.second.front()
+               << ": " << DescribeSubBlockShort(leftover) << ").";
+            throw runtime_error(ss.str());
+        }
+    }
+}
+
+float ReadF32(const uint8_t* p)
+{
+    float f;
+    memcpy(&f, p, sizeof(f));
+    return f;
+}
+
+double ReadF64(const uint8_t* p)
+{
+    double d;
+    memcpy(&d, p, sizeof(d));
+    return d;
+}
+
+uint16_t ReadU16LE(const uint8_t* p)
+{
+    return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+
+void AccumulatePixelDifference(
+    PixelType pt,
+    const uint8_t* baseA,
+    size_t strideA,
+    const uint8_t* baseB,
+    size_t strideB,
+    uint32_t w,
+    uint32_t h,
+    long double* sumSq,
+    uint64_t* sampleCount,
+    long double* maxAbs)
+{
+    switch (pt)
+    {
+    case PixelType::Gray8:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                const long double d = static_cast<long double>(ra[x]) - static_cast<long double>(rb[x]);
+                *sumSq += d * d;
+                ++*sampleCount;
+                if (fabsl(d) > *maxAbs)
+                {
+                    *maxAbs = fabsl(d);
+                }
+            }
+        }
+        break;
+    case PixelType::Gray16:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                const long double va = ReadU16LE(ra + 2 * x);
+                const long double vb = ReadU16LE(rb + 2 * x);
+                const long double d = va - vb;
+                *sumSq += d * d;
+                ++*sampleCount;
+                if (fabsl(d) > *maxAbs)
+                {
+                    *maxAbs = fabsl(d);
+                }
+            }
+        }
+        break;
+    case PixelType::Gray32Float:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                const long double va = ReadF32(ra + 4 * x);
+                const long double vb = ReadF32(rb + 4 * x);
+                const long double d = va - vb;
+                *sumSq += d * d;
+                ++*sampleCount;
+                if (fabsl(d) > *maxAbs)
+                {
+                    *maxAbs = fabsl(d);
+                }
+            }
+        }
+        break;
+    case PixelType::Bgr24:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int c = 0; c < 3; ++c)
+                {
+                    const long double d = static_cast<long double>(ra[3 * x + c]) - static_cast<long double>(rb[3 * x + c]);
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    case PixelType::Bgr48:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int c = 0; c < 3; ++c)
+                {
+                    const long double va = ReadU16LE(ra + 6 * x + 2 * c);
+                    const long double vb = ReadU16LE(rb + 6 * x + 2 * c);
+                    const long double d = va - vb;
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    case PixelType::Bgra32:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int c = 0; c < 4; ++c)
+                {
+                    const long double d = static_cast<long double>(ra[4 * x + c]) - static_cast<long double>(rb[4 * x + c]);
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    case PixelType::Bgr96Float:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int c = 0; c < 3; ++c)
+                {
+                    const long double va = ReadF32(ra + 12 * x + 4 * c);
+                    const long double vb = ReadF32(rb + 12 * x + 4 * c);
+                    const long double d = va - vb;
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    case PixelType::Gray32:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                int32_t ia, ib;
+                memcpy(&ia, ra + 4 * x, sizeof(ia));
+                memcpy(&ib, rb + 4 * x, sizeof(ib));
+                const long double d = static_cast<long double>(ia) - static_cast<long double>(ib);
+                *sumSq += d * d;
+                ++*sampleCount;
+                if (fabsl(d) > *maxAbs)
+                {
+                    *maxAbs = fabsl(d);
+                }
+            }
+        }
+        break;
+    case PixelType::Gray64Float:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                const long double va = ReadF64(ra + 8 * x);
+                const long double vb = ReadF64(rb + 8 * x);
+                const long double d = va - vb;
+                *sumSq += d * d;
+                ++*sampleCount;
+                if (fabsl(d) > *maxAbs)
+                {
+                    *maxAbs = fabsl(d);
+                }
+            }
+        }
+        break;
+    case PixelType::Gray64ComplexFloat:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int k = 0; k < 4; ++k)
+                {
+                    const long double va = ReadF32(ra + 16 * x + 4 * k);
+                    const long double vb = ReadF32(rb + 16 * x + 4 * k);
+                    const long double d = va - vb;
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    case PixelType::Bgr192ComplexFloat:
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            const uint8_t* ra = baseA + y * strideA;
+            const uint8_t* rb = baseB + y * strideB;
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                for (int k = 0; k < 6; ++k)
+                {
+                    const long double va = ReadF32(ra + 24 * x + 4 * k);
+                    const long double vb = ReadF32(rb + 24 * x + 4 * k);
+                    const long double d = va - vb;
+                    *sumSq += d * d;
+                    ++*sampleCount;
+                    if (fabsl(d) > *maxAbs)
+                    {
+                        *maxAbs = fabsl(d);
+                    }
+                }
+            }
+        }
+        break;
+    default:
+        {
+            stringstream ss;
+            ss << "CompareImages: unsupported pixel type " << static_cast<int>(pt) << ".";
+            throw runtime_error(ss.str());
+        }
+    }
+}
+} // namespace
+
+class CExecuteCompareImages : CExecuteBase
+{
+public:
+    static bool execute(const CCmdLineOptions& options);
+};
+
+bool CExecuteCompareImages::execute(const CCmdLineOptions& options)
+{
+    auto readerA = CreateAndOpenCziReader(options);
+    auto readerB = CreateAndOpenCziReaderForPath(options.GetCompareCziFilename().c_str(), options);
+
+    const SubBlockStatistics statsA = readerA->GetStatistics();
+    const SubBlockStatistics statsB = readerB->GetStatistics();
+    if (statsA.subBlockCount != statsB.subBlockCount)
+    {
+        stringstream ss;
+        ss << "CompareImages: subblock count differs (A=" << statsA.subBlockCount << ", B=" << statsB.subBlockCount << ").";
+        throw runtime_error(ss.str());
+    }
+
+    if (statsA.subBlockCount <= 0)
+    {
+        throw runtime_error("CompareImages: no subblocks in source A.");
+    }
+
+    vector<int> partnerBIndexByAIndex;
+    BuildSubBlockPartners(*readerA, *readerB, statsA.subBlockCount, &partnerBIndexByAIndex);
+
+    const shared_ptr<ILog> log = options.GetLog();
+    bool reordered = false;
+    for (int i = 0; i < statsA.subBlockCount; ++i)
+    {
+        if (partnerBIndexByAIndex[static_cast<size_t>(i)] != i)
+        {
+            reordered = true;
+            break;
+        }
+    }
+
+    if (reordered)
+    {
+        log->WriteLineStdOut("CompareImages: subblocks paired by tile layout (directory order differs between the two files).");
+    }
+
+    long double sumSqTotal = 0;
+    uint64_t sampleTotal = 0;
+    long double maxAbsGlobal = 0;
+    int worstIndex = 0;
+    long double worstBlockRms = -1;
+
+    for (int i = 0; i < statsA.subBlockCount; ++i)
+    {
+        const int j = partnerBIndexByAIndex[static_cast<size_t>(i)];
+        const auto sbA = readerA->ReadSubBlock(i);
+        const auto sbB = readerB->ReadSubBlock(j);
+        if (sbA == nullptr || sbB == nullptr)
+        {
+            stringstream ss;
+            ss << "CompareImages: ReadSubBlock failed (A index " << i << ", B index " << j << ").";
+            throw runtime_error(ss.str());
+        }
+
+        const shared_ptr<IBitmapData> bmA = sbA->CreateBitmap(nullptr);
+        const shared_ptr<IBitmapData> bmB = sbB->CreateBitmap(nullptr);
+        const ScopedBitmapLockerSP lockA(bmA);
+        const ScopedBitmapLockerSP lockB(bmB);
+
+        if (bmA->GetPixelType() != bmB->GetPixelType() || bmA->GetWidth() != bmB->GetWidth() || bmA->GetHeight() != bmB->GetHeight())
+        {
+            throw runtime_error("CompareImages: decoded bitmap shape or type mismatch.");
+        }
+
+        const PixelType pt = bmA->GetPixelType();
+        const uint32_t w = bmA->GetWidth();
+        const uint32_t h = bmA->GetHeight();
+        const size_t bpp = Utils::GetBytesPerPixel(pt);
+        const size_t minStride = static_cast<size_t>(w) * bpp;
+        if (lockA.stride < minStride || lockB.stride < minStride)
+        {
+            throw runtime_error("CompareImages: decoded bitmap stride too small for width and pixel type.");
+        }
+
+        long double sumSqBlock = 0;
+        uint64_t samplesBlock = 0;
+        long double maxAbsBlock = 0;
+        AccumulatePixelDifference(
+            pt,
+            static_cast<const uint8_t*>(lockA.ptrDataRoi),
+            lockA.stride,
+            static_cast<const uint8_t*>(lockB.ptrDataRoi),
+            lockB.stride,
+            w,
+            h,
+            &sumSqBlock,
+            &samplesBlock,
+            &maxAbsBlock);
+
+        sumSqTotal += sumSqBlock;
+        sampleTotal += samplesBlock;
+        if (maxAbsBlock > maxAbsGlobal)
+        {
+            maxAbsGlobal = maxAbsBlock;
+        }
+
+        const long double blockRms = (samplesBlock > 0)
+                                         ? sqrtl(static_cast<long double>(sumSqBlock) / static_cast<long double>(samplesBlock))
+                                         : 0;
+        if (options.IsLogLevelEnabled(4) || options.IsLogLevelEnabled(5))
+        {
+            stringstream line;
+            line << "CompareImages: subblock A[" << i << "]<->B[" << j << "] RMSD=" << fixed << setprecision(8) << static_cast<double>(blockRms)
+                 << " max_abs=" << static_cast<double>(maxAbsBlock);
+            log->WriteLineStdOut(line.str());
+        }
+
+        if (worstBlockRms < 0 || blockRms > worstBlockRms)
+        {
+            worstBlockRms = blockRms;
+            worstIndex = i;
+        }
+    }
+
+    const long double overallRms = (sampleTotal > 0)
+                                       ? sqrtl(static_cast<long double>(sumSqTotal) / static_cast<long double>(sampleTotal))
+                                       : 0;
+
+    stringstream summary;
+    summary << "CompareImages: compared " << statsA.subBlockCount << " subblock(s), " << sampleTotal
+            << " scalar sample(s)." << '\n';
+    summary << "  Overall RMSD: " << fixed << setprecision(10) << static_cast<double>(overallRms) << '\n';
+    summary << "  Max absolute sample difference: " << setprecision(10) << static_cast<double>(maxAbsGlobal) << '\n';
+    summary << "  Largest per-subblock RMSD at index " << worstIndex << ": " << setprecision(10) << static_cast<double>(worstBlockRms) << '\n';
+    summary << "  Source A: " << convertToUtf8(options.GetCZIFilename()) << '\n';
+    summary << "  Source B: " << convertToUtf8(options.GetCompareCziFilename());
+    log->WriteLineStdOut(summary.str());
+
+    if (sumSqTotal == 0)
+    {
+        log->WriteLineStdOut("CompareImages: decoded pixels match exactly (RMSD is zero).");
+    }
+
+    return true;
+}
+
+bool executeCompareImages(const CCmdLineOptions& options)
+{
+    return CExecuteCompareImages::execute(options);
+}

--- a/Src/CZICmd/executeCompareImages.h
+++ b/Src/CZICmd/executeCompareImages.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+class CCmdLineOptions;
+
+bool executeCompareImages(const CCmdLineOptions& options);

--- a/Src/CZICmd/executeCreateCzi.cpp
+++ b/Src/CZICmd/executeCreateCzi.cpp
@@ -150,6 +150,40 @@ private:
                 addInfo.SetCompressionMode(CompressionMode::Zstd0);
                 writer->SyncAddSubBlock(addInfo);
             }
+            else if (options.GetCompressionMode() == CompressionMode::Jxl)
+            {
+#if LIBCZI_HAVE_LIBJXL
+                auto memblk = JxlLibCompress::Compress(
+                    bm->GetPixelType(),
+                    bm->GetWidth(),
+                    bm->GetHeight(),
+                    locker.stride,
+                    locker.ptrDataRoi,
+                    options.GetCompressionParameters().get());
+
+                AddSubBlockInfoMemPtr addInfo;
+                addInfo.Clear();
+                addInfo.coordinate = coord;
+                addInfo.mIndexValid = true;
+                addInfo.mIndex = m;
+                addInfo.x = x;
+                addInfo.y = y;
+                addInfo.logicalWidth = bm->GetWidth();
+                addInfo.logicalHeight = bm->GetHeight();
+                addInfo.physicalWidth = bm->GetWidth();
+                addInfo.physicalHeight = bm->GetHeight();
+                addInfo.PixelType = bm->GetPixelType();
+                addInfo.ptrData = memblk->GetPtr();
+                addInfo.dataSize = memblk->GetSizeOfData();
+                addInfo.ptrSbBlkMetadata = sbBlkMetadata;
+                addInfo.sbBlkMetadataSize = sbBlkMetadataSize;
+                addInfo.SetCompressionMode(CompressionMode::Jxl);
+                writer->SyncAddSubBlock(addInfo);
+#else
+                throw runtime_error(
+                    "CreateCZI with JPEG XL requires libCZI built with LIBCZI_BUILD_WITH_LIBJXL=ON and libjxl.");
+#endif
+            }
         }
     }
 }

--- a/Src/CZICmd/executeReEncodeCzi.cpp
+++ b/Src/CZICmd/executeReEncodeCzi.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "executeReEncodeCzi.h"
+#include "executeBase.h"
+#include "inc_libCZI.h"
+#include "libCZI_compress.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace libCZI;
+using namespace std;
+
+namespace
+{
+    static shared_ptr<IMemoryBlock> EncodeTile(
+        CompressionMode target,
+        PixelType pixelType,
+        uint32_t width,
+        uint32_t height,
+        uint32_t stride,
+        const void* pixels,
+        const ICompressParameters* compressParams)
+    {
+        switch (target)
+        {
+        case CompressionMode::Zstd0:
+            return ZstdCompress::CompressZStd0Alloc(width, height, stride, pixelType, pixels, compressParams);
+        case CompressionMode::Zstd1:
+            return ZstdCompress::CompressZStd1Alloc(width, height, stride, pixelType, pixels, compressParams);
+        case CompressionMode::JpgXr:
+            return JxrLibCompress::Compress(pixelType, width, height, stride, pixels, compressParams);
+#if LIBCZI_HAVE_LIBJXL
+        case CompressionMode::Jxl:
+            return JxlLibCompress::Compress(pixelType, width, height, stride, pixels, compressParams);
+#else
+        case CompressionMode::Jxl:
+            throw runtime_error("ReEncodeCZI: JPEG XL output requires LIBCZI_BUILD_WITH_LIBJXL=ON.");
+#endif
+        default:
+            break;
+        }
+
+        stringstream ss;
+        ss << "ReEncodeCZI: unsupported target compression \""
+           << Utils::CompressionModeToInformalString(target)
+           << "\" (supported: zstd0, zstd1, jpgxr, jxl";
+#if !LIBCZI_HAVE_LIBJXL
+        ss << " (jxl not built)";
+#endif
+        ss << ", uncompressed).";
+        throw runtime_error(ss.str());
+    }
+}
+
+class CExecuteReEncodeCzi : CExecuteBase
+{
+public:
+    static bool execute(const CCmdLineOptions& options);
+};
+
+bool CExecuteReEncodeCzi::execute(const CCmdLineOptions& options)
+{
+    const CompressionMode targetCompression = options.GetCompressionMode();
+    if (targetCompression == CompressionMode::Invalid)
+    {
+        throw invalid_argument("ReEncodeCZI requires --compressionopts (e.g. zstd1:ExplicitLevel=3 or jxl:).");
+    }
+
+    auto reader = CExecuteReEncodeCzi::CreateAndOpenCziReader(options);
+    const FileHeaderInfo hdr = reader->GetFileHeaderInfo();
+    SubBlockStatistics stats = reader->GetStatistics();
+    if (stats.subBlockCount <= 0)
+    {
+        throw runtime_error("ReEncodeCZI: source has no subblocks.");
+    }
+
+    const wstring outPath = options.MakeOutputFilename(nullptr, L"czi");
+    auto outStream = CreateOutputStreamForFile(outPath.c_str(), true);
+    auto writer = CreateCZIWriter();
+
+    auto writerInfo = make_shared<CCziWriterInfo>(hdr.fileGuid);
+    if (!stats.dimBounds.IsEmpty())
+    {
+        writerInfo->SetDimBounds(&stats.dimBounds);
+    }
+
+    if (stats.IsMIndexValid())
+    {
+        writerInfo->SetMIndexBounds(stats.minMindex, stats.maxMindex);
+    }
+
+    writerInfo->SetReservedSizeForSubBlockDirectory(true, static_cast<size_t>(max(1, stats.subBlockCount)));
+
+    int attachmentCount = 0;
+    reader->EnumerateAttachments(
+        [&](int, const AttachmentInfo&)->bool
+        {
+            ++attachmentCount;
+            return true;
+        });
+    writerInfo->SetReservedSizeForAttachmentsDirectory(true, static_cast<size_t>(max(1, attachmentCount)));
+
+    writer->Create(outStream, writerInfo);
+
+    const ICompressParameters* compressParams = options.GetCompressionParameters().get();
+
+    reader->EnumerateSubBlocks(
+        [&](int index, const SubBlockInfo&)->bool
+        {
+            auto sb = reader->ReadSubBlock(index);
+            if (sb == nullptr)
+            {
+                stringstream ss;
+                ss << "ReEncodeCZI: ReadSubBlock(" << index << ") failed.";
+                throw runtime_error(ss.str());
+            }
+
+            const SubBlockInfo& sbi = sb->GetSubBlockInfo();
+            shared_ptr<IBitmapData> bitmap = sb->CreateBitmap(nullptr);
+            ScopedBitmapLockerSP locker(bitmap);
+
+            vector<uint8_t> metaCopy;
+            size_t metaSize = 0;
+            const auto metaBlob = sb->GetRawData(ISubBlock::MemBlkType::Metadata, &metaSize);
+            if (metaSize > 0 && metaBlob != nullptr)
+            {
+                const auto* p = static_cast<const uint8_t*>(metaBlob.get());
+                metaCopy.assign(p, p + metaSize);
+            }
+
+            vector<uint8_t> attCopy;
+            size_t attSize = 0;
+            const auto attBlob = sb->GetRawData(ISubBlock::MemBlkType::Attachment, &attSize);
+            if (attSize > 0 && attBlob != nullptr)
+            {
+                const auto* p = static_cast<const uint8_t*>(attBlob.get());
+                attCopy.assign(p, p + attSize);
+            }
+
+            if (targetCompression == CompressionMode::UnCompressed)
+            {
+                AddSubBlockInfoStridedBitmap addStrided;
+                addStrided.Clear();
+                addStrided.coordinate = sbi.coordinate;
+                addStrided.mIndexValid = sbi.IsMindexValid();
+                addStrided.mIndex = sbi.mIndex;
+                addStrided.x = sbi.logicalRect.x;
+                addStrided.y = sbi.logicalRect.y;
+                addStrided.logicalWidth = sbi.logicalRect.w;
+                addStrided.logicalHeight = sbi.logicalRect.h;
+                addStrided.physicalWidth = sbi.physicalSize.w;
+                addStrided.physicalHeight = sbi.physicalSize.h;
+                addStrided.PixelType = sbi.pixelType;
+                addStrided.pyramid_type = sbi.pyramidType;
+                addStrided.ptrBitmap = locker.ptrDataRoi;
+                addStrided.strideBitmap = locker.stride;
+                addStrided.ptrSbBlkMetadata = metaCopy.empty() ? nullptr : metaCopy.data();
+                addStrided.sbBlkMetadataSize = static_cast<uint32_t>(metaCopy.size());
+                addStrided.ptrSbBlkAttachment = attCopy.empty() ? nullptr : attCopy.data();
+                addStrided.sbBlkAttachmentSize = static_cast<uint32_t>(attCopy.size());
+                writer->SyncAddSubBlock(addStrided);
+            }
+            else
+            {
+                shared_ptr<IMemoryBlock> compressed = EncodeTile(
+                    targetCompression,
+                    sbi.pixelType,
+                    bitmap->GetWidth(),
+                    bitmap->GetHeight(),
+                    locker.stride,
+                    locker.ptrDataRoi,
+                    compressParams);
+
+                AddSubBlockInfoMemPtr addMem;
+                addMem.Clear();
+                addMem.coordinate = sbi.coordinate;
+                addMem.mIndexValid = sbi.IsMindexValid();
+                addMem.mIndex = sbi.mIndex;
+                addMem.x = sbi.logicalRect.x;
+                addMem.y = sbi.logicalRect.y;
+                addMem.logicalWidth = sbi.logicalRect.w;
+                addMem.logicalHeight = sbi.logicalRect.h;
+                addMem.physicalWidth = sbi.physicalSize.w;
+                addMem.physicalHeight = sbi.physicalSize.h;
+                addMem.PixelType = sbi.pixelType;
+                addMem.pyramid_type = sbi.pyramidType;
+                addMem.SetCompressionMode(targetCompression);
+                addMem.ptrData = compressed->GetPtr();
+                addMem.dataSize = static_cast<uint32_t>(compressed->GetSizeOfData());
+                addMem.ptrSbBlkMetadata = metaCopy.empty() ? nullptr : metaCopy.data();
+                addMem.sbBlkMetadataSize = static_cast<uint32_t>(metaCopy.size());
+                addMem.ptrSbBlkAttachment = attCopy.empty() ? nullptr : attCopy.data();
+                addMem.sbBlkAttachmentSize = static_cast<uint32_t>(attCopy.size());
+                writer->SyncAddSubBlock(addMem);
+            }
+
+            return true;
+        });
+
+    reader->EnumerateAttachments(
+        [&](int index, const AttachmentInfo&)->bool
+        {
+            auto att = reader->ReadAttachment(index);
+            if (att == nullptr)
+            {
+                stringstream ss;
+                ss << "ReEncodeCZI: ReadAttachment(" << index << ") failed.";
+                throw runtime_error(ss.str());
+            }
+
+            size_t dataSize = 0;
+            const auto blob = att->GetRawData(&dataSize);
+            vector<uint8_t> dataCopy;
+            if (dataSize > 0 && blob != nullptr)
+            {
+                const auto* p = static_cast<const uint8_t*>(blob.get());
+                dataCopy.assign(p, p + dataSize);
+            }
+
+            const AttachmentInfo& ai = att->GetAttachmentInfo();
+            AddAttachmentInfo addAtt;
+            addAtt.Clear();
+            addAtt.contentGuid = ai.contentGuid;
+            addAtt.SetContentFileType(ai.contentFileType);
+            addAtt.SetName(ai.name.c_str());
+            addAtt.ptrData = dataCopy.empty() ? nullptr : dataCopy.data();
+            addAtt.dataSize = static_cast<uint32_t>(dataCopy.size());
+            writer->SyncAddAttachment(addAtt);
+            return true;
+        });
+
+    shared_ptr<IMetadataSegment> mdSeg = reader->ReadMetadataSegment();
+    if (mdSeg == nullptr)
+    {
+        throw runtime_error("ReEncodeCZI: source has no metadata segment.");
+    }
+
+    size_t xmlSize = 0;
+    const shared_ptr<const void> xmlBlob = mdSeg->GetRawData(IMetadataSegment::XmlMetadata, &xmlSize);
+    size_t mdAttSize = 0;
+    const shared_ptr<const void> mdAttBlob = mdSeg->GetRawData(IMetadataSegment::Attachment, &mdAttSize);
+
+    string mdXmlStr;
+    if (xmlSize > 0 && xmlBlob != nullptr)
+    {
+        mdXmlStr.assign(static_cast<const char*>(xmlBlob.get()), xmlSize);
+    }
+
+    vector<uint8_t> mdSegAttStorage;
+    if (mdAttSize > 0 && mdAttBlob != nullptr)
+    {
+        const auto* p = static_cast<const uint8_t*>(mdAttBlob.get());
+        mdSegAttStorage.assign(p, p + mdAttSize);
+    }
+
+    reader->Close();
+    reader.reset();
+
+    WriteMetadataInfo wmi;
+    wmi.Clear();
+    wmi.szMetadata = mdXmlStr.empty() ? "" : mdXmlStr.c_str();
+    wmi.szMetadataSize = mdXmlStr.size();
+    wmi.ptrAttachment = mdSegAttStorage.empty() ? nullptr : mdSegAttStorage.data();
+    wmi.attachmentSize = mdSegAttStorage.size();
+    writer->SyncWriteMetadata(wmi);
+
+    writer->Close();
+
+    wstringstream msg;
+    msg << L"ReEncodeCZI wrote \"" << outPath << L"\" (" << stats.subBlockCount << L" subblocks, "
+        << attachmentCount << L" attachments).";
+    options.GetLog()->WriteLineStdOut(msg.str().c_str());
+
+    return true;
+}
+
+bool executeReEncodeCzi(const CCmdLineOptions& options)
+{
+    return CExecuteReEncodeCzi::execute(options);
+}

--- a/Src/CZICmd/executeReEncodeCzi.cpp
+++ b/Src/CZICmd/executeReEncodeCzi.cpp
@@ -9,18 +9,35 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+#include <exception>
+#include <iomanip>
+#include <iostream>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
+
+#if defined(_WIN32)
+#include <sys/types.h>
+#include <sys/stat.h>
+#else
+#include <sys/stat.h>
+#endif
 
 using namespace libCZI;
 using namespace std;
 
 namespace
 {
-    static shared_ptr<IMemoryBlock> EncodeTile(
+    shared_ptr<IMemoryBlock> EncodeTile(
         CompressionMode target,
         PixelType pixelType,
         uint32_t width,
@@ -58,13 +75,270 @@ namespace
         ss << ", uncompressed).";
         throw runtime_error(ss.str());
     }
-}
+
+    string FormatLocalTime(const chrono::system_clock::time_point tp)
+    {
+        const time_t tt = chrono::system_clock::to_time_t(tp);
+        tm tmBuf{};
+#if defined(_MSC_VER)
+        if (localtime_s(&tmBuf, &tt) != 0)
+        {
+            return "(invalid time)";
+        }
+#elif defined(_WIN32)
+        const tm* p = localtime(&tt);
+        if (p == nullptr)
+        {
+            return "(invalid time)";
+        }
+
+        tmBuf = *p;
+#else
+        if (localtime_r(&tt, &tmBuf) == nullptr)
+        {
+            return "(invalid time)";
+        }
+#endif
+        stringstream ss;
+        ss << put_time(&tmBuf, "%Y-%m-%d %H:%M:%S");
+        return ss.str();
+    }
+
+    string FormatElapsedSeconds(chrono::steady_clock::duration d)
+    {
+        const double secs = chrono::duration<double>(d).count();
+        stringstream ss;
+        ss << fixed << setprecision(2) << secs << " s";
+        return ss.str();
+    }
+
+    bool TryGetFileSizeBytes(const wstring& path, uint64_t* outSize)
+    {
+        if (outSize == nullptr)
+        {
+            return false;
+        }
+
+#if defined(_WIN32)
+        struct __stat64 st{};
+        if (_wstat64(path.c_str(), &st) != 0)
+        {
+            return false;
+        }
+
+        *outSize = static_cast<uint64_t>(st.st_size);
+        return true;
+#else
+        struct stat st{};
+        if (stat(convertToUtf8(path).c_str(), &st) != 0)
+        {
+            return false;
+        }
+
+        *outSize = static_cast<uint64_t>(st.st_size);
+        return true;
+#endif
+    }
+
+    void WriteReencodeProgressBar(ILog* log, int completedSteps, int totalSteps, const char* label)
+    {
+        if (log == nullptr || totalSteps <= 0)
+        {
+            return;
+        }
+
+        const int pct = min(100, max(0, (completedSteps * 100) / totalSteps));
+        constexpr int barWidth = 40;
+        const int filled = min(barWidth, max(0, (completedSteps * barWidth) / totalSteps));
+
+        stringstream ss;
+        ss << "\r" << label << " [";
+        for (int i = 0; i < barWidth; ++i)
+        {
+            ss << (i < filled ? '#' : '-');
+        }
+
+        ss << "] " << completedSteps << "/" << totalSteps << " (" << pct << "%)";
+        log->WriteStdOut(ss.str());
+        cout.flush();
+    }
+} // namespace
 
 class CExecuteReEncodeCzi : CExecuteBase
 {
+    struct PreparedReencodeSubblock
+    {
+        bool valid = false;
+        bool isUncompressed = false;
+        SubBlockInfo sbi{};
+        vector<uint8_t> metaCopy;
+        vector<uint8_t> attCopy;
+        shared_ptr<IMemoryBlock> compressed;
+        vector<uint8_t> pixelCopy;
+        uint32_t pixelStrideBytes = 0;
+    };
+
+    static PreparedReencodeSubblock PrepareSubblockForReencode(
+        const shared_ptr<ICZIReader>& reader,
+        int index,
+        CompressionMode targetCompression,
+        const ICompressParameters* compressParams);
+
+    static void ReencodeSubblockWorker(
+        const CCmdLineOptions* options,
+        CompressionMode targetCompression,
+        const ICompressParameters* compressParams,
+        int subBlockCount,
+        atomic<int>* nextIndex,
+        atomic<bool>* cancelFlag,
+        vector<PreparedReencodeSubblock>* preparedOut,
+        mutex* slotMutex,
+        mutex* errorMutex,
+        exception_ptr* firstError,
+        shared_ptr<ILog> progressLog,
+        atomic<int>* progressDone,
+        mutex* progressMx,
+        int progressTotalSteps);
+
 public:
     static bool execute(const CCmdLineOptions& options);
 };
+
+/*static*/ CExecuteReEncodeCzi::PreparedReencodeSubblock CExecuteReEncodeCzi::PrepareSubblockForReencode(
+    const shared_ptr<ICZIReader>& reader,
+    int index,
+    CompressionMode targetCompression,
+    const ICompressParameters* compressParams)
+{
+    const auto sb = reader->ReadSubBlock(index);
+    if (sb == nullptr)
+    {
+        stringstream ss;
+        ss << "ReEncodeCZI: ReadSubBlock(" << index << ") failed.";
+        throw runtime_error(ss.str());
+    }
+
+    PreparedReencodeSubblock out;
+    out.sbi = sb->GetSubBlockInfo();
+
+    size_t metaSize = 0;
+    const auto metaBlob = sb->GetRawData(ISubBlock::MemBlkType::Metadata, &metaSize);
+    if (metaSize > 0 && metaBlob != nullptr)
+    {
+        const auto* p = static_cast<const uint8_t*>(metaBlob.get());
+        out.metaCopy.assign(p, p + metaSize);
+    }
+
+    size_t attSize = 0;
+    const auto attBlob = sb->GetRawData(ISubBlock::MemBlkType::Attachment, &attSize);
+    if (attSize > 0 && attBlob != nullptr)
+    {
+        const auto* p = static_cast<const uint8_t*>(attBlob.get());
+        out.attCopy.assign(p, p + attSize);
+    }
+
+    const shared_ptr<IBitmapData> bitmap = sb->CreateBitmap(nullptr);
+    const ScopedBitmapLockerSP locker(bitmap);
+
+    if (targetCompression == CompressionMode::UnCompressed)
+    {
+        const uint32_t w = bitmap->GetWidth();
+        const uint32_t h = bitmap->GetHeight();
+        const PixelType pt = out.sbi.pixelType;
+        const size_t bpp = Utils::GetBytesPerPixel(pt);
+        const size_t rowBytes = static_cast<size_t>(w) * bpp;
+        if (locker.stride < rowBytes)
+        {
+            throw runtime_error("ReEncodeCZI: decoded bitmap stride too small for uncompressed copy.");
+        }
+
+        out.pixelCopy.resize(rowBytes * static_cast<size_t>(h));
+        const auto* srcBase = static_cast<const uint8_t*>(locker.ptrDataRoi);
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            memcpy(
+                out.pixelCopy.data() + static_cast<size_t>(y) * rowBytes,
+                srcBase + static_cast<size_t>(y) * locker.stride,
+                rowBytes);
+        }
+
+        out.pixelStrideBytes = static_cast<uint32_t>(rowBytes);
+        out.isUncompressed = true;
+    }
+    else
+    {
+        out.compressed = EncodeTile(
+            targetCompression,
+            out.sbi.pixelType,
+            bitmap->GetWidth(),
+            bitmap->GetHeight(),
+            locker.stride,
+            locker.ptrDataRoi,
+            compressParams);
+    }
+
+    out.valid = true;
+    return out;
+}
+
+/*static*/ void CExecuteReEncodeCzi::ReencodeSubblockWorker(
+    const CCmdLineOptions* options,
+    CompressionMode targetCompression,
+    const ICompressParameters* compressParams,
+    int subBlockCount,
+    atomic<int>* nextIndex,
+    atomic<bool>* cancelFlag,
+    vector<PreparedReencodeSubblock>* preparedOut,
+    mutex* slotMutex,
+    mutex* errorMutex,
+    exception_ptr* firstError,
+    shared_ptr<ILog> progressLog,
+    atomic<int>* progressDone,
+    mutex* progressMx,
+    int progressTotalSteps)
+{
+    shared_ptr<ICZIReader> reader = CreateAndOpenCziReader(*options);
+
+    for (;;)
+    {
+        if (cancelFlag->load(memory_order_relaxed))
+        {
+            break;
+        }
+
+        const int index = nextIndex->fetch_add(1, memory_order_relaxed);
+        if (index >= subBlockCount)
+        {
+            break;
+        }
+
+        try
+        {
+            PreparedReencodeSubblock prepared = PrepareSubblockForReencode(reader, index, targetCompression, compressParams);
+            {
+                lock_guard<mutex> lock(*slotMutex);
+                (*preparedOut)[static_cast<size_t>(index)] = move(prepared);
+            }
+
+            const int step = progressDone->fetch_add(1, memory_order_relaxed) + 1;
+            {
+                lock_guard<mutex> pg(*progressMx);
+                WriteReencodeProgressBar(progressLog.get(), step, progressTotalSteps, "ReEncodeCZI");
+            }
+        }
+        catch (...)
+        {
+            lock_guard<mutex> el(*errorMutex);
+            if (!firstError)
+            {
+                *firstError = current_exception();
+            }
+
+            cancelFlag->store(true, memory_order_relaxed);
+            break;
+        }
+    }
+}
 
 bool CExecuteReEncodeCzi::execute(const CCmdLineOptions& options)
 {
@@ -74,7 +348,7 @@ bool CExecuteReEncodeCzi::execute(const CCmdLineOptions& options)
         throw invalid_argument("ReEncodeCZI requires --compressionopts (e.g. zstd1:ExplicitLevel=3 or jxl:).");
     }
 
-    auto reader = CExecuteReEncodeCzi::CreateAndOpenCziReader(options);
+    auto reader = CreateAndOpenCziReader(options);
     const FileHeaderInfo hdr = reader->GetFileHeaderInfo();
     SubBlockStatistics stats = reader->GetStatistics();
     if (stats.subBlockCount <= 0)
@@ -112,98 +386,185 @@ bool CExecuteReEncodeCzi::execute(const CCmdLineOptions& options)
 
     const ICompressParameters* compressParams = options.GetCompressionParameters().get();
 
-    reader->EnumerateSubBlocks(
-        [&](int index, const SubBlockInfo&)->bool
+    const int subBlockCount = stats.subBlockCount;
+    vector<PreparedReencodeSubblock> prepared(static_cast<size_t>(subBlockCount));
+
+    const int progressTotalSteps = max(1, subBlockCount * 2);
+    atomic<int> progressDone{ 0 };
+    mutex progressMx;
+    const shared_ptr<ILog> log = options.GetLog();
+    const auto wallStartSubblocks = chrono::system_clock::now();
+    const auto steadyStartSubblocks = chrono::steady_clock::now();
+    {
+        stringstream ss;
+        ss << "ReEncodeCZI: subblock recompression started at " << FormatLocalTime(wallStartSubblocks);
+        log->WriteLineStdOut(ss.str());
+    }
+
+    unsigned workerCount = thread::hardware_concurrency();
+    if (workerCount == 0)
+    {
+        workerCount = 1;
+    }
+
+    if (static_cast<int>(workerCount) > subBlockCount)
+    {
+        workerCount = static_cast<unsigned>(subBlockCount);
+    }
+
+    if (workerCount > 1U)
+    {
+        wstringstream parMsg;
+        parMsg << L"ReEncodeCZI: preparing subblocks with " << workerCount << L" threads.";
+        options.GetLog()->WriteLineStdOut(parMsg.str().c_str());
+    }
+
+    exception_ptr firstError;
+
+    try
+    {
+        if (workerCount <= 1U)
         {
-            auto sb = reader->ReadSubBlock(index);
-            if (sb == nullptr)
+            for (int i = 0; i < subBlockCount; ++i)
             {
-                stringstream ss;
-                ss << "ReEncodeCZI: ReadSubBlock(" << index << ") failed.";
-                throw runtime_error(ss.str());
+                prepared[static_cast<size_t>(i)] = PrepareSubblockForReencode(reader, i, targetCompression, compressParams);
+                const int step = progressDone.fetch_add(1, memory_order_relaxed) + 1;
+                {
+                    lock_guard<mutex> pg(progressMx);
+                    WriteReencodeProgressBar(log.get(), step, progressTotalSteps, "ReEncodeCZI");
+                }
+            }
+        }
+        else
+        {
+            atomic<int> nextIndex{ 0 };
+            atomic<bool> cancelFlag{ false };
+            mutex slotMutex;
+            mutex errorMutex;
+
+            vector<thread> workers;
+            workers.reserve(workerCount);
+            for (unsigned t = 0; t < workerCount; ++t)
+            {
+                workers.emplace_back(
+                    ReencodeSubblockWorker,
+                    &options,
+                    targetCompression,
+                    compressParams,
+                    subBlockCount,
+                    &nextIndex,
+                    &cancelFlag,
+                    &prepared,
+                    &slotMutex,
+                    &errorMutex,
+                    &firstError,
+                    log,
+                    &progressDone,
+                    &progressMx,
+                    progressTotalSteps);
             }
 
-            const SubBlockInfo& sbi = sb->GetSubBlockInfo();
-            shared_ptr<IBitmapData> bitmap = sb->CreateBitmap(nullptr);
-            ScopedBitmapLockerSP locker(bitmap);
-
-            vector<uint8_t> metaCopy;
-            size_t metaSize = 0;
-            const auto metaBlob = sb->GetRawData(ISubBlock::MemBlkType::Metadata, &metaSize);
-            if (metaSize > 0 && metaBlob != nullptr)
+            for (thread& w : workers)
             {
-                const auto* p = static_cast<const uint8_t*>(metaBlob.get());
-                metaCopy.assign(p, p + metaSize);
+                w.join();
             }
 
-            vector<uint8_t> attCopy;
-            size_t attSize = 0;
-            const auto attBlob = sb->GetRawData(ISubBlock::MemBlkType::Attachment, &attSize);
-            if (attSize > 0 && attBlob != nullptr)
+            if (firstError)
             {
-                const auto* p = static_cast<const uint8_t*>(attBlob.get());
-                attCopy.assign(p, p + attSize);
+                log->WriteStdOut("\n");
+                cout.flush();
+                rethrow_exception(firstError);
+            }
+        }
+
+        for (int i = 0; i < subBlockCount; ++i)
+        {
+            PreparedReencodeSubblock& p = prepared[static_cast<size_t>(i)];
+            if (!p.valid)
+            {
+                throw runtime_error("ReEncodeCZI: internal error, missing prepared subblock.");
             }
 
-            if (targetCompression == CompressionMode::UnCompressed)
+            if (p.isUncompressed)
             {
                 AddSubBlockInfoStridedBitmap addStrided;
                 addStrided.Clear();
-                addStrided.coordinate = sbi.coordinate;
-                addStrided.mIndexValid = sbi.IsMindexValid();
-                addStrided.mIndex = sbi.mIndex;
-                addStrided.x = sbi.logicalRect.x;
-                addStrided.y = sbi.logicalRect.y;
-                addStrided.logicalWidth = sbi.logicalRect.w;
-                addStrided.logicalHeight = sbi.logicalRect.h;
-                addStrided.physicalWidth = sbi.physicalSize.w;
-                addStrided.physicalHeight = sbi.physicalSize.h;
-                addStrided.PixelType = sbi.pixelType;
-                addStrided.pyramid_type = sbi.pyramidType;
-                addStrided.ptrBitmap = locker.ptrDataRoi;
-                addStrided.strideBitmap = locker.stride;
-                addStrided.ptrSbBlkMetadata = metaCopy.empty() ? nullptr : metaCopy.data();
-                addStrided.sbBlkMetadataSize = static_cast<uint32_t>(metaCopy.size());
-                addStrided.ptrSbBlkAttachment = attCopy.empty() ? nullptr : attCopy.data();
-                addStrided.sbBlkAttachmentSize = static_cast<uint32_t>(attCopy.size());
+                addStrided.coordinate = p.sbi.coordinate;
+                addStrided.mIndexValid = p.sbi.IsMindexValid();
+                addStrided.mIndex = p.sbi.mIndex;
+                addStrided.x = p.sbi.logicalRect.x;
+                addStrided.y = p.sbi.logicalRect.y;
+                addStrided.logicalWidth = p.sbi.logicalRect.w;
+                addStrided.logicalHeight = p.sbi.logicalRect.h;
+                addStrided.physicalWidth = p.sbi.physicalSize.w;
+                addStrided.physicalHeight = p.sbi.physicalSize.h;
+                addStrided.PixelType = p.sbi.pixelType;
+                addStrided.pyramid_type = p.sbi.pyramidType;
+                addStrided.ptrBitmap = p.pixelCopy.data();
+                addStrided.strideBitmap = p.pixelStrideBytes;
+                addStrided.ptrSbBlkMetadata = p.metaCopy.empty() ? nullptr : p.metaCopy.data();
+                addStrided.sbBlkMetadataSize = static_cast<uint32_t>(p.metaCopy.size());
+                addStrided.ptrSbBlkAttachment = p.attCopy.empty() ? nullptr : p.attCopy.data();
+                addStrided.sbBlkAttachmentSize = static_cast<uint32_t>(p.attCopy.size());
                 writer->SyncAddSubBlock(addStrided);
             }
             else
             {
-                shared_ptr<IMemoryBlock> compressed = EncodeTile(
-                    targetCompression,
-                    sbi.pixelType,
-                    bitmap->GetWidth(),
-                    bitmap->GetHeight(),
-                    locker.stride,
-                    locker.ptrDataRoi,
-                    compressParams);
-
                 AddSubBlockInfoMemPtr addMem;
                 addMem.Clear();
-                addMem.coordinate = sbi.coordinate;
-                addMem.mIndexValid = sbi.IsMindexValid();
-                addMem.mIndex = sbi.mIndex;
-                addMem.x = sbi.logicalRect.x;
-                addMem.y = sbi.logicalRect.y;
-                addMem.logicalWidth = sbi.logicalRect.w;
-                addMem.logicalHeight = sbi.logicalRect.h;
-                addMem.physicalWidth = sbi.physicalSize.w;
-                addMem.physicalHeight = sbi.physicalSize.h;
-                addMem.PixelType = sbi.pixelType;
-                addMem.pyramid_type = sbi.pyramidType;
+                addMem.coordinate = p.sbi.coordinate;
+                addMem.mIndexValid = p.sbi.IsMindexValid();
+                addMem.mIndex = p.sbi.mIndex;
+                addMem.x = p.sbi.logicalRect.x;
+                addMem.y = p.sbi.logicalRect.y;
+                addMem.logicalWidth = p.sbi.logicalRect.w;
+                addMem.logicalHeight = p.sbi.logicalRect.h;
+                addMem.physicalWidth = p.sbi.physicalSize.w;
+                addMem.physicalHeight = p.sbi.physicalSize.h;
+                addMem.PixelType = p.sbi.pixelType;
+                addMem.pyramid_type = p.sbi.pyramidType;
                 addMem.SetCompressionMode(targetCompression);
-                addMem.ptrData = compressed->GetPtr();
-                addMem.dataSize = static_cast<uint32_t>(compressed->GetSizeOfData());
-                addMem.ptrSbBlkMetadata = metaCopy.empty() ? nullptr : metaCopy.data();
-                addMem.sbBlkMetadataSize = static_cast<uint32_t>(metaCopy.size());
-                addMem.ptrSbBlkAttachment = attCopy.empty() ? nullptr : attCopy.data();
-                addMem.sbBlkAttachmentSize = static_cast<uint32_t>(attCopy.size());
+                addMem.ptrData = p.compressed->GetPtr();
+                addMem.dataSize = static_cast<uint32_t>(p.compressed->GetSizeOfData());
+                addMem.ptrSbBlkMetadata = p.metaCopy.empty() ? nullptr : p.metaCopy.data();
+                addMem.sbBlkMetadataSize = static_cast<uint32_t>(p.metaCopy.size());
+                addMem.ptrSbBlkAttachment = p.attCopy.empty() ? nullptr : p.attCopy.data();
+                addMem.sbBlkAttachmentSize = static_cast<uint32_t>(p.attCopy.size());
                 writer->SyncAddSubBlock(addMem);
             }
 
-            return true;
-        });
+            p = {};
+
+            const int step = progressDone.fetch_add(1, memory_order_relaxed) + 1;
+            {
+                lock_guard<mutex> pg(progressMx);
+                WriteReencodeProgressBar(log.get(), step, progressTotalSteps, "ReEncodeCZI");
+            }
+        }
+    }
+    catch (...)
+    {
+        log->WriteStdOut("\n");
+        cout.flush();
+        throw;
+    }
+
+    {
+        lock_guard<mutex> pg(progressMx);
+        WriteReencodeProgressBar(log.get(), progressTotalSteps, progressTotalSteps, "ReEncodeCZI");
+    }
+
+    log->WriteStdOut("\n");
+    cout.flush();
+
+    const auto steadyEndSubblocks = chrono::steady_clock::now();
+    const auto wallEndSubblocks = chrono::system_clock::now();
+    {
+        stringstream ss;
+        ss << "ReEncodeCZI: subblock recompression finished at " << FormatLocalTime(wallEndSubblocks)
+           << " (elapsed " << FormatElapsedSeconds(steadyEndSubblocks - steadyStartSubblocks) << ").";
+        log->WriteLineStdOut(ss.str());
+    }
 
     reader->EnumerateAttachments(
         [&](int index, const AttachmentInfo&)->bool
@@ -274,10 +635,50 @@ bool CExecuteReEncodeCzi::execute(const CCmdLineOptions& options)
 
     writer->Close();
 
+    const auto steadyEndTotal = chrono::steady_clock::now();
+    const auto wallEndTotal = chrono::system_clock::now();
+
     wstringstream msg;
     msg << L"ReEncodeCZI wrote \"" << outPath << L"\" (" << stats.subBlockCount << L" subblocks, "
         << attachmentCount << L" attachments).";
     options.GetLog()->WriteLineStdOut(msg.str().c_str());
+
+    {
+        stringstream ss;
+        ss << "ReEncodeCZI: full output completed at " << FormatLocalTime(wallEndTotal)
+           << " (total elapsed including attachments and metadata: "
+           << FormatElapsedSeconds(steadyEndTotal - steadyStartSubblocks) << ").";
+        options.GetLog()->WriteLineStdOut(ss.str());
+    }
+
+    {
+        uint64_t inBytes = 0;
+        uint64_t outBytes = 0;
+        if (!TryGetFileSizeBytes(options.GetCZIFilename(), &inBytes) || !TryGetFileSizeBytes(outPath, &outBytes))
+        {
+            stringstream ss;
+            ss << "ReEncodeCZI: could not read source or output file size for comparison.";
+            options.GetLog()->WriteLineStdOut(ss.str());
+        }
+        else
+        {
+            stringstream ss;
+            ss << fixed << setprecision(2);
+            ss << "ReEncodeCZI: file size " << inBytes << " -> " << outBytes << " bytes";
+            if (inBytes > 0)
+            {
+                const double pct = 100.0 * (static_cast<double>(outBytes) - static_cast<double>(inBytes))
+                    / static_cast<double>(inBytes);
+                ss << " (" << (pct >= 0 ? "+" : "") << pct << "% vs source).";
+            }
+            else
+            {
+                ss << " (source size 0; percentage N/A).";
+            }
+
+            options.GetLog()->WriteLineStdOut(ss.str());
+        }
+    }
 
     return true;
 }

--- a/Src/CZICmd/executeReEncodeCzi.h
+++ b/Src/CZICmd/executeReEncodeCzi.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "cmdlineoptions.h"
+
+bool executeReEncodeCzi(const CCmdLineOptions& options);

--- a/Src/libCZI/CMakeLists.txt
+++ b/Src/libCZI/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 include(FetchContent)
+include(FindPkgConfig)
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
 include(CMakePackageConfigHelpers)
@@ -132,6 +133,11 @@ set(LIBCZISRCFILES
             BitmapOperationsBitonal.h
             BitmapOperationsBitonal.cpp
 )
+
+set(LIBCZI_JXL_SOURCES "")
+if (LIBCZI_BUILD_WITH_LIBJXL)
+  list(APPEND LIBCZI_JXL_SOURCES jxlCompress.cpp decoder_jxl.cpp decoder_jxl.h)
+endif()
 
 # prepare the configuration-file "libCZI_Config.h"
 if (IS_BIG_ENDIAN)
@@ -317,6 +323,36 @@ else()
   set(libCZI_WINDOWSAPI_UWP_AVAILABLE 0)
 endif()
 
+set(libCZI_have_libjxl 0)
+set(LIBCZI_LIBJXL_LINK "")
+if (LIBCZI_BUILD_WITH_LIBJXL)
+  set(_libczi_libjxl_resolved FALSE)
+  find_package(libjxl CONFIG QUIET)
+  if (libjxl_FOUND)
+    if (TARGET libjxl::jxl)
+      set(LIBCZI_LIBJXL_LINK libjxl::jxl)
+      set(_libczi_libjxl_resolved TRUE)
+    elseif (TARGET libjxl::jxl_enc AND TARGET libjxl::jxl_dec)
+      set(LIBCZI_LIBJXL_LINK libjxl::jxl_enc libjxl::jxl_dec)
+      set(_libczi_libjxl_resolved TRUE)
+    endif()
+  endif()
+  if (NOT _libczi_libjxl_resolved)
+    find_package(PkgConfig QUIET)
+    if (PkgConfig_FOUND)
+      pkg_check_modules(libczi_libjxl IMPORTED_TARGET libjxl)
+      if (libczi_libjxl_FOUND)
+        set(LIBCZI_LIBJXL_LINK PkgConfig::libczi_libjxl)
+        set(_libczi_libjxl_resolved TRUE)
+      endif()
+    endif()
+  endif()
+  if (NOT _libczi_libjxl_resolved)
+    message(FATAL_ERROR "LIBCZI_BUILD_WITH_LIBJXL is ON but libjxl was not found. Install libjxl (e.g. libjxl-dev) or provide CMake package 'libjxl'.")
+  endif()
+  set(libCZI_have_libjxl 1)
+endif()
+
 configure_file (
   "${CMAKE_CURRENT_SOURCE_DIR}/libCZI_Config.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/libCZI_Config.h"
@@ -332,13 +368,14 @@ set(libCZIPublicHeaders "ImportExport.h" "libCZI.h" "libCZI_Compositor.h" "libCZ
 #define the shared libCZI - library
 #
 if (LIBCZI_BUILD_DYNLIB)
-  add_library(libCZI SHARED ${LIBCZISRCFILES} $<TARGET_OBJECTS:JxrDecodeStatic>)
+  add_library(libCZI SHARED ${LIBCZISRCFILES} ${LIBCZI_JXL_SOURCES} $<TARGET_OBJECTS:JxrDecodeStatic>)
  
   set_target_properties(libCZI PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED YES) # https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
   SET_TARGET_PROPERTIES (libCZI PROPERTIES DEFINE_SYMBOL  "LIBCZI_EXPORTS" )
   set_target_properties(libCZI PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 1)
   # add the binary tree to the search path for include files so that we will find libCZI_Config.h
-  target_include_directories(libCZI PRIVATE  "${CMAKE_CURRENT_BINARY_DIR}")
+  target_include_directories(libCZI PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+  target_include_directories(libCZI PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
   target_include_directories(libCZI PRIVATE  ${EIGEN3_INCLUDE_DIR})
   target_link_libraries(libCZI PRIVATE  ${ADDITIONAL_LIBS_REQUIRED_FOR_ATOMIC})
   set_target_properties(libCZI PROPERTIES DEBUG_POSTFIX "d")
@@ -353,6 +390,9 @@ if (LIBCZI_BUILD_DYNLIB)
   endif()
   if (LIBCZI_BUILD_AZURESDK_BASED_STREAM)
     target_link_libraries(libCZI PRIVATE Azure::azure-identity Azure::azure-storage-blobs)
+  endif()
+  if (LIBCZI_BUILD_WITH_LIBJXL)
+    target_link_libraries(libCZI PRIVATE ${LIBCZI_LIBJXL_LINK})
   endif()
   if (LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3)
    target_link_libraries(libCZI PRIVATE Eigen3::Eigen)
@@ -375,12 +415,13 @@ endif(LIBCZI_BUILD_DYNLIB)
 #define the static libCZI - library
 #
 # Notes: -we use JxrDecode as an "object-library" in order have it "embedded" into libCZI.a
-add_library(libCZIStatic STATIC ${LIBCZISRCFILES} $<TARGET_OBJECTS:JxrDecodeStatic>)
+add_library(libCZIStatic STATIC ${LIBCZISRCFILES} ${LIBCZI_JXL_SOURCES} $<TARGET_OBJECTS:JxrDecodeStatic>)
 set_target_properties(libCZIStatic PROPERTIES CXX_STANDARD 14)
 target_compile_definitions(libCZIStatic PRIVATE _LIBCZISTATICLIB)
 set_target_properties(libCZIStatic PROPERTIES VERSION ${PROJECT_VERSION})
 # add the binary tree to the search path for include files so that we will find libCZI_Config.h
-target_include_directories(libCZIStatic PRIVATE  "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(libCZIStatic PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(libCZIStatic PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 target_include_directories(libCZIStatic PRIVATE  ${EIGEN3_INCLUDE_DIR})
 target_link_libraries(libCZIStatic PRIVATE  ${ADDITIONAL_LIBS_REQUIRED_FOR_ATOMIC})
 set_target_properties(libCZIStatic PROPERTIES DEBUG_POSTFIX "d")
@@ -396,6 +437,10 @@ if (LIBCZI_BUILD_CURL_BASED_STREAM)
 endif()
 if (LIBCZI_BUILD_AZURESDK_BASED_STREAM)
   target_link_libraries(libCZIStatic PRIVATE Azure::azure-identity Azure::azure-storage-blobs)
+endif()
+if (LIBCZI_BUILD_WITH_LIBJXL)
+  # PUBLIC so static consumers (e.g. CZIcmd) resolve JPEG XL symbols at link time.
+  target_link_libraries(libCZIStatic PUBLIC ${LIBCZI_LIBJXL_LINK})
 endif()
 
 if (LIBCZI_BUILD_PREFER_EXTERNALPACKAGE_EIGEN3)

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -9,6 +9,9 @@
 #include "inc_libCZI_Config.h"
 #include "CziSubBlock.h"
 #include "decoder_zstd.h"
+#if LIBCZI_HAVE_LIBJXL
+#include "decoder_jxl.h"
+#endif
 
 using namespace libCZI;
 using namespace libCZI::detail;
@@ -172,6 +175,18 @@ static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_Uncompresse
     }
 }
 
+#if LIBCZI_HAVE_LIBJXL
+static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_Jxl(ISubBlock* subBlk)
+{
+    auto dec = GetSite()->GetDecoder(ImageDecoderType::JXL, nullptr);
+    const void* ptr;
+    size_t size;
+    subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
+    const SubBlockInfo& sub_block_info = subBlk->GetSubBlockInfo();
+    return dec->Decode(ptr, size, sub_block_info.pixelType, sub_block_info.physicalSize.w, sub_block_info.physicalSize.h);
+}
+#endif
+
 std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlock(ISubBlock* subBlk, const CreateBitmapOptions* options)
 {
     switch (subBlk->GetSubBlockInfo().GetCompressionMode())
@@ -184,6 +199,10 @@ std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlock(ISubBlock*
         return CreateBitmapFromSubBlock_ZStd1(subBlk, options != nullptr ? options->handle_zstd_data_size_mismatch : true);
     case CompressionMode::UnCompressed:
         return CreateBitmapFromSubBlock_Uncompressed(subBlk, options != nullptr ? options->handle_uncompressed_data_size_mismatch : true);
+#if LIBCZI_HAVE_LIBJXL
+    case CompressionMode::Jxl:
+        return CreateBitmapFromSubBlock_Jxl(subBlk);
+#endif
     default:    // silence warnings
         throw std::logic_error("The method or operation is not implemented.");
     }

--- a/Src/libCZI/CziUtils.cpp
+++ b/Src/libCZI/CziUtils.cpp
@@ -80,6 +80,7 @@ using namespace libCZI::detail;
     case 4: return CompressionMode::JpgXr;
     case 5: return CompressionMode::Zstd0;
     case 6: return CompressionMode::Zstd1;
+    case 7: return CompressionMode::Jxl;
     default: return CompressionMode::Invalid;
     }
 }
@@ -98,6 +99,8 @@ using namespace libCZI::detail;
         return 5;
     case CompressionMode::Zstd1:
         return 6;
+    case CompressionMode::Jxl:
+        return 7;
     default:
         return (std::numeric_limits<int32_t>::min)();
     }

--- a/Src/libCZI/StreamImpl.cpp
+++ b/Src/libCZI/StreamImpl.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "StreamImpl.h"
+#include <algorithm>
 #include <cerrno>
 #include <sstream>
 #include <codecvt>
@@ -17,6 +18,82 @@
 
 using namespace std;
 using namespace libCZI::detail;
+
+namespace
+{
+    // Single write syscalls can return short counts (signals, quotas, some FS layers).
+    // Chunk to stay under common kernel limits (e.g. Linux MAX_RW_COUNT) and loop until complete.
+    constexpr std::uint64_t kStreamWriteChunkMax = 16ULL * 1024 * 1024;
+
+    void WriteAllPwrite(int fd, std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
+    {
+        const auto* bytes = static_cast<const std::uint8_t*>(pv);
+        std::uint64_t done = 0;
+        while (done < size)
+        {
+            const std::uint64_t remain = size - done;
+            const size_t chunk = static_cast<size_t>((std::min)(remain, kStreamWriteChunkMax));
+            const ssize_t w = pwrite(fd, bytes + done, chunk, static_cast<off_t>(offset + done));
+            if (w < 0)
+            {
+                const auto err = errno;
+                ostringstream ss;
+                ss << "pwrite failed (errno=" << err << " -> " << strerror(err) << ")";
+                throw runtime_error(ss.str());
+            }
+
+            if (w == 0)
+            {
+                throw runtime_error("pwrite returned 0 bytes (unexpected short write / progress stalled).");
+            }
+
+            done += static_cast<std::uint64_t>(w);
+        }
+
+        if (ptrBytesWritten != nullptr)
+        {
+            *ptrBytesWritten = done;
+        }
+    }
+
+    void WriteAllFwrite(FILE* fp, std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
+    {
+        const auto* bytes = static_cast<const std::uint8_t*>(pv);
+        std::uint64_t done = 0;
+        while (done < size)
+        {
+#if defined(_WIN32)
+            if (_fseeki64(fp, offset + done, SEEK_SET) != 0)
+#else
+            if (fseeko(fp, offset + done, SEEK_SET) != 0)
+#endif
+            {
+                const auto err = errno;
+                ostringstream ss;
+                ss << "Seek to file-position " << (offset + done) << " failed, errno=" << err << ".";
+                throw runtime_error(ss.str());
+            }
+
+            const std::uint64_t remain = size - done;
+            const size_t chunk = static_cast<size_t>((std::min)(remain, kStreamWriteChunkMax));
+            const size_t w = fwrite(bytes + done, 1, chunk, fp);
+            if (w != chunk)
+            {
+                const auto err = errno;
+                ostringstream ss;
+                ss << "fwrite failed at offset " << (offset + done) << " (wrote " << w << " of " << chunk << " bytes, errno=" << err << ").";
+                throw runtime_error(ss.str());
+            }
+
+            done += w;
+        }
+
+        if (ptrBytesWritten != nullptr)
+        {
+            *ptrBytesWritten = done;
+        }
+    }
+}
 
 //----------------------------------------------------------------------------
 
@@ -55,19 +132,7 @@ COutputStreamImplPwrite::~COutputStreamImplPwrite()
 
 /*virtual*/void COutputStreamImplPwrite::Write(std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
 {
-    ssize_t bytesWritten = pwrite(this->fileDescriptor, pv, size, offset);
-    if (bytesWritten < 0)
-    {
-        auto err = errno;
-        std::stringstream ss;
-        ss << "Error reading from file (errno=" << err << " -> " << strerror(err) << ")";
-        throw std::runtime_error(ss.str());
-    }
-
-    if (ptrBytesWritten != nullptr)
-    {
-        *ptrBytesWritten = bytesWritten;
-    }
+    WriteAllPwrite(this->fileDescriptor, offset, pv, size, ptrBytesWritten);
 }
 #endif
 
@@ -231,25 +296,7 @@ CSimpleOutputStreamStreams::~CSimpleOutputStreamStreams()
 
 void CSimpleOutputStreamStreams::Write(std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
 {
-#if defined(_WIN32)
-    int r = _fseeki64(this->fp, offset, SEEK_SET);
-#else
-    int r = fseeko(this->fp, offset, SEEK_SET);
-#endif
-
-    if (r != 0)
-    {
-        const auto err = errno;
-        ostringstream ss;
-        ss << "Seek to file-position " << offset << " failed, errno=<<" << err << ".";
-        throw std::runtime_error(ss.str());
-    }
-
-    const std::uint64_t bytesRead = fwrite(pv, 1, (size_t)size, this->fp);
-    if (ptrBytesWritten != nullptr)
-    {
-        *ptrBytesWritten = bytesRead;
-    }
+    WriteAllFwrite(this->fp, offset, pv, size, ptrBytesWritten);
 }
 
 //-----------------------------------------------------------------------------
@@ -299,19 +346,7 @@ CInputOutputStreamImplPreadPwrite::~CInputOutputStreamImplPreadPwrite()
 
 /*virtual*/void CInputOutputStreamImplPreadPwrite::Write(std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
 {
-    ssize_t bytesWritten = pwrite(this->fileDescriptor, pv, size, offset);
-    if (bytesWritten < 0)
-    {
-        auto err = errno;
-        ostringstream ss;
-        ss << "Error reading from file (errno=" << err << " -> " << strerror(err) << ")";
-        throw std::runtime_error(ss.str());
-    }
-
-    if (ptrBytesWritten != nullptr)
-    {
-        *ptrBytesWritten = bytesWritten;
-    }
+    WriteAllPwrite(this->fileDescriptor, offset, pv, size, ptrBytesWritten);
 }
 #endif
 
@@ -433,25 +468,7 @@ CSimpleInputOutputStreamImpl::~CSimpleInputOutputStreamImpl()
 
 void CSimpleInputOutputStreamImpl::Write(std::uint64_t offset, const void* pv, std::uint64_t size, std::uint64_t* ptrBytesWritten)
 {
-#if defined(_WIN32)
-    int r = _fseeki64(this->fp, offset, SEEK_SET);
-#else
-    int r = fseeko(this->fp, offset, SEEK_SET);
-#endif
-
-    if (r != 0)
-    {
-        const auto err = errno;
-        ostringstream ss;
-        ss << "Seek to file-position " << offset << " failed, errno=<<" << err << ".";
-        throw std::runtime_error(ss.str());
-    }
-
-    const std::uint64_t bytesRead = fwrite(pv, 1, (size_t)size, this->fp);
-    if (ptrBytesWritten != nullptr)
-    {
-        *ptrBytesWritten = bytesRead;
-    }
+    WriteAllFwrite(this->fp, offset, pv, size, ptrBytesWritten);
 }
 
 /*virtual*/void CSimpleInputOutputStreamImpl::Read(std::uint64_t offset, void* pv, std::uint64_t size, std::uint64_t* ptrBytesRead)

--- a/Src/libCZI/decoder_jxl.cpp
+++ b/Src/libCZI/decoder_jxl.cpp
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "decoder_jxl.h"
+
+#if LIBCZI_HAVE_LIBJXL
+
+#include "bitmapData.h"
+#include "BitmapOperations.h"
+#include "inc_libCZI_Config.h"
+#include "libCZI_Utilities.h"
+#include "Site.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include <jxl/decode.h>
+#include <jxl/types.h>
+
+using namespace libCZI;
+using namespace libCZI::detail;
+using namespace std;
+
+namespace
+{
+    void ThrowIfBigEndianHost()
+    {
+#if LIBCZI_ISBIGENDIANHOST
+        throw runtime_error("JPEG XL subblock decompression is not supported on big-endian hosts.");
+#endif
+    }
+
+    static JxlPixelFormat OutFormatForPixelType(PixelType pt)
+    {
+        JxlPixelFormat fmt{};
+        fmt.endianness = JXL_NATIVE_ENDIAN;
+        fmt.align = 0;
+        switch (pt)
+        {
+        case PixelType::Gray8:
+            fmt.num_channels = 1;
+            fmt.data_type = JXL_TYPE_UINT8;
+            break;
+        case PixelType::Gray16:
+            fmt.num_channels = 1;
+            fmt.data_type = JXL_TYPE_UINT16;
+            break;
+        case PixelType::Gray32Float:
+            fmt.num_channels = 1;
+            fmt.data_type = JXL_TYPE_FLOAT;
+            break;
+        case PixelType::Bgr24:
+            fmt.num_channels = 3;
+            fmt.data_type = JXL_TYPE_UINT8;
+            break;
+        case PixelType::Bgr48:
+            fmt.num_channels = 3;
+            fmt.data_type = JXL_TYPE_UINT16;
+            break;
+        case PixelType::Bgr96Float:
+            fmt.num_channels = 3;
+            fmt.data_type = JXL_TYPE_FLOAT;
+            break;
+        default:
+            throw logic_error("unsupported pixel type for JXL decode");
+        }
+
+        return fmt;
+    }
+
+    static void CopyPackedToBitmap(const uint8_t* packed, size_t row_bytes, uint32_t height, const shared_ptr<IBitmapData>& bitmap)
+    {
+        ScopedBitmapLockerSP locker(bitmap);
+        for (uint32_t y = 0; y < height; ++y)
+        {
+            memcpy(
+                static_cast<uint8_t*>(locker.ptrDataRoi) + static_cast<size_t>(y) * locker.stride,
+                packed + static_cast<size_t>(y) * row_bytes,
+                row_bytes);
+        }
+    }
+
+    static void SwapRgbToBgrInPlace(PixelType pt, void* ptr, uint32_t width, uint32_t height, uint32_t stride_bytes)
+    {
+        switch (pt)
+        {
+        case PixelType::Bgr24:
+        {
+            auto* p = static_cast<uint8_t*>(ptr);
+            for (uint32_t y = 0; y < height; ++y)
+            {
+                uint8_t* row = p + static_cast<size_t>(y) * stride_bytes;
+                for (uint32_t x = 0; x < width; ++x)
+                {
+                    uint8_t* px = row + x * 3;
+                    std::swap(px[0], px[2]);
+                }
+            }
+            break;
+        }
+        case PixelType::Bgr48:
+            CBitmapOperations::RGB48ToBGR48(
+                width,
+                height,
+                static_cast<uint16_t*>(ptr),
+                stride_bytes);
+            break;
+        case PixelType::Bgr96Float:
+        {
+            auto* p = static_cast<uint8_t*>(ptr);
+            for (uint32_t y = 0; y < height; ++y)
+            {
+                float* row = reinterpret_cast<float*>(p + static_cast<size_t>(y) * stride_bytes);
+                for (uint32_t x = 0; x < width; ++x)
+                {
+                    float* px = row + x * 3;
+                    std::swap(px[0], px[2]);
+                }
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+}
+
+/*static*/ std::shared_ptr<CJxlDecoder> CJxlDecoder::Create()
+{
+    return make_shared<CJxlDecoder>();
+}
+
+std::shared_ptr<IBitmapData> CJxlDecoder::Decode(
+    const void* ptr_data,
+    size_t size,
+    const PixelType* pixel_type,
+    const uint32_t* width,
+    const uint32_t* height,
+    const char* additional_arguments)
+{
+    (void)additional_arguments;
+    ThrowIfBigEndianHost();
+
+    if (pixel_type == nullptr || width == nullptr || height == nullptr)
+    {
+        throw invalid_argument("JXL decoder requires pixel type, width and height");
+    }
+
+    const size_t row_bytes = static_cast<size_t>(*width) * static_cast<size_t>(Utils::GetBytesPerPixel(*pixel_type));
+    const size_t expected_bytes = row_bytes * static_cast<size_t>(*height);
+    vector<uint8_t> decode_buffer(expected_bytes);
+    JxlPixelFormat out_fmt = OutFormatForPixelType(*pixel_type);
+
+    unique_ptr<JxlDecoder, void (*)(JxlDecoder*)> dec(JxlDecoderCreate(nullptr), JxlDecoderDestroy);
+    if (dec == nullptr)
+    {
+        throw runtime_error("JxlDecoderCreate failed");
+    }
+
+    /* Only informative events (>= 0x40); low bits like JXL_DEC_NEED_IMAGE_OUT_BUFFER are invalid here. */
+    const JxlDecoderStatus sub_st = JxlDecoderSubscribeEvents(
+        dec.get(),
+        JXL_DEC_BASIC_INFO | JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE);
+    if (sub_st != JXL_DEC_SUCCESS)
+    {
+        stringstream ss;
+        ss << "JxlDecoderSubscribeEvents failed: " << static_cast<int>(sub_st);
+        throw runtime_error(ss.str());
+    }
+
+    if (JxlDecoderSetInput(dec.get(), static_cast<const uint8_t*>(ptr_data), size) != JXL_DEC_SUCCESS)
+    {
+        throw runtime_error("JxlDecoderSetInput failed");
+    }
+
+    JxlDecoderCloseInput(dec.get());
+
+    shared_ptr<IBitmapData> bitmap = CStdBitmapData::Create(*pixel_type, *width, *height);
+
+    bool set_out_buffer = false;
+
+    for (;;)
+    {
+        const JxlDecoderStatus st = JxlDecoderProcessInput(dec.get());
+        if (st == JXL_DEC_ERROR)
+        {
+            throw runtime_error("JXL decode error");
+        }
+
+        if (st == JXL_DEC_BASIC_INFO)
+        {
+            JxlBasicInfo info;
+            if (JxlDecoderGetBasicInfo(dec.get(), &info) != JXL_DEC_SUCCESS)
+            {
+                throw runtime_error("JxlDecoderGetBasicInfo failed");
+            }
+
+            if (info.xsize != *width || info.ysize != *height)
+            {
+                stringstream ss;
+                ss << "JXL dimension mismatch: expected " << *width << "x" << *height << ", got " << info.xsize << "x" << info.ysize;
+                throw logic_error(ss.str());
+            }
+
+            continue;
+        }
+
+        if (st == JXL_DEC_FRAME)
+        {
+            continue;
+        }
+
+        if (st == JXL_DEC_NEED_IMAGE_OUT_BUFFER)
+        {
+            size_t need_buffer_size = 0;
+            if (JxlDecoderImageOutBufferSize(dec.get(), &out_fmt, &need_buffer_size) != JXL_DEC_SUCCESS)
+            {
+                throw runtime_error("JxlDecoderImageOutBufferSize failed");
+            }
+
+            if (need_buffer_size != expected_bytes)
+            {
+                stringstream ss;
+                ss << "JXL output buffer size mismatch: expected " << expected_bytes << ", got " << need_buffer_size;
+                throw logic_error(ss.str());
+            }
+
+            if (JxlDecoderSetImageOutBuffer(dec.get(), &out_fmt, decode_buffer.data(), decode_buffer.size()) != JXL_DEC_SUCCESS)
+            {
+                throw runtime_error("JxlDecoderSetImageOutBuffer failed");
+            }
+
+            set_out_buffer = true;
+            continue;
+        }
+
+        if (st == JXL_DEC_FULL_IMAGE)
+        {
+            break;
+        }
+
+        if (st == JXL_DEC_SUCCESS)
+        {
+            break;
+        }
+
+        if (st == JXL_DEC_NEED_MORE_INPUT)
+        {
+            throw runtime_error("JXL decode: unexpected need for more input");
+        }
+
+        stringstream ss;
+        ss << "JXL decode: unexpected decoder status " << static_cast<int>(st);
+        throw runtime_error(ss.str());
+    }
+
+    if (!set_out_buffer)
+    {
+        throw runtime_error("JXL decode: output buffer was never requested");
+    }
+
+    CopyPackedToBitmap(decode_buffer.data(), row_bytes, *height, bitmap);
+    {
+        ScopedBitmapLockerSP locker(bitmap);
+        SwapRgbToBgrInPlace(*pixel_type, locker.ptrDataRoi, *width, *height, locker.stride);
+    }
+
+    return bitmap;
+}
+
+#endif

--- a/Src/libCZI/decoder_jxl.h
+++ b/Src/libCZI/decoder_jxl.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "inc_libCZI_Config.h"
+
+#if LIBCZI_HAVE_LIBJXL
+
+#include <memory>
+#include "libCZI_Site.h"
+
+namespace libCZI
+{
+    namespace detail
+    {
+        class CJxlDecoder : public libCZI::IDecoder
+        {
+        public:
+            static std::shared_ptr<CJxlDecoder> Create();
+
+            std::shared_ptr<libCZI::IBitmapData> Decode(const void* ptrData, size_t size, const libCZI::PixelType* pixelType, const std::uint32_t* width, const std::uint32_t* height, const char* additional_arguments) override;
+
+            std::shared_ptr<libCZI::IBitmapData> Decode(const void* ptrData, size_t size, libCZI::PixelType pixelType, std::uint32_t width, std::uint32_t height, const char* additional_arguments = nullptr)
+            {
+                return this->Decode(ptrData, size, &pixelType, &width, &height, additional_arguments);
+            }
+        };
+    }
+}
+
+#endif

--- a/Src/libCZI/jxlCompress.cpp
+++ b/Src/libCZI/jxlCompress.cpp
@@ -1,0 +1,475 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "libCZI_compress.h"
+#include "inc_libCZI_Config.h"
+#include "libCZI_Utilities.h"
+
+#if LIBCZI_HAVE_LIBJXL
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include <jxl/color_encoding.h>
+#include <jxl/encode.h>
+#include <jxl/types.h>
+
+using namespace libCZI;
+using namespace std;
+
+namespace
+{
+    class MemoryBlockOnVector : public IMemoryBlock
+    {
+        vector<uint8_t> data_;
+    public:
+        explicit MemoryBlockOnVector(vector<uint8_t>&& d)
+            : data_(std::move(d))
+        {
+        }
+
+        void* GetPtr() override
+        {
+            return this->data_.empty() ? nullptr : this->data_.data();
+        }
+
+        size_t GetSizeOfData() const override
+        {
+            return this->data_.size();
+        }
+    };
+
+    static void ThrowIfBigEndianHost()
+    {
+#if LIBCZI_ISBIGENDIANHOST
+        throw runtime_error("JPEG XL subblock compression is not supported on big-endian hosts.");
+#endif
+    }
+
+    static size_t MinStrideBytes(PixelType pt, uint32_t width)
+    {
+        return static_cast<size_t>(width) * static_cast<size_t>(Utils::GetBytesPerPixel(pt));
+    }
+
+    static void CopyRowsToPacked(const void* src, uint32_t src_stride, uint32_t width, uint32_t height, size_t row_bytes, void* dst)
+    {
+        auto* d = static_cast<uint8_t*>(dst);
+        const auto* s = static_cast<const uint8_t*>(src);
+        for (uint32_t y = 0; y < height; ++y)
+        {
+            memcpy(d + static_cast<size_t>(y) * row_bytes, s + static_cast<size_t>(y) * src_stride, row_bytes);
+        }
+    }
+
+    static void Bgr24ToRgb24Packed(const void* src, uint32_t src_stride, uint32_t width, uint32_t height, uint8_t* dst_rgb)
+    {
+        for (uint32_t y = 0; y < height; ++y)
+        {
+            const auto* row = static_cast<const uint8_t*>(src) + static_cast<size_t>(y) * src_stride;
+            uint8_t* d = dst_rgb + static_cast<size_t>(y) * width * 3;
+            for (uint32_t x = 0; x < width; ++x)
+            {
+                d[0] = row[2];
+                d[1] = row[1];
+                d[2] = row[0];
+                row += 3;
+                d += 3;
+            }
+        }
+    }
+
+    static void Bgr48ToRgb48Packed(const void* src, uint32_t src_stride, uint32_t width, uint32_t height, uint16_t* dst_rgb)
+    {
+        for (uint32_t y = 0; y < height; ++y)
+        {
+            const auto* row = static_cast<const uint8_t*>(src) + static_cast<size_t>(y) * src_stride;
+            uint16_t* d = dst_rgb + static_cast<size_t>(y) * width * 3;
+            for (uint32_t x = 0; x < width; ++x)
+            {
+                const auto* p = reinterpret_cast<const uint16_t*>(row);
+                d[0] = p[2];
+                d[1] = p[1];
+                d[2] = p[0];
+                row += 6;
+                d += 3;
+            }
+        }
+    }
+
+    static void Bgr96FloatToRgb96Packed(const void* src, uint32_t src_stride, uint32_t width, uint32_t height, float* dst_rgb)
+    {
+        for (uint32_t y = 0; y < height; ++y)
+        {
+            const auto* row = static_cast<const uint8_t*>(src) + static_cast<size_t>(y) * src_stride;
+            float* d = dst_rgb + static_cast<size_t>(y) * width * 3;
+            for (uint32_t x = 0; x < width; ++x)
+            {
+                const auto* p = reinterpret_cast<const float*>(row);
+                d[0] = p[2];
+                d[1] = p[1];
+                d[2] = p[0];
+                row += 12;
+                d += 3;
+            }
+        }
+    }
+
+    static void FillBasicInfoForPixelType(PixelType pt, uint32_t width, uint32_t height, JxlBasicInfo* bi)
+    {
+        memset(bi, 0, sizeof(*bi));
+        JxlEncoderInitBasicInfo(bi);
+        bi->xsize = width;
+        bi->ysize = height;
+        bi->num_extra_channels = 0;
+        bi->alpha_bits = 0;
+        bi->orientation = JXL_ORIENT_IDENTITY;
+        bi->have_container = JXL_FALSE;
+        /* Required for JxlEncoderSetFrameLossless when basic info implies XYB. */
+        bi->uses_original_profile = JXL_TRUE;
+
+        switch (pt)
+        {
+        case PixelType::Gray8:
+            bi->bits_per_sample = 8;
+            bi->exponent_bits_per_sample = 0;
+            bi->num_color_channels = 1;
+            break;
+        case PixelType::Gray16:
+            bi->bits_per_sample = 16;
+            bi->exponent_bits_per_sample = 0;
+            bi->num_color_channels = 1;
+            break;
+        case PixelType::Gray32Float:
+            bi->bits_per_sample = 32;
+            bi->exponent_bits_per_sample = 8;
+            bi->num_color_channels = 1;
+            break;
+        case PixelType::Bgr24:
+            bi->bits_per_sample = 8;
+            bi->exponent_bits_per_sample = 0;
+            bi->num_color_channels = 3;
+            break;
+        case PixelType::Bgr48:
+            bi->bits_per_sample = 16;
+            bi->exponent_bits_per_sample = 0;
+            bi->num_color_channels = 3;
+            break;
+        case PixelType::Bgr96Float:
+            bi->bits_per_sample = 32;
+            bi->exponent_bits_per_sample = 8;
+            bi->num_color_channels = 3;
+            break;
+        default:
+            throw logic_error("unsupported pixel type for JXL");
+        }
+    }
+
+    static void SetColorEncodingForPixelType(PixelType pt, JxlColorEncoding* color)
+    {
+        switch (pt)
+        {
+        case PixelType::Gray8:
+        case PixelType::Gray16:
+        case PixelType::Bgr24:
+        case PixelType::Bgr48:
+            JxlColorEncodingSetToSRGB(color, (pt == PixelType::Gray8 || pt == PixelType::Gray16) ? JXL_TRUE : JXL_FALSE);
+            break;
+        case PixelType::Gray32Float:
+        case PixelType::Bgr96Float:
+            JxlColorEncodingSetToLinearSRGB(color, (pt == PixelType::Gray32Float) ? JXL_TRUE : JXL_FALSE);
+            break;
+        default:
+            throw logic_error("unsupported pixel type for JXL");
+        }
+    }
+
+    static JxlPixelFormat PixelFormatFor(PixelType pt)
+    {
+        JxlPixelFormat fmt{};
+        fmt.endianness = JXL_NATIVE_ENDIAN;
+        fmt.align = 0;
+        switch (pt)
+        {
+        case PixelType::Gray8:
+        case PixelType::Bgr24:
+            fmt.num_channels = (pt == PixelType::Gray8) ? 1u : 3u;
+            fmt.data_type = JXL_TYPE_UINT8;
+            break;
+        case PixelType::Gray16:
+        case PixelType::Bgr48:
+            fmt.num_channels = (pt == PixelType::Gray16) ? 1u : 3u;
+            fmt.data_type = JXL_TYPE_UINT16;
+            break;
+        case PixelType::Gray32Float:
+        case PixelType::Bgr96Float:
+            fmt.num_channels = (pt == PixelType::Gray32Float) ? 1u : 3u;
+            fmt.data_type = JXL_TYPE_FLOAT;
+            break;
+        default:
+            throw logic_error("unsupported pixel type for JXL");
+        }
+
+        return fmt;
+    }
+
+    static void PreparePackedPixels(
+        PixelType pt,
+        const void* ptr_data,
+        uint32_t stride,
+        uint32_t width,
+        uint32_t height,
+        vector<uint8_t>* packed,
+        JxlPixelFormat* fmt)
+    {
+        const size_t row_b = MinStrideBytes(pt, width);
+        const size_t total = row_b * height;
+        packed->resize(total);
+        *fmt = PixelFormatFor(pt);
+
+        switch (pt)
+        {
+        case PixelType::Gray8:
+        case PixelType::Gray16:
+        case PixelType::Gray32Float:
+            CopyRowsToPacked(ptr_data, stride, width, height, row_b, packed->data());
+            break;
+        case PixelType::Bgr24:
+            Bgr24ToRgb24Packed(ptr_data, stride, width, height, packed->data());
+            break;
+        case PixelType::Bgr48:
+            Bgr48ToRgb48Packed(ptr_data, stride, width, height, reinterpret_cast<uint16_t*>(packed->data()));
+            break;
+        case PixelType::Bgr96Float:
+            Bgr96FloatToRgb96Packed(ptr_data, stride, width, height, reinterpret_cast<float*>(packed->data()));
+            break;
+        default:
+            throw logic_error("unsupported pixel type for JXL");
+        }
+    }
+
+    static void CheckJxlEnc(JxlEncoderStatus st, const char* what)
+    {
+        if (st != JXL_ENC_SUCCESS)
+        {
+            stringstream ss;
+            ss << what << " failed with status " << static_cast<int>(st);
+            throw runtime_error(ss.str());
+        }
+    }
+
+    int ClampInt(int v, int lo, int hi)
+    {
+        if (v < lo)
+        {
+            return lo;
+        }
+
+        if (v > hi)
+        {
+            return hi;
+        }
+
+        return v;
+    }
+
+    int ReadEffort(const ICompressParameters* parameters)
+    {
+        CompressParameter c;
+        if (parameters != nullptr && parameters->TryGetProperty(CompressionParameterKey::JXL_EFFORT, &c))
+        {
+            if (c.GetType() == CompressParameter::Type::Int32)
+            {
+                return ClampInt(c.GetInt32(), 1, 9);
+            }
+
+            if (c.GetType() == CompressParameter::Type::Uint32)
+            {
+                return ClampInt(static_cast<int>(c.GetUInt32()), 1, 9);
+            }
+        }
+
+        return 7;
+    }
+
+    bool ReadModular(const ICompressParameters* parameters)
+    {
+        CompressParameter c;
+        if (parameters != nullptr && parameters->TryGetProperty(CompressionParameterKey::JXL_MODULAR, &c)
+            && c.GetType() == CompressParameter::Type::Boolean)
+        {
+            return c.GetBoolean();
+        }
+
+        return true;
+    }
+
+    bool TryReadClampedInt32(
+        const ICompressParameters* parameters,
+        CompressionParameterKey key,
+        int lo,
+        int hi,
+        int* out)
+    {
+        CompressParameter c;
+        if (parameters == nullptr || !parameters->TryGetProperty(key, &c))
+        {
+            return false;
+        }
+
+        if (c.GetType() == CompressParameter::Type::Int32)
+        {
+            *out = ClampInt(c.GetInt32(), lo, hi);
+            return true;
+        }
+
+        if (c.GetType() == CompressParameter::Type::Uint32)
+        {
+            *out = ClampInt(static_cast<int>(c.GetUInt32()), lo, hi);
+            return true;
+        }
+
+        return false;
+    }
+
+    void ApplyJxlFrameSettings(JxlEncoderFrameSettings* fs, const ICompressParameters* parameters)
+    {
+        const int effort = ReadEffort(parameters);
+        CheckJxlEnc(JxlEncoderFrameSettingsSetOption(fs, JXL_ENC_FRAME_SETTING_EFFORT, effort), "JXL_ENC_FRAME_SETTING_EFFORT");
+
+        const bool modular = ReadModular(parameters);
+        CheckJxlEnc(
+            JxlEncoderFrameSettingsSetOption(fs, JXL_ENC_FRAME_SETTING_MODULAR, modular ? 1 : 0),
+            "JXL_ENC_FRAME_SETTING_MODULAR");
+
+        int decodingSpeed;
+        if (TryReadClampedInt32(parameters, CompressionParameterKey::JXL_DECODING_SPEED, 0, 4, &decodingSpeed))
+        {
+            CheckJxlEnc(
+                JxlEncoderFrameSettingsSetOption(fs, JXL_ENC_FRAME_SETTING_DECODING_SPEED, decodingSpeed),
+                "JXL_ENC_FRAME_SETTING_DECODING_SPEED");
+        }
+
+        int responsive;
+        if (TryReadClampedInt32(parameters, CompressionParameterKey::JXL_RESPONSIVE, 0, 2, &responsive))
+        {
+            CheckJxlEnc(
+                JxlEncoderFrameSettingsSetOption(fs, JXL_ENC_FRAME_SETTING_RESPONSIVE, responsive),
+                "JXL_ENC_FRAME_SETTING_RESPONSIVE");
+        }
+    }
+}
+
+/*static*/ std::shared_ptr<IMemoryBlock> JxlLibCompress::Compress(
+    PixelType pixel_type,
+    uint32_t width,
+    uint32_t height,
+    uint32_t stride,
+    const void* ptr_data,
+    const ICompressParameters* parameters)
+{
+    ThrowIfBigEndianHost();
+
+    switch (pixel_type)
+    {
+    case PixelType::Gray8:
+    case PixelType::Gray16:
+    case PixelType::Gray32Float:
+    case PixelType::Bgr24:
+    case PixelType::Bgr48:
+    case PixelType::Bgr96Float:
+        break;
+    default:
+        throw logic_error("unsupported pixel type for JXL");
+    }
+
+    JxlBasicInfo basic_info;
+    FillBasicInfoForPixelType(pixel_type, width, height, &basic_info);
+
+    JxlColorEncoding color_encoding;
+    memset(&color_encoding, 0, sizeof(color_encoding));
+    SetColorEncodingForPixelType(pixel_type, &color_encoding);
+
+    vector<uint8_t> packed;
+    JxlPixelFormat pixel_format;
+    PreparePackedPixels(pixel_type, ptr_data, stride, width, height, &packed, &pixel_format);
+
+    unique_ptr<JxlEncoder, void (*)(JxlEncoder*)> enc(JxlEncoderCreate(nullptr), JxlEncoderDestroy);
+    if (enc == nullptr)
+    {
+        throw runtime_error("JxlEncoderCreate failed");
+    }
+
+    CheckJxlEnc(JxlEncoderUseContainer(enc.get(), JXL_FALSE), "JxlEncoderUseContainer");
+    CheckJxlEnc(JxlEncoderSetBasicInfo(enc.get(), &basic_info), "JxlEncoderSetBasicInfo");
+    CheckJxlEnc(JxlEncoderSetColorEncoding(enc.get(), &color_encoding), "JxlEncoderSetColorEncoding");
+
+    const int required_codestream_level = JxlEncoderGetRequiredCodestreamLevel(enc.get());
+    if (required_codestream_level == -1)
+    {
+        throw runtime_error("JxlEncoderGetRequiredCodestreamLevel: no valid codestream level for this configuration");
+    }
+
+    if (required_codestream_level == 10)
+    {
+        CheckJxlEnc(JxlEncoderSetCodestreamLevel(enc.get(), 10), "JxlEncoderSetCodestreamLevel(10)");
+    }
+    else
+    {
+        CheckJxlEnc(JxlEncoderSetCodestreamLevel(enc.get(), 5), "JxlEncoderSetCodestreamLevel(5)");
+    }
+
+    JxlEncoderFrameSettings* fs = JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
+    if (fs == nullptr)
+    {
+        throw runtime_error("JxlEncoderFrameSettingsCreate failed");
+    }
+
+    CheckJxlEnc(JxlEncoderSetFrameLossless(fs, JXL_TRUE), "JxlEncoderSetFrameLossless");
+    ApplyJxlFrameSettings(fs, parameters);
+
+    const size_t frame_size = packed.size();
+    CheckJxlEnc(JxlEncoderAddImageFrame(fs, &pixel_format, packed.data(), frame_size), "JxlEncoderAddImageFrame");
+
+    JxlEncoderCloseInput(enc.get());
+
+    vector<uint8_t> compressed(4096);
+    size_t used = 0;
+    for (;;)
+    {
+        uint8_t* next = compressed.data() + used;
+        size_t avail = compressed.size() - used;
+        if (avail < 32)
+        {
+            compressed.resize(max(compressed.size() * 2, used + 4096));
+            continue;
+        }
+
+        JxlEncoderStatus pr = JxlEncoderProcessOutput(enc.get(), &next, &avail);
+        used = static_cast<size_t>(next - compressed.data());
+        if (pr == JXL_ENC_NEED_MORE_OUTPUT)
+        {
+            compressed.resize(max(compressed.size() * 2, used + 4096));
+            continue;
+        }
+
+        if (pr != JXL_ENC_SUCCESS)
+        {
+            stringstream ss;
+            ss << "JxlEncoderProcessOutput failed: " << static_cast<int>(pr);
+            throw runtime_error(ss.str());
+        }
+
+        break;
+    }
+
+    compressed.resize(used);
+    return make_shared<MemoryBlockOnVector>(std::move(compressed));
+}
+
+#endif

--- a/Src/libCZI/libCZI_Config.h.in
+++ b/Src/libCZI/libCZI_Config.h.in
@@ -66,3 +66,6 @@
 
 // whether the function "bswap32" is available (in the header-file sys/endian.h)
 #define LIBCZI_HAS_BSWAP_LONG_IN_SYS_ENDIAN @libCZI_Has_bswap_long_in_sys_endian@
+
+// whether libjxl is available for JPEG XL (provisional CZI compression id 7) encode/decode
+#define LIBCZI_HAVE_LIBJXL @libCZI_have_libjxl@

--- a/Src/libCZI/libCZI_Pixels.h
+++ b/Src/libCZI/libCZI_Pixels.h
@@ -167,7 +167,8 @@ namespace libCZI
         Jpg = 1,            ///< The data is JPG-compressed.
         JpgXr = 4,          ///< The data is JPG-XR-compressed.
         Zstd0 = 5,          ///< The data is compressed with zstd.
-        Zstd1 = 6           ///< The data contains a header, followed by a zstd-compressed block. 
+        Zstd1 = 6,          ///< The data contains a header, followed by a zstd-compressed block.
+        Jxl = 7             ///< JPEG XL lossless (raw CZI compression id 7, provisional / experimental). Requires libjxl at build time.
     };
 
     /// This enum is used in the context of a subblock to describe which "type of pyramid" is represented by the subblock.

--- a/Src/libCZI/libCZI_Site.cpp
+++ b/Src/libCZI/libCZI_Site.cpp
@@ -6,6 +6,9 @@
 #include "inc_libCZI_Config.h"
 #include "decoder.h"
 #include "decoder_zstd.h"
+#if LIBCZI_HAVE_LIBJXL
+#include "decoder_jxl.h"
+#endif
 #include <mutex>
 #include <cstdlib>
 #include "bitmapData.h"
@@ -66,6 +69,10 @@ private:
     std::shared_ptr<IDecoder> zstd0decoder;
     std::once_flag  zstd1DecoderInitialized;
     std::shared_ptr<IDecoder> zstd1decoder;
+#if LIBCZI_HAVE_LIBJXL
+    std::once_flag jxlDecoderInitialized;
+    std::shared_ptr<IDecoder> jxldecoder;
+#endif
 public:
     std::shared_ptr<IDecoder> GetDecoder(ImageDecoderType type, const char* arguments) override
     {
@@ -83,6 +90,18 @@ public:
 
             return this->jpgXrdecoder;
         }
+#if LIBCZI_HAVE_LIBJXL
+        case ImageDecoderType::JXL:
+        {
+            std::call_once(jxlDecoderInitialized,
+                [this]()
+                {
+                    this->jxldecoder = CJxlDecoder::Create();
+                });
+
+            return this->jxldecoder;
+        }
+#endif
         case ImageDecoderType::ZStd0:
         {
             std::call_once(zstd0DecoderInitialized,
@@ -119,6 +138,10 @@ private:
     std::shared_ptr<IDecoder> zstd0decoder;
     std::once_flag  zstd1DecoderInitialized;
     std::shared_ptr<IDecoder> zstd1decoder;
+#if LIBCZI_HAVE_LIBJXL
+    std::once_flag jxlDecoderInitialized;
+    std::shared_ptr<IDecoder> jxldecoder;
+#endif
 public:
     std::shared_ptr<IDecoder> GetDecoder(ImageDecoderType type, const char* arguments) override
     {
@@ -136,6 +159,18 @@ public:
 
             return this->jpgXrdecoder;
         }
+#if LIBCZI_HAVE_LIBJXL
+        case ImageDecoderType::JXL:
+        {
+            std::call_once(jxlDecoderInitialized,
+                [this]()
+                {
+                    this->jxldecoder = CJxlDecoder::Create();
+                });
+
+            return this->jxldecoder;
+        }
+#endif
         case ImageDecoderType::ZStd0:
         {
             std::call_once(zstd0DecoderInitialized,

--- a/Src/libCZI/libCZI_Site.h
+++ b/Src/libCZI/libCZI_Site.h
@@ -19,7 +19,9 @@ namespace libCZI
 
         ZStd0,          ///< Identifies a decoder capable of decoding a zstd compressed image (type "zstd0").
 
-        ZStd1           ///< Identifies a decoder capable of decoding a zstd compressed image (type "zstd1").
+        ZStd1,          ///< Identifies a decoder capable of decoding a zstd compressed image (type "zstd1").
+
+        JXL             ///< Identifies a decoder capable of decoding a JPEG XL compressed image (provisional CZI id 7).
     };
 
     class IBitmapData;

--- a/Src/libCZI/libCZI_Utilities.cpp
+++ b/Src/libCZI/libCZI_Utilities.cpp
@@ -29,7 +29,8 @@ namespace
             libCZI::CompressionMode::Jpg,
             libCZI::CompressionMode::JpgXr,
             libCZI::CompressionMode::Zstd0,
-            libCZI::CompressionMode::Zstd1
+            libCZI::CompressionMode::Zstd1,
+            libCZI::CompressionMode::Jxl
         };
 
         for (const auto& compressionMode : AvailableCompressionModes)
@@ -43,6 +44,31 @@ namespace
 
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    bool tryParseBoolish(const string& value, bool* out)
+    {
+        if (Utilities::icasecmp(value, "true") || value == "1" || Utilities::icasecmp(value, "yes"))
+        {
+            if (out != nullptr)
+            {
+                *out = true;
+            }
+
+            return true;
+        }
+
+        if (Utilities::icasecmp(value, "false") || value == "0" || Utilities::icasecmp(value, "no"))
+        {
+            if (out != nullptr)
+            {
+                *out = false;
+            }
+
+            return true;
         }
 
         return false;
@@ -98,6 +124,94 @@ namespace
                         }
                     }
                 }
+                else if (Utilities::icasecmp(key, Utils::KEY_JXL_EFFORT))
+                {
+                    size_t indexParsingStopped;
+                    try
+                    {
+                        const int i = stoi(value, &indexParsingStopped);
+                        if (value[indexParsingStopped] != '\0')
+                        {
+                            return false;
+                        }
+
+                        if (map != nullptr)
+                        {
+                            (*map)[static_cast<int>(libCZI::CompressionParameterKey::JXL_EFFORT)] = libCZI::CompressParameter(static_cast<std::int32_t>(i));
+                        }
+                    }
+                    catch (invalid_argument&)
+                    {
+                        return false;
+                    }
+                    catch (out_of_range&)
+                    {
+                        return false;
+                    }
+                }
+                else if (Utilities::icasecmp(key, Utils::KEY_JXL_MODULAR))
+                {
+                    bool b;
+                    if (!tryParseBoolish(value, &b))
+                    {
+                        return false;
+                    }
+
+                    if (map != nullptr)
+                    {
+                        (*map)[static_cast<int>(libCZI::CompressionParameterKey::JXL_MODULAR)] = libCZI::CompressParameter(b);
+                    }
+                }
+                else if (Utilities::icasecmp(key, Utils::KEY_JXL_DECODING_SPEED))
+                {
+                    size_t indexParsingStopped;
+                    try
+                    {
+                        const int i = stoi(value, &indexParsingStopped);
+                        if (value[indexParsingStopped] != '\0')
+                        {
+                            return false;
+                        }
+
+                        if (map != nullptr)
+                        {
+                            (*map)[static_cast<int>(libCZI::CompressionParameterKey::JXL_DECODING_SPEED)] = libCZI::CompressParameter(static_cast<std::int32_t>(i));
+                        }
+                    }
+                    catch (invalid_argument&)
+                    {
+                        return false;
+                    }
+                    catch (out_of_range&)
+                    {
+                        return false;
+                    }
+                }
+                else if (Utilities::icasecmp(key, Utils::KEY_JXL_RESPONSIVE))
+                {
+                    size_t indexParsingStopped;
+                    try
+                    {
+                        const int i = stoi(value, &indexParsingStopped);
+                        if (value[indexParsingStopped] != '\0')
+                        {
+                            return false;
+                        }
+
+                        if (map != nullptr)
+                        {
+                            (*map)[static_cast<int>(libCZI::CompressionParameterKey::JXL_RESPONSIVE)] = libCZI::CompressParameter(static_cast<std::int32_t>(i));
+                        }
+                    }
+                    catch (invalid_argument&)
+                    {
+                        return false;
+                    }
+                    catch (out_of_range&)
+                    {
+                        return false;
+                    }
+                }
             }
         }
 
@@ -108,6 +222,10 @@ namespace
 const char* const Utils::KEY_COMPRESS_EXPLICIT_LEVEL = "ExplicitLevel";
 const char* const Utils::KEY_COMPRESS_PRE_PROCESS = "PreProcess";
 const char* const Utils::VALUE_COMPRESS_HILO_BYTE_UNPACK = "HiLoByteUnpack";
+const char* const Utils::KEY_JXL_EFFORT = "Effort";
+const char* const Utils::KEY_JXL_MODULAR = "Modular";
+const char* const Utils::KEY_JXL_DECODING_SPEED = "DecodingSpeed";
+const char* const Utils::KEY_JXL_RESPONSIVE = "Responsive";
 
 /*static*/char Utils::DimensionToChar(libCZI::DimensionIndex dim)
 {
@@ -468,6 +586,8 @@ std::vector<tOutput> InternalCreateLookUpTableFromGamma(int tableElementCnt, tFl
         return "zstd0";
     case CompressionMode::Zstd1:
         return "zstd1";
+    case CompressionMode::Jxl:
+        return "jxl";
     case CompressionMode::Invalid:
         return "invalid";
     }

--- a/Src/libCZI/libCZI_Utilities.h
+++ b/Src/libCZI/libCZI_Utilities.h
@@ -369,6 +369,12 @@ namespace libCZI
         //!             - Pixel type Gray48: Used       --> "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
         static const char* const VALUE_COMPRESS_HILO_BYTE_UNPACK /*= "HiLoByteUnpack"*/;
 
+        //! JPEG XL frame settings (used with \c jxl:... only). Example: \c "jxl:Effort=5;Modular=true;DecodingSpeed=0;Responsive=0"
+        static const char* const KEY_JXL_EFFORT /*= "Effort"*/;
+        static const char* const KEY_JXL_MODULAR /*= "Modular"*/;
+        static const char* const KEY_JXL_DECODING_SPEED /*= "DecodingSpeed"*/;
+        static const char* const KEY_JXL_RESPONSIVE /*= "Responsive"*/;
+
         //! Define a type for compression options. It is a pair where one parameter is compression mode
         //! and the others are compression parameters.
         using CompressionOption = std::pair<libCZI::CompressionMode, std::shared_ptr<libCZI::ICompressParameters>>;
@@ -378,7 +384,7 @@ namespace libCZI
         //! The format of the string representation is: "<compression_method>: key=value; ...". 
         //! It starts with the name of the compression-method, followed by a colon,
         //! then followed by a list of key-value pairs which are separated by a semicolon.
-        //! Examples: "zstd0:ExplicitLevel=3", "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
+        //! Examples: "zstd0:ExplicitLevel=3", "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack", "jxl:Effort=7;Modular=true"
         //! If parsing fails an excpetion of type "Logic_error" is thrown.
         static CompressionOption ParseCompressionOptions(const std::string& options);
 

--- a/Src/libCZI/libCZI_compress.h
+++ b/Src/libCZI/libCZI_compress.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <map>
 #include <type_traits>
+#include "inc_libCZI_Config.h"
 #include "libCZI.h"
 
 namespace libCZI
@@ -30,6 +31,20 @@ namespace libCZI
         /// gives the best quality (i.e. loss-less compression). This parameter is used with the "jxrlib" compression scheme only.
         /// If value is out-of-range, it will be clipped.
         JXRLIB_QUALITY = 3,
+
+        /// JPEG XL encoder effort (type: int32, clipped to 1..9). Used with \c CompressionMode::Jxl only.
+        /// Parsed from \c jxl:Effort=N in \c --compressionopts. Default when omitted is 7.
+        JXL_EFFORT = 4,
+
+        /// Use modular mode for the frame (type: boolean). Used with \c CompressionMode::Jxl only.
+        /// Parsed from \c jxl:Modular=true|false. Default when omitted is true (recommended with lossless).
+        JXL_MODULAR = 5,
+
+        /// \c JXL_ENC_FRAME_SETTING_DECODING_SPEED (type: int32, clipped to 0..4). Optional; when omitted the encoder default applies.
+        JXL_DECODING_SPEED = 6,
+
+        /// \c JXL_ENC_FRAME_SETTING_RESPONSIVE (type: int32, clipped to 0..2). Optional; when omitted the encoder default applies.
+        JXL_RESPONSIVE = 7,
     };
 
     /// Simple variant type used for the compression-parameters-property-bag.
@@ -550,6 +565,25 @@ namespace libCZI
             const void* ptrData,
             const ICompressParameters* parameters);
     };
+
+#if LIBCZI_HAVE_LIBJXL
+    /// JPEG XL lossless compression (raw CZI id 7, provisional). Requires \c LIBCZI_BUILD_WITH_LIBJXL.
+    class LIBCZI_API JxlLibCompress
+    {
+    public:
+        /// Compress the bitmap to a single-frame JPEG XL codestream suitable for a CZI subblock.
+        ///
+        /// \param  parameters  Optional \c ICompressParameters (see \c CompressionParameterKey values \c JXL_*).
+        ///                     Unrecognized keys are ignored; omitted keys use encoder defaults described on those keys.
+        static std::shared_ptr<IMemoryBlock> Compress(
+            libCZI::PixelType pixel_type,
+            std::uint32_t width,
+            std::uint32_t height,
+            std::uint32_t stride,
+            const void* ptrData,
+            const ICompressParameters* parameters);
+    };
+#endif
 
     /// Simplistic implementation of the compression-parameters property bag. Note that for high-performance scenarios
     /// it might be a good idea to re-use instances of this, or have a custom implementation without heap-allocation

--- a/Src/libCZI_UnitTests/CMakeLists.txt
+++ b/Src/libCZI_UnitTests/CMakeLists.txt
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+set(LIBCZI_UNITTESTS_JXL_SOURCES "")
+if (LIBCZI_BUILD_WITH_LIBJXL)
+  list(APPEND LIBCZI_UNITTESTS_JXL_SOURCES test_jxl.cpp)
+endif()
+
 ADD_EXECUTABLE(libCZI_UnitTests 
 										inc_libCZI.h
 										include_gtest.h
@@ -50,9 +55,11 @@ ADD_EXECUTABLE(libCZI_UnitTests
 										test_subblockmetadata.cpp 
 										test_subblockattachment.cpp
 										test_maskawarecomposition.cpp 
-										test_pixels.cpp)
+										test_pixels.cpp
+										${LIBCZI_UNITTESTS_JXL_SOURCES})
 
 TARGET_LINK_LIBRARIES(libCZI_UnitTests PRIVATE libCZIStatic GTest::gtest GTest::gmock)
+target_include_directories(libCZI_UnitTests PRIVATE "${CMAKE_BINARY_DIR}/Src/libCZI")
 set_target_properties(libCZI_UnitTests PROPERTIES CXX_STANDARD 14)
 
 target_compile_definitions(libCZI_UnitTests PRIVATE _LIBCZISTATICLIB)

--- a/Src/libCZI_UnitTests/test_Utilities.cpp
+++ b/Src/libCZI_UnitTests/test_Utilities.cpp
@@ -353,6 +353,39 @@ TEST(Utilities, ParseCompressionOptionEmptyPropertyBagCheckForCorrectCompression
     EXPECT_EQ(compressionOptions.first, CompressionMode::Zstd1);
 }
 
+TEST(Utilities, ParseCompressionOptionJxl)
+{
+    const auto compressionOptions = Utils::ParseCompressionOptions("jxl:");
+    EXPECT_EQ(compressionOptions.first, CompressionMode::Jxl);
+}
+
+TEST(Utilities, ParseCompressionOptionJxlWithFrameSettings)
+{
+    const auto compressionOptions = Utils::ParseCompressionOptions("jxl:Effort=3;Modular=false;DecodingSpeed=2;Responsive=1");
+    EXPECT_EQ(compressionOptions.first, CompressionMode::Jxl);
+    ASSERT_NE(compressionOptions.second, nullptr);
+    CompressParameter c;
+    ASSERT_TRUE(compressionOptions.second->TryGetProperty(CompressionParameterKey::JXL_EFFORT, &c));
+    EXPECT_EQ(c.GetType(), CompressParameter::Type::Int32);
+    EXPECT_EQ(c.GetInt32(), 3);
+    ASSERT_TRUE(compressionOptions.second->TryGetProperty(CompressionParameterKey::JXL_MODULAR, &c));
+    EXPECT_EQ(c.GetType(), CompressParameter::Type::Boolean);
+    EXPECT_FALSE(c.GetBoolean());
+    ASSERT_TRUE(compressionOptions.second->TryGetProperty(CompressionParameterKey::JXL_DECODING_SPEED, &c));
+    EXPECT_EQ(c.GetInt32(), 2);
+    ASSERT_TRUE(compressionOptions.second->TryGetProperty(CompressionParameterKey::JXL_RESPONSIVE, &c));
+    EXPECT_EQ(c.GetInt32(), 1);
+}
+
+TEST(Utilities, ParseCompressionOptionJxlEffortStoredRawValueClampedAtEncode)
+{
+    const auto compressionOptions = Utils::ParseCompressionOptions("jxl:Effort=12");
+    EXPECT_EQ(compressionOptions.first, CompressionMode::Jxl);
+    CompressParameter c;
+    ASSERT_TRUE(compressionOptions.second->TryGetProperty(CompressionParameterKey::JXL_EFFORT, &c));
+    EXPECT_EQ(c.GetInt32(), 12);
+}
+
 TEST(Utilities, CallGetLibCZIVersionAndCheckResultForPlausibility)
 {
     int major, minor, patch, tweak;

--- a/Src/libCZI_UnitTests/test_jxl.cpp
+++ b/Src/libCZI_UnitTests/test_jxl.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2017-2025 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "include_gtest.h"
+#include "inc_libCZI.h"
+#include "../libCZI/bitmapData.h"
+#include "../libCZI/decoder_jxl.h"
+#include "utils.h"
+
+#include <cmath>
+#include <cstring>
+#include <memory>
+
+using namespace libCZI;
+using namespace libCZI::detail;
+
+namespace
+{
+    void RoundTripLossless(PixelType pt, uint32_t w, uint32_t h)
+    {
+        std::shared_ptr<IBitmapData> img = CreateRandomBitmap(pt, w, h);
+        ScopedBitmapLockerSP lock_in{ img };
+        std::shared_ptr<IMemoryBlock> compressed = JxlLibCompress::Compress(
+            pt,
+            w,
+            h,
+            lock_in.stride,
+            lock_in.ptrDataRoi,
+            nullptr);
+        ASSERT_TRUE(compressed != nullptr);
+        ASSERT_GT(compressed->GetSizeOfData(), 0u);
+
+        std::shared_ptr<CJxlDecoder> dec = CJxlDecoder::Create();
+        std::shared_ptr<IBitmapData> out = dec->Decode(
+            compressed->GetPtr(),
+            compressed->GetSizeOfData(),
+            pt,
+            w,
+            h);
+
+        EXPECT_TRUE(AreBitmapDataEqual(img, out)) << "Pixel-perfect roundtrip failed for pixel type " << static_cast<int>(pt);
+    }
+
+    std::shared_ptr<IBitmapData> MakeFloatBitmapGray(uint32_t w, uint32_t h)
+    {
+        auto bm = CStdBitmapData::Create(PixelType::Gray32Float, w, h);
+        ScopedBitmapLockerSP lck{ bm };
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            float* row = reinterpret_cast<float*>(static_cast<uint8_t*>(lck.ptrDataRoi) + static_cast<size_t>(y) * lck.stride);
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                row[x] = static_cast<float>(std::sin(static_cast<double>(x + y * w)) * 0.25f);
+            }
+        }
+
+        return bm;
+    }
+
+    std::shared_ptr<IBitmapData> MakeFloatBitmapBgr(uint32_t w, uint32_t h)
+    {
+        auto bm = CStdBitmapData::Create(PixelType::Bgr96Float, w, h);
+        ScopedBitmapLockerSP lck{ bm };
+        for (uint32_t y = 0; y < h; ++y)
+        {
+            float* row = reinterpret_cast<float*>(static_cast<uint8_t*>(lck.ptrDataRoi) + static_cast<size_t>(y) * lck.stride);
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                row[x * 3 + 0] = static_cast<float>(y) / static_cast<float>(h + 1);
+                row[x * 3 + 1] = static_cast<float>(x) / static_cast<float>(w + 1);
+                row[x * 3 + 2] = static_cast<float>((x ^ y) & 255) / 255.0f;
+            }
+        }
+
+        return bm;
+    }
+
+    void RoundTripLosslessBitmap(const std::shared_ptr<IBitmapData>& img)
+    {
+        const PixelType pt = img->GetPixelType();
+        const uint32_t w = img->GetWidth();
+        const uint32_t h = img->GetHeight();
+        ScopedBitmapLockerSP lock_in{ img };
+        std::shared_ptr<IMemoryBlock> compressed = JxlLibCompress::Compress(
+            pt,
+            w,
+            h,
+            lock_in.stride,
+            lock_in.ptrDataRoi,
+            nullptr);
+        ASSERT_TRUE(compressed != nullptr);
+
+        std::shared_ptr<CJxlDecoder> dec = CJxlDecoder::Create();
+        std::shared_ptr<IBitmapData> out = dec->Decode(
+            compressed->GetPtr(),
+            compressed->GetSizeOfData(),
+            pt,
+            w,
+            h);
+
+        EXPECT_TRUE(AreBitmapDataEqual(img, out));
+    }
+}
+
+TEST(JxlLossless, Gray8)
+{
+    RoundTripLossless(PixelType::Gray8, 64, 48);
+}
+
+TEST(JxlLossless, Gray16)
+{
+    RoundTripLossless(PixelType::Gray16, 55, 33);
+}
+
+TEST(JxlLossless, Bgr24)
+{
+    RoundTripLossless(PixelType::Bgr24, 61, 37);
+}
+
+TEST(JxlLossless, Bgr48)
+{
+    RoundTripLossless(PixelType::Bgr48, 29, 41);
+}
+
+TEST(JxlLossless, Gray32Float)
+{
+    RoundTripLosslessBitmap(MakeFloatBitmapGray(47, 39));
+}
+
+TEST(JxlLossless, Bgr96Float)
+{
+    RoundTripLosslessBitmap(MakeFloatBitmapBgr(31, 27));
+}


### PR DESCRIPTION
# Fill out and Adjust this Template

## Description

Summary of the change(s) and which issue(s) is/are fixed  

Added the jpegxl format for inner compression, motivation is mainly storage gain, 
added the file format support (need review and UUID Attribution on Zeiss Side) 
added command to CZIcmd for assessing the lossless compression (RMSD pre blocks)
added command to CZIcmd to ReEncode an existing file with any of the supported format from libczi

Relevant motivation and context  

Test image case show 25% filesize reduction compared to zstd, default from our microscope.


Dependencies required for this change  

libjxl

Fixes # (issue)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  

CZIcmd  -c ReEncodeCZI -o ~/data/image_test --compressionopts "jxl:Effort=3"  -s myinputimage
CZIcmd -c PrintInformation -s ~/data/image_test.czi -i AllSubBlocks 

Provide instructions to reproduce.

## Checklist:

- [] I followed the Contributing Guidelines.
- [] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
