### PR TITLE
fix LoHiBytePackStrided call argument calculation

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -10,6 +10,7 @@ DISABLE:
   - SPELL # Comment to enable checks of spelling mistakes
 DISABLE_ERRORS_LINTERS:
   - MARKDOWN_MARKDOWN_LINK_CHECK # Make non-blocking due to network timeouts etc.
+  - REPOSITORY_GRYPE             # Make non-blocking due to database age issues in CI
 DISABLE_LINTERS:
   - REPOSITORY_TRIVY  # this linter seems currently broken, so we disable it here for now
 C_CPPLINT_ARGUMENTS: --verbose=2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.67.4
+      VERSION 0.67.5
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/libCZI/decoder_zstd.cpp
+++ b/Src/libCZI/decoder_zstd.cpp
@@ -292,6 +292,10 @@ namespace
 
             auto bitmap = CStdBitmapData::Create(pixel_type, width, height);
             auto bitmap_lock_info = libCZI::ScopedBitmapLockerSP(bitmap);
+
+            // note: we divide the stride by 2 because that's the number of bytes per pel for a 16-bit pel, 
+            // and this gives the correct size also for Bgr48 (which we simply treat as a sequence of 16-bit
+            // pels for the purpose of the hi-lo-byte packing)
             LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, stride / 2, height, bitmap_lock_info.stride, bitmap_lock_info.ptrDataRoi);
             return bitmap;
         }

--- a/Src/libCZI/decoder_zstd.cpp
+++ b/Src/libCZI/decoder_zstd.cpp
@@ -292,7 +292,7 @@ namespace
 
             auto bitmap = CStdBitmapData::Create(pixel_type, width, height);
             auto bitmap_lock_info = libCZI::ScopedBitmapLockerSP(bitmap);
-            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, stride / bytes_per_pel, height, bitmap_lock_info.stride, bitmap_lock_info.ptrDataRoi);
+            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, stride / 2, height, bitmap_lock_info.stride, bitmap_lock_info.ptrDataRoi);
             return bitmap;
         }
         else if (zstd_frame_content_size < expectedSize)
@@ -307,7 +307,7 @@ namespace
 
             auto bitmap = CStdBitmapData::Create(pixel_type, width, height, stride);
             auto bitmap_lock_info = libCZI::ScopedBitmapLockerSP(bitmap);
-            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, decompressed_size / bytes_per_pel, 1, zstd_frame_content_size, bitmap_lock_info.ptrDataRoi);
+            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, decompressed_size / 2, 1, zstd_frame_content_size, bitmap_lock_info.ptrDataRoi);
             memset(static_cast<uint8_t*>(bitmap_lock_info.ptrDataRoi) + decompressed_size, 0, expectedSize - decompressed_size);
             return bitmap;
         }
@@ -331,7 +331,7 @@ namespace
                 throw runtime_error("Failed to allocate temporary buffer for Zstd-decompression.");
             }
 
-            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, decompressed_size / bytes_per_pel, 1, zstd_frame_content_size, temporary_buffer_for_packed.get());
+            LoHiBytePackUnpack::LoHiBytePackStrided(temporary_buffer.get(), zstd_frame_content_size, decompressed_size / 2, 1, zstd_frame_content_size, temporary_buffer_for_packed.get());
 
             // now we can release the first temporary buffer
             temporary_buffer.reset();

--- a/Src/libCZI_UnitTests/test_ZstdCompress.cpp
+++ b/Src/libCZI_UnitTests/test_ZstdCompress.cpp
@@ -15,11 +15,20 @@ using namespace libCZI;
 using namespace libCZI::detail;
 using namespace std;
 
+class ZStd1DecodeParametersFixture : public testing::TestWithParam<const char*>
+{
+protected:
+    const char* GetDecodeParameters() const
+    {
+        return GetParam();
+    }
+};
+
 static void _testImageCompressDecompressZStd0Basic(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType);
 static void _testImageCompressDecompressZStd0Param(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType, const ICompressParameters* parameters);
 
 static void _testImageCompressDecompressZStd1Basic(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType);
-static void _testImageCompressDecompressZStd1Param(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType, const ICompressParameters* parameters);
+static void _testImageCompressDecompressZStd1Param(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType, const ICompressParameters* parameters, const char* decode_parameters);
 
 //!< ZStd0 Compress and decompress image, pass null pointer as a compression parameter
 static void _testImageCompressDecompressZStd0Basic(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType)
@@ -30,7 +39,7 @@ static void _testImageCompressDecompressZStd0Basic(uint32_t imgWidth, uint32_t i
 //!< ZStd1 Compress and decompress image, pass null pointer as a compression parameter
 static void _testImageCompressDecompressZStd1Basic(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType)
 {
-    _testImageCompressDecompressZStd1Param(imgWidth, imgHeight, pixelType, nullptr);
+    _testImageCompressDecompressZStd1Param(imgWidth, imgHeight, pixelType, nullptr, nullptr);
 }
 
 //!< ZStd0 Compress and decompress image, pass a compression parameter.
@@ -74,7 +83,7 @@ static void _testImageCompressDecompressZStd0Param(uint32_t imgWidth, uint32_t i
 //! The function creates bitmap image with random pixels, which type is defined by 'pixelType' parameter.
 //! At the moment only Gray8, Gray16, Brg24 and Brg48 are supported.
 //! After decompression, the image buffer must have same data.
-static void _testImageCompressDecompressZStd1Param(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType, const ICompressParameters* parameters)
+static void _testImageCompressDecompressZStd1Param(uint32_t imgWidth, uint32_t imgHeight, PixelType pixelType, const ICompressParameters* parameters, const char* decode_parameters)
 {
     const size_t maxSize = ZstdCompress::CalculateMaxCompressedSizeZStd1(imgWidth, imgHeight, pixelType);
     std::unique_ptr<uint8_t[]> buffer = unique_ptr<uint8_t[]>(new uint8_t[maxSize]);
@@ -95,7 +104,7 @@ static void _testImageCompressDecompressZStd1Param(uint32_t imgWidth, uint32_t i
     EXPECT_TRUE(maxSize >= imgSize) << "Unexpected compress image size";
 
     std::shared_ptr<CZstd1Decoder> dec = CZstd1Decoder::Create();
-    std::shared_ptr<libCZI::IBitmapData> decImg = dec->Decode(buffer.get(), imgSize, pixelType, img->GetWidth(), img->GetHeight());
+    std::shared_ptr<libCZI::IBitmapData> decImg = dec->Decode(buffer.get(), imgSize, pixelType, img->GetWidth(), img->GetHeight(), decode_parameters);
 
     EXPECT_TRUE(decImg != nullptr) << "Failed to create decoded image";
     EXPECT_TRUE(decImg->GetHeight() == imgHeight) << "The decoded image has wrong height";
@@ -117,12 +126,12 @@ TEST(ZStdCompress, CompressZStd0Gray8Basic)
 
 //! Test ZStd1 compression and decompression for pixel type Gray8 
 //! and use default compression parameters.
-TEST(ZStdCompress, CompressZStd1Gray8Basic)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray8Basic)
 {
     constexpr PixelType pixelType = PixelType::Gray8;
 
-    _testImageCompressDecompressZStd1Basic(64, 64, pixelType);
-    _testImageCompressDecompressZStd1Basic(61, 61, pixelType);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, nullptr, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, nullptr, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Gray16 
@@ -137,12 +146,12 @@ TEST(ZStdCompress, CompressZStd0Gray16Basic)
 
 //! Test ZStd1 compression and decompression for pixel type Gray16 
 //! and use default compression parameters.
-TEST(ZStdCompress, CompressZStd1Gray16Basic)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray16Basic)
 {
     constexpr PixelType pixelType = PixelType::Gray16;
 
-    _testImageCompressDecompressZStd1Basic(64, 64, pixelType);
-    _testImageCompressDecompressZStd1Basic(61, 61, pixelType);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, nullptr, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, nullptr, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Brg24 
@@ -157,12 +166,12 @@ TEST(ZStdCompress, CompressZStd0Brg24Basic)
 
 //! Test ZStd1 compression and decompression for pixel type Brg24 
 //! and use default compression parameters.
-TEST(ZStdCompress, CompressZStd1Brg24Basic)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg24Basic)
 {
     constexpr PixelType pixelType = PixelType::Bgr24;
 
-    _testImageCompressDecompressZStd1Basic(64, 64, pixelType);
-    _testImageCompressDecompressZStd1Basic(61, 61, pixelType);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, nullptr, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, nullptr, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Brg48 
@@ -177,12 +186,12 @@ TEST(ZStdCompress, CompressZStd0Brg48Basic)
 
 //! Test ZStd1 compression and decompression for pixel type Brg48 
 //! and use default compression parameters.
-TEST(ZStdCompress, CompressZStd1Brg48Basic)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg48Basic)
 {
     constexpr PixelType pixelType = PixelType::Bgr48;
 
-    _testImageCompressDecompressZStd1Basic(64, 64, pixelType);
-    _testImageCompressDecompressZStd1Basic(61, 61, pixelType);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, nullptr, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, nullptr, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Gray8 
@@ -202,7 +211,7 @@ TEST(ZStdCompress, CompressZStd0Gray8Level2)
 
 //! Test ZStd1 compression and decompression for pixel type Gray8 
 //! and use compression parameter "zstd1:ExplicitLevel=2"
-TEST(ZStdCompress, CompressZStd1Gray8Level2)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray8Level2)
 {
     constexpr PixelType pixelType = PixelType::Gray8;
     constexpr int32_t keyLevel = static_cast<int>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -211,8 +220,8 @@ TEST(ZStdCompress, CompressZStd1Gray8Level2)
     libCZI::CompressParametersOnMap params;
     params.map[keyLevel] = CompressParameter(valLevel);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Gray16
@@ -232,7 +241,7 @@ TEST(ZStdCompress, CompressZStd0Gray16Level2)
 
 //! Test ZStd1 compression and decompression for pixel type Gray16
 //! and use compression parameter "zstd1:ExplicitLevel=2"
-TEST(ZStdCompress, CompressZStd1Gray16Level2)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray16Level2)
 {
     constexpr PixelType pixelType = PixelType::Gray16;
     constexpr int32_t keyLevel = static_cast<int>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -241,8 +250,8 @@ TEST(ZStdCompress, CompressZStd1Gray16Level2)
     libCZI::CompressParametersOnMap params;
     params.map[keyLevel] = CompressParameter(valLevel);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Brg24 
@@ -262,7 +271,7 @@ TEST(ZStdCompress, CompressZStd0Brg24Level2)
 
 //! Test ZStd1 compression and decompression for pixel type Brg24 
 //! and use compression parameter "zstd1:ExplicitLevel=2"
-TEST(ZStdCompress, CompressZStd1Brg24Level2)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg24Level2)
 {
     constexpr PixelType pixelType = PixelType::Bgr24;
     constexpr int32_t keyLevel = static_cast<int>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -271,8 +280,8 @@ TEST(ZStdCompress, CompressZStd1Brg24Level2)
     libCZI::CompressParametersOnMap params;
     params.map[keyLevel] = CompressParameter(valLevel);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Brg48
@@ -292,7 +301,7 @@ TEST(ZStdCompress, CompressZStd0Brg48Level2)
 
 //! Test ZStd1 compression and decompression for pixel type Brg48
 //! and use compression parameter "zstd1:ExplicitLevel=2"
-TEST(ZStdCompress, CompressZStd1Brg48Level2)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg48Level2)
 {
     constexpr PixelType pixelType = PixelType::Bgr48;
     constexpr int32_t keyLevel = static_cast<int>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -301,8 +310,8 @@ TEST(ZStdCompress, CompressZStd1Brg48Level2)
     libCZI::CompressParametersOnMap params;
     params.map[keyLevel] = CompressParameter(valLevel);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Gray8
@@ -327,7 +336,7 @@ TEST(ZStdCompress, CompressZStd0Gray8Level2LowByte)
 //! Test ZStd1 compression and decompression for pixel type Gray8
 //! and use compression parameter "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
 //! The Low-high byte packing is ignored for the Gray8.
-TEST(ZStdCompress, CompressZStd1Gray8Level2LowByte)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray8Level2LowByte)
 {
     constexpr PixelType pixelType = PixelType::Gray8;
     constexpr int32_t keyLevel = static_cast<int32_t>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -339,8 +348,8 @@ TEST(ZStdCompress, CompressZStd1Gray8Level2LowByte)
     params.map[keyLevel] = CompressParameter(valLevel);
     params.map[keyLowPack] = CompressParameter(valLowPack);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Gray16
@@ -364,7 +373,7 @@ TEST(ZStdCompress, CompressZStd0Gray16Level2LowByte)
 
 //! Test ZStd1 compression and decompression for pixel type Gray16
 //! and use compression parameter "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
-TEST(ZStdCompress, CompressZStd1Gray16Level2LowByte)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Gray16Level2LowByte)
 {
     constexpr PixelType pixelType = PixelType::Gray16;
     constexpr int32_t keyLevel = static_cast<int32_t>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -376,8 +385,8 @@ TEST(ZStdCompress, CompressZStd1Gray16Level2LowByte)
     params.map[keyLevel] = CompressParameter(valLevel);
     params.map[keyLowPack] = CompressParameter(valLowPack);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Bgr24
@@ -402,7 +411,7 @@ TEST(ZStdCompress, CompressZStd0Brg24Level2LowByte)
 //! Test ZStd1 compression and decompression for pixel type Bgr24
 //! and use compression parameter "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
 //! The Low-high byte packing is ignored for the Bgr24.
-TEST(ZStdCompress, CompressZStd1Brg24Level2LowByte)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg24Level2LowByte)
 {
     constexpr PixelType pixelType = PixelType::Bgr24;
     constexpr int32_t keyLevel = static_cast<int32_t>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -414,8 +423,8 @@ TEST(ZStdCompress, CompressZStd1Brg24Level2LowByte)
     params.map[keyLevel] = CompressParameter(valLevel);
     params.map[keyLowPack] = CompressParameter(valLowPack);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
 
 //! Test ZStd0 compression and decompression for pixel type Bgr48
@@ -439,7 +448,7 @@ TEST(ZStdCompress, CompressZStd0Brg48Level2LowByte)
 
 //! Test ZStd1 compression and decompression for pixel type Bgr48
 //! and use compression parameter "zstd1:ExplicitLevel=2;PreProcess=HiLoByteUnpack"
-TEST(ZStdCompress, CompressZStd1Brg48Level2LowByte)
+TEST_P(ZStd1DecodeParametersFixture, CompressZStd1Brg48Level2LowByte)
 {
     constexpr PixelType pixelType = PixelType::Bgr48;
     constexpr int32_t keyLevel = static_cast<int32_t>(libCZI::CompressionParameterKey::ZSTD_RAWCOMPRESSIONLEVEL);
@@ -451,6 +460,16 @@ TEST(ZStdCompress, CompressZStd1Brg48Level2LowByte)
     params.map[keyLevel] = CompressParameter(valLevel);
     params.map[keyLowPack] = CompressParameter(valLowPack);
 
-    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params);
-    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params);
+    _testImageCompressDecompressZStd1Param(64, 64, pixelType, &params, GetDecodeParameters());
+    _testImageCompressDecompressZStd1Param(61, 61, pixelType, &params, GetDecodeParameters());
 }
+
+// run the tests with and without decode parameter "handle_data_size_mismatch", which is used to
+// handle the data size mismatch between compressed data and expected data size in decoder, and 
+// it should not affect the decompression result.
+INSTANTIATE_TEST_SUITE_P(
+    DecodeParameters,
+    ZStd1DecodeParametersFixture,
+    testing::Values(
+        nullptr,
+        "handle_data_size_mismatch"));

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -53,3 +53,4 @@ Version history
  0.67.2             | [155](https://github.com/ZEISS/libczi/pull/155)      | code cleanup
  0.67.3             | [158](https://github.com/ZEISS/libczi/pull/158)      | have all internal code in its own namespace `libCZI::detail`, update vendored pugixml to version 1.15, fix issue with big-endian-machines
  0.67.4             | [158](https://github.com/ZEISS/libczi/pull/159)      | remove version requirement for external eigen3 package
+ 0.67.5             | [167](https://github.com/ZEISS/libczi/pull/167)      | fix bug with zstd1-decoding in case of pixeltype BGR48


### PR DESCRIPTION
## Description

Fix a bug where decoding a hi-lo-byte-packed-zstd1-compressed-subblock has given a bogus result.

Fixes #167 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally, with the repro-steps described in bug

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
