### PR TITLE
Jbl/chunked prereq cleanups

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,6 +91,7 @@ jobs:
               -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON `
               -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON `
               -DLIBCZI_BUILD_LIBCZIAPI=ON `
+              -DLIBCZI_BUILD_UNITTESTS=OFF `
               -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
               -DVCPKG_TARGET_TRIPLET=arm64-windows-static `
               -DCRASH_ON_UNALIGNED_ACCESS=OFF `

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -227,5 +227,5 @@ jobs:
           verbose: true
           # Only one flag to be safe with
           # https://docs.codecov.com/docs/flags#one-to-one-relationship-of-flags-to-uploads
-          flags: ${{matrix.OS}}
+          flags: ${{matrix.os}}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)
 
 project(libCZI 
-      VERSION 0.67.6
+      VERSION 0.68.0
       HOMEPAGE_URL "https://github.com/ZEISS/libczi"
       DESCRIPTION "libCZI is an Open Source Cross-Platform C++ library to read and write CZI")
 

--- a/Src/CZICmd/CMakeLists.txt
+++ b/Src/CZICmd/CMakeLists.txt
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
   cli11
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11
-  GIT_TAG        v2.4.2
+  GIT_TAG        v2.6.2
 )
 
 set(CLI11_BUILD_TESTS OFF CACHE BOOL "" FORCE)

--- a/Src/CZICmd/cmdlineoptions.cpp
+++ b/Src/CZICmd/cmdlineoptions.cpp
@@ -19,9 +19,7 @@
 #include "IBitmapGen.h"
 #include <iomanip>
 
-#include <CLI/App.hpp>
-#include <CLI/Formatter.hpp>
-#include <CLI/Config.hpp>
+#include <CLI/CLI.hpp>
 
 using namespace std;
 

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -318,7 +318,7 @@ CCZIReader::CCZIReader() :
     return this->ReadAttachment(entry);
 }
 
-/*virtual*/AttachmentStatistics CCZIReader::GetAttachmentStatistics()
+/*virtual*/AttachmentStatistics CCZIReader::GetAttachmentStatistics() const
 {
     this->ThrowIfNotOperational();
     AttachmentStatistics statistics;

--- a/Src/libCZI/CZIReader.cpp
+++ b/Src/libCZI/CZIReader.cpp
@@ -318,6 +318,14 @@ CCZIReader::CCZIReader() :
     return this->ReadAttachment(entry);
 }
 
+/*virtual*/AttachmentStatistics CCZIReader::GetAttachmentStatistics()
+{
+    this->ThrowIfNotOperational();
+    AttachmentStatistics statistics;
+    statistics.attachmentsCount = this->attachmentDir.GetAttachmentCount();
+    return statistics;
+}
+
 std::shared_ptr<ISubBlock> CCZIReader::ReadSubBlock(const CCziSubBlockDirectory::SubBlkEntry& entry)
 {
     const CCZIParse::SubBlockStorageAllocate allocateInfo{ ::malloc, ::free };

--- a/Src/libCZI/CZIReader.h
+++ b/Src/libCZI/CZIReader.h
@@ -58,6 +58,7 @@ namespace libCZI
             void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum) override;
             std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
+            libCZI::AttachmentStatistics GetAttachmentStatistics() override;
 
         private:
             std::shared_ptr<libCZI::ISubBlock> ReadSubBlock(const CCziSubBlockDirectory::SubBlkEntry& entry);

--- a/Src/libCZI/CZIReader.h
+++ b/Src/libCZI/CZIReader.h
@@ -58,7 +58,7 @@ namespace libCZI
             void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& infi)>& funcEnum) override;
             std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
-            libCZI::AttachmentStatistics GetAttachmentStatistics() override;
+            libCZI::AttachmentStatistics GetAttachmentStatistics() const override;
 
         private:
             std::shared_ptr<libCZI::ISubBlock> ReadSubBlock(const CCziSubBlockDirectory::SubBlkEntry& entry);

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -149,14 +149,14 @@ namespace
 #if LIBCZI_ISBIGENDIANHOST
             if (CziUtils::IsPixelTypeEndianessAgnostic(pixelType))
             {
-                CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrData, locked_bitmap.stride, width, height, false);
+                CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrDataRoi, locked_bitmap.stride, width, height, false);
             }
             else
             {
-                CBitmapOperations::CopyConvertBigEndian(pixelType, pv, source_stride, locked_bitmap.ptrData, locked_bitmap.stride, width, height);
+                CBitmapOperations::CopyConvertBigEndian(pixelType, pv, source_stride, locked_bitmap.ptrDataRoi, locked_bitmap.stride, width, height);
             }
 #else
-            CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrData, locked_bitmap.stride, width, height, false);
+            CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrDataRoi, locked_bitmap.stride, width, height, false);
 #endif
             return bitmap;
         }

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -262,7 +262,7 @@ std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlockData(
         std::uint32_t height,
         const CreateBitmapOptions* options)
 {
-    switch (compression_mode)  // NOLINT(clang-diagnostic-switch-enum)
+    switch (compression_mode)
     {
     case CompressionMode::JpgXr:
         return CreateBitmapFromSubBlockData_JpgXr(pv, size, pixelType, width, height, options != nullptr ? options->handle_jpgxr_bitmap_mismatch : true);

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -46,8 +46,8 @@ namespace
                 // create a bitmap of the size described in the subblock
                 auto adjusted_bitmap = CStdBitmapData::Create(pixelType, width, height);
                 CBitmapOperations::Fill(adjusted_bitmap.get(), RgbFloatColor{ 0,0,0 });
-                auto adjusted_bitmap_lock = adjusted_bitmap->Lock();
-                auto decoded_bitmap_lock = decoded_bitmap->Lock();
+                const ScopedBitmapLockerSP adjusted_bitmap_lock{ adjusted_bitmap };
+                const ScopedBitmapLockerSP decoded_bitmap_lock{ decoded_bitmap };
                 CBitmapOperations::CopyWithOffsetInfo copy_info;
                 copy_info.xOffset = 0;
                 copy_info.yOffset = 0;
@@ -63,8 +63,6 @@ namespace
                 copy_info.dstHeight = adjusted_bitmap->GetHeight();
                 copy_info.drawTileBorder = false;
                 CBitmapOperations::CopyWithOffset(copy_info);
-                adjusted_bitmap->Unlock();
-                decoded_bitmap->Unlock();
                 return adjusted_bitmap;
             }
         }

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -13,162 +13,226 @@
 using namespace libCZI;
 using namespace libCZI::detail;
 
-static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_JpgXr(ISubBlock* subBlk, bool handle_jxr_bitmap_mismatch)
+namespace
 {
-    auto dec = GetSite()->GetDecoder(ImageDecoderType::JPXR_JxrLib, nullptr);
-    const void* ptr;
-    size_t size;
-    subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
-    const SubBlockInfo& sub_block_info = subBlk->GetSubBlockInfo();
-
-    if (!handle_jxr_bitmap_mismatch)
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlockData_JpgXr(
+            const void* pv,
+            size_t size,
+            libCZI::PixelType pixelType,
+            std::uint32_t width,
+            std::uint32_t height,
+            bool handle_jxr_bitmap_mismatch)
     {
-        return dec->Decode(ptr, size, sub_block_info.pixelType, sub_block_info.physicalSize.w, sub_block_info.physicalSize.h);
-    }
-    else
-    {
-        // This means - according to the "resolution protocol", if there is a mismatch between the bitmap encoded as JpgXR and the
-        //  description in the subblock, we have to crop or pad the bitmap to the size described in the subblock.
-        auto decoded_bitmap = dec->Decode(ptr, size, nullptr, nullptr, nullptr);
-        if (decoded_bitmap->GetWidth() == sub_block_info.physicalSize.w &&
-            decoded_bitmap->GetHeight() == sub_block_info.physicalSize.h &&
-            decoded_bitmap->GetPixelType() == sub_block_info.pixelType)
+        auto dec = GetSite()->GetDecoder(ImageDecoderType::JPXR_JxrLib, nullptr);
+        if (!handle_jxr_bitmap_mismatch)
         {
-            return decoded_bitmap;
+            return dec->Decode(pv, size, pixelType, width, height);
         }
         else
         {
-            // ok, we have a discrepancy between the size of the bitmap and the size described in the subblock, so let's crop or pad the bitmap
-
-            // create a bitmap of the size described in the subblock
-            auto adjusted_bitmap = CStdBitmapData::Create(sub_block_info.pixelType, sub_block_info.physicalSize.w, sub_block_info.physicalSize.h);
-            CBitmapOperations::Fill(adjusted_bitmap.get(), RgbFloatColor{ 0,0,0 });
-            auto adjusted_bitmap_lock = adjusted_bitmap->Lock();
-            auto decoded_bitmap_lock = decoded_bitmap->Lock();
-            CBitmapOperations::CopyWithOffsetInfo copy_info;
-            copy_info.xOffset = 0;
-            copy_info.yOffset = 0;
-            copy_info.srcPixelType = decoded_bitmap->GetPixelType();
-            copy_info.srcPtr = decoded_bitmap_lock.ptrDataRoi;
-            copy_info.srcStride = decoded_bitmap_lock.stride;
-            copy_info.srcWidth = decoded_bitmap->GetWidth();
-            copy_info.srcHeight = decoded_bitmap->GetHeight();
-            copy_info.dstPixelType = sub_block_info.pixelType;
-            copy_info.dstPtr = adjusted_bitmap_lock.ptrDataRoi;
-            copy_info.dstStride = adjusted_bitmap_lock.stride;
-            copy_info.dstWidth = adjusted_bitmap->GetWidth();
-            copy_info.dstHeight = adjusted_bitmap->GetHeight();
-            copy_info.drawTileBorder = false;
-            CBitmapOperations::CopyWithOffset(copy_info);
-            adjusted_bitmap->Unlock();
-            decoded_bitmap->Unlock();
-            return adjusted_bitmap;
-        }
-    }
-}
-
-static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_ZStd0(ISubBlock* subBlk, bool handle_zstd_data_size_mismatch)
-{
-    auto dec = GetSite()->GetDecoder(ImageDecoderType::ZStd0, nullptr);
-    const void* ptr;
-    size_t size;
-    subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
-    const SubBlockInfo& sub_block_info = subBlk->GetSubBlockInfo();
-    return dec->Decode(
-                    ptr, 
-                    size, 
-                    sub_block_info.pixelType, 
-                    sub_block_info.physicalSize.w, 
-                    sub_block_info.physicalSize.h, 
-                    handle_zstd_data_size_mismatch ? CZstd0Decoder::kOption_handle_data_size_mismatch : nullptr);
-}
-
-static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_ZStd1(ISubBlock* subBlk, bool handle_zstd_data_size_mismatch)
-{
-    auto dec = GetSite()->GetDecoder(ImageDecoderType::ZStd1, nullptr);
-    const void* ptr;
-    size_t size;
-    subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
-    const SubBlockInfo& sub_block_info = subBlk->GetSubBlockInfo();
-    return dec->Decode(
-                    ptr, 
-                    size, 
-                    sub_block_info.pixelType, 
-                    sub_block_info.physicalSize.w, 
-                    sub_block_info.physicalSize.h,
-                    handle_zstd_data_size_mismatch ? CZstd1Decoder::kOption_handle_data_size_mismatch : nullptr);
-}
-
-static std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_Uncompressed(ISubBlock* subBlk, bool handle_uncompressed_data_size_mismatch)
-{
-    const auto& sub_block_info = subBlk->GetSubBlockInfo();
-
-    // The stride with an uncompressed bitmap in CZI is exactly the line-size.
-    const std::uint32_t stride = sub_block_info.physicalSize.w * CziUtils::GetBytesPerPel(sub_block_info.pixelType);
-    const size_t expected_size = static_cast<size_t>(stride) * sub_block_info.physicalSize.h;
-
-    size_t size;
-    auto sub_block_data = subBlk->GetRawData(ISubBlock::MemBlkType::Data, &size);
-
-    if (expected_size <= size)
-    {
-        CSharedPtrAllocator sharedPtrAllocator(sub_block_data);
-        auto sb = CBitmapData<CSharedPtrAllocator>::Create(
-                                                        sharedPtrAllocator,
-                                                        sub_block_info.pixelType,
-                                                        sub_block_info.physicalSize.w,
-                                                        sub_block_info.physicalSize.h,
-                                                        stride);
-#if LIBCZI_ISBIGENDIANHOST
-        if (!CziUtils::IsPixelTypeEndianessAgnostic(subBlk->GetSubBlockInfo().pixelType))
-        {
-            return CBitmapOperations::ConvertToBigEndian(sb.get());
-        }
-#endif
-
-        return sb;
-    }
-    else
-    {
-        if (!handle_uncompressed_data_size_mismatch)
-        {
-            throw std::logic_error("insufficient size of subblock");
-        }
-
-        // ok - according to the "resolution protocol" the bitmap is to be filled with zeroes
-        auto bitmap = CStdBitmapData::Create(sub_block_info.pixelType, sub_block_info.physicalSize.w, sub_block_info.physicalSize.h);
-        auto lock = bitmap->Lock();
-        size_t remaining_size = size;
-        for (uint32_t y = 0; y < sub_block_info.physicalSize.h; ++y)
-        {
-            uint8_t* destination = static_cast<uint8_t*>(lock.ptrDataRoi) + y * static_cast<size_t>(lock.stride);
-            if (remaining_size > 0)
+            // This means - according to the "resolution protocol", if there is a mismatch between the bitmap encoded as JpgXR and the
+            //  description in the subblock, we have to crop or pad the bitmap to the size described in the subblock.
+            auto decoded_bitmap = dec->Decode(pv, size, nullptr, nullptr, nullptr);
+            if (decoded_bitmap->GetWidth() == width &&
+                decoded_bitmap->GetHeight() == height &&
+                decoded_bitmap->GetPixelType() == pixelType)
             {
-                const uint8_t* source = static_cast<const uint8_t*>(sub_block_data.get()) + y * static_cast<size_t>(stride);
-                size_t copy_size = std::min(remaining_size, static_cast<size_t>(stride));
-                memcpy(destination, source, copy_size);
-                remaining_size -= copy_size;
-                if (remaining_size == 0)
-                {
-                    std::memset(destination + copy_size, 0, static_cast<size_t>(stride) - copy_size);
-                }
+                return decoded_bitmap;
             }
             else
             {
-                std::memset(destination, 0, stride);
+                // ok, we have a discrepancy between the size of the bitmap and the size described in the subblock, so let's crop or pad the bitmap
+
+                // create a bitmap of the size described in the subblock
+                auto adjusted_bitmap = CStdBitmapData::Create(pixelType, width, height);
+                CBitmapOperations::Fill(adjusted_bitmap.get(), RgbFloatColor{ 0,0,0 });
+                auto adjusted_bitmap_lock = adjusted_bitmap->Lock();
+                auto decoded_bitmap_lock = decoded_bitmap->Lock();
+                CBitmapOperations::CopyWithOffsetInfo copy_info;
+                copy_info.xOffset = 0;
+                copy_info.yOffset = 0;
+                copy_info.srcPixelType = decoded_bitmap->GetPixelType();
+                copy_info.srcPtr = decoded_bitmap_lock.ptrDataRoi;
+                copy_info.srcStride = decoded_bitmap_lock.stride;
+                copy_info.srcWidth = decoded_bitmap->GetWidth();
+                copy_info.srcHeight = decoded_bitmap->GetHeight();
+                copy_info.dstPixelType = pixelType;
+                copy_info.dstPtr = adjusted_bitmap_lock.ptrDataRoi;
+                copy_info.dstStride = adjusted_bitmap_lock.stride;
+                copy_info.dstWidth = adjusted_bitmap->GetWidth();
+                copy_info.dstHeight = adjusted_bitmap->GetHeight();
+                copy_info.drawTileBorder = false;
+                CBitmapOperations::CopyWithOffset(copy_info);
+                adjusted_bitmap->Unlock();
+                decoded_bitmap->Unlock();
+                return adjusted_bitmap;
             }
         }
+    }
 
-        bitmap->Unlock();
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_JpgXr(ISubBlock* subBlk, bool handle_jxr_bitmap_mismatch)
+    {
+        const void* ptr;
+        size_t size;
+        subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
+        const SubBlockInfo& sub_block_info = subBlk->GetSubBlockInfo();
+
+        return CreateBitmapFromSubBlockData_JpgXr(ptr, size, sub_block_info.pixelType, sub_block_info.physicalSize.w, sub_block_info.physicalSize.h, handle_jxr_bitmap_mismatch);
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlockData_ZStd0(
+            const void* pv,
+            size_t size,
+            libCZI::PixelType pixelType,
+            std::uint32_t width,
+            std::uint32_t height,
+            bool handle_zstd_data_size_mismatch)
+    {
+        auto dec = GetSite()->GetDecoder(ImageDecoderType::ZStd0, nullptr);
+        return dec->Decode(
+                        pv,
+                        size,
+                        pixelType,
+                        width,
+                        height,
+                        handle_zstd_data_size_mismatch ? CZstd0Decoder::kOption_handle_data_size_mismatch : nullptr);
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_ZStd0(ISubBlock* subBlk, bool handle_zstd_data_size_mismatch)
+    {
+        const void* ptr;
+        size_t size;
+        subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
+        return CreateBitmapFromSubBlockData_ZStd0(ptr, size, subBlk->GetSubBlockInfo().pixelType, subBlk->GetSubBlockInfo().physicalSize.w, subBlk->GetSubBlockInfo().physicalSize.h, handle_zstd_data_size_mismatch);
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlockData_ZStd1(
+            const void* pv,
+            size_t size,
+            libCZI::PixelType pixelType,
+            std::uint32_t width,
+            std::uint32_t height,
+            bool handle_zstd_data_size_mismatch)
+    {
+        auto dec = GetSite()->GetDecoder(ImageDecoderType::ZStd1, nullptr);
+        return dec->Decode(
+                        pv,
+                        size,
+                        pixelType,
+                        width,
+                        height,
+                        handle_zstd_data_size_mismatch ? CZstd1Decoder::kOption_handle_data_size_mismatch : nullptr);
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_ZStd1(ISubBlock* subBlk, bool handle_zstd_data_size_mismatch)
+    {
+        const void* ptr;
+        size_t size;
+        subBlk->DangerousGetRawData(ISubBlock::MemBlkType::Data, ptr, size);
+        return CreateBitmapFromSubBlockData_ZStd1(ptr, size, subBlk->GetSubBlockInfo().pixelType, subBlk->GetSubBlockInfo().physicalSize.w, subBlk->GetSubBlockInfo().physicalSize.h, handle_zstd_data_size_mismatch);
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlockData_Uncompressed(
+                                            const void* pv,
+                                            size_t size,
+                                            libCZI::PixelType pixelType,
+                                            std::uint32_t width,
+                                            std::uint32_t height,
+                                            bool handle_uncompressed_data_size_mismatch)
+    {
+        // The stride with an uncompressed bitmap in CZI is exactly the line-size.
+        const std::uint32_t source_stride = width * CziUtils::GetBytesPerPel(pixelType);
+        const size_t expected_size = static_cast<size_t>(source_stride) * height;
+
+        if (expected_size <= size)
+        {
+            auto bitmap = CStdBitmapData::Create(pixelType, width, height);
+            ScopedBitmapLockerSP locked_bitmap{ bitmap };
+            CBitmapOperations::CopyConvertBigEndian(pixelType, pv, source_stride, locked_bitmap.ptrData, locked_bitmap.stride, width, height);
+            return bitmap;
+        }
+        else
+        {
+            if (!handle_uncompressed_data_size_mismatch)
+            {
+                throw std::logic_error("insufficient size of subblock");
+            }
+
+            // ok - according to the "resolution protocol" the bitmap is to be filled with zeroes
+            auto bitmap = CStdBitmapData::Create(pixelType, width, height);
+            auto lock = bitmap->Lock();
+            size_t remaining_size = size;
+            for (uint32_t y = 0; y < height; ++y)
+            {
+                uint8_t* destination = static_cast<uint8_t*>(lock.ptrDataRoi) + y * static_cast<size_t>(lock.stride);
+                if (remaining_size > 0)
+                {
+                    const uint8_t* source = static_cast<const uint8_t*>(pv) + y * static_cast<size_t>(source_stride);
+                    size_t copy_size = std::min(remaining_size, static_cast<size_t>(source_stride));
+                    memcpy(destination, source, copy_size);
+                    remaining_size -= copy_size;
+                    if (remaining_size == 0)
+                    {
+                        std::memset(destination + copy_size, 0, static_cast<size_t>(source_stride) - copy_size);
+                    }
+                }
+                else
+                {
+                    std::memset(destination, 0, source_stride);
+                }
+            }
+
+            bitmap->Unlock();
 
 #if LIBCZI_ISBIGENDIANHOST
-        if (!CziUtils::IsPixelTypeEndianessAgnostic(subBlk->GetSubBlockInfo().pixelType))
-        {
-            return CBitmapOperations::ConvertToBigEndian(bitmap.get());
-        }
+            if (!CziUtils::IsPixelTypeEndianessAgnostic(pixelType))
+            {
+                return CBitmapOperations::ConvertToBigEndian(bitmap.get());
+            }
 #endif
 
-        return bitmap;
+            return bitmap;
+        }
+    }
+
+    std::shared_ptr<libCZI::IBitmapData> CreateBitmapFromSubBlock_Uncompressed(ISubBlock* subBlk, bool handle_uncompressed_data_size_mismatch)
+    {
+        const auto& sub_block_info = subBlk->GetSubBlockInfo();
+
+        // The stride with an uncompressed bitmap in CZI is exactly the line-size.
+        const std::uint32_t stride = sub_block_info.physicalSize.w * CziUtils::GetBytesPerPel(sub_block_info.pixelType);
+        const size_t expected_size = static_cast<size_t>(stride) * sub_block_info.physicalSize.h;
+
+        size_t size;
+        auto sub_block_data = subBlk->GetRawData(ISubBlock::MemBlkType::Data, &size);
+
+        if (expected_size <= size
+#if LIBCZI_ISBIGENDIANHOST
+            && CziUtils::IsPixelTypeEndianessAgnostic(subBlk->GetSubBlockInfo().pixelType)
+#endif
+            )
+        {
+            // only in this case (data is >= expected size, and if the pixel type is not endianness-agnostic on a big-endian host) 
+            // we can directly use the data as bitmap data without copying or conversion
+            CSharedPtrAllocator sharedPtrAllocator(sub_block_data);
+            auto sb = CBitmapData<CSharedPtrAllocator>::Create(
+                                                            sharedPtrAllocator,
+                                                            sub_block_info.pixelType,
+                                                            sub_block_info.physicalSize.w,
+                                                            sub_block_info.physicalSize.h,
+                                                            stride);
+            return sb;
+        }
+        else
+        {
+            return CreateBitmapFromSubBlockData_Uncompressed(
+                sub_block_data.get(),
+                size,
+                sub_block_info.pixelType,
+                sub_block_info.physicalSize.w,
+                sub_block_info.physicalSize.h,
+                handle_uncompressed_data_size_mismatch);
+        }
     }
 }
 
@@ -186,5 +250,29 @@ std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlock(ISubBlock*
         return CreateBitmapFromSubBlock_Uncompressed(subBlk, options != nullptr ? options->handle_uncompressed_data_size_mismatch : true);
     default:    // silence warnings
         throw std::logic_error("The method or operation is not implemented.");
+    }
+}
+
+std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlockData(
+        libCZI::CompressionMode compression_mode,
+        const void* pv,
+        size_t size,
+        libCZI::PixelType pixelType,
+        std::uint32_t width,
+        std::uint32_t height,
+        const CreateBitmapOptions* options)
+{
+    switch (compression_mode)  // NOLINT(clang-diagnostic-switch-enum)
+    {
+    case CompressionMode::JpgXr:
+        return CreateBitmapFromSubBlockData_JpgXr(pv, size, pixelType, width, height, options != nullptr ? options->handle_jpgxr_bitmap_mismatch : true);
+    case CompressionMode::Zstd0:
+        return CreateBitmapFromSubBlockData_ZStd0(pv, size, pixelType, width, height, options != nullptr ? options->handle_zstd_data_size_mismatch : true);
+    case CompressionMode::Zstd1:
+        return CreateBitmapFromSubBlockData_ZStd1(pv, size, pixelType, width, height, options != nullptr ? options->handle_zstd_data_size_mismatch : true);
+    case CompressionMode::UnCompressed:
+        return CreateBitmapFromSubBlockData_Uncompressed(pv, size, pixelType, width, height, options != nullptr ? options->handle_uncompressed_data_size_mismatch : true);
+    default:
+        throw std::logic_error("The specified compression mode is not supported or implemented.");
     }
 }

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -273,6 +273,11 @@ std::shared_ptr<libCZI::IBitmapData> libCZI::CreateBitmapFromSubBlockData(
         std::uint32_t height,
         const CreateBitmapOptions* options)
 {
+    if (pv == nullptr)
+    {
+        throw std::invalid_argument("The input data pointer is null.");
+    }
+
     switch (compression_mode)
     {
     case CompressionMode::JpgXr:

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -148,7 +148,18 @@ namespace
         {
             auto bitmap = CStdBitmapData::Create(pixelType, width, height);
             ScopedBitmapLockerSP locked_bitmap{ bitmap };
-            CBitmapOperations::CopyConvertBigEndian(pixelType, pv, source_stride, locked_bitmap.ptrData, locked_bitmap.stride, width, height);
+#if LIBCZI_ISBIGENDIANHOST
+            if (CziUtils::IsPixelTypeEndianessAgnostic(pixelType))
+            {
+                CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrData, locked_bitmap.stride, width, height, false);
+            }
+            else
+            {
+                CBitmapOperations::CopyConvertBigEndian(pixelType, pv, source_stride, locked_bitmap.ptrData, locked_bitmap.stride, width, height);
+            }
+#else
+            CBitmapOperations::Copy(pixelType, pv, source_stride, pixelType, locked_bitmap.ptrData, locked_bitmap.stride, width, height, false);
+#endif
             return bitmap;
         }
         else

--- a/Src/libCZI/CreateBitmap.cpp
+++ b/Src/libCZI/CreateBitmap.cpp
@@ -223,7 +223,7 @@ namespace
 #endif
             )
         {
-            // only in this case (data is >= expected size, and if the pixel type is not endianness-agnostic on a big-endian host) 
+            // only in this case (data is >= expected size, and on a big-endian host if the pixel type is endianness-agnostic)
             // we can directly use the data as bitmap data without copying or conversion
             CSharedPtrAllocator sharedPtrAllocator(sub_block_data);
             auto sb = CBitmapData<CSharedPtrAllocator>::Create(

--- a/Src/libCZI/CziAttachmentsDirectory.cpp
+++ b/Src/libCZI/CziAttachmentsDirectory.cpp
@@ -66,6 +66,12 @@ bool CCziAttachmentsDirectory::TryGetAttachment(int index, AttachmentEntry& entr
     return false;
 }
 
+
+int CCziAttachmentsDirectory::GetAttachmentCount() const
+{
+    return static_cast<int>(this->attachmentEntries.size());
+}
+
 //-----------------------------------------------------------------------------
 
 bool CWriterCziAttachmentsDirectory::TryAddAttachment(const AttachmentEntry& entry)

--- a/Src/libCZI/CziAttachmentsDirectory.h
+++ b/Src/libCZI/CziAttachmentsDirectory.h
@@ -55,6 +55,7 @@ namespace libCZI
             void AddAttachmentEntry(const AttachmentEntry& entry);
             void EnumAttachments(const std::function<bool(int index, const CCziAttachmentsDirectory::AttachmentEntry&)>& func);
             bool TryGetAttachment(int index, AttachmentEntry& entry) const;
+            int GetAttachmentCount() const;
         };
 
         class CWriterCziAttachmentsDirectory : public CCziAttachmentsDirectoryBase

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -834,7 +834,7 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
     return this->ReadAttachment(entry);
 }
 
-/*virtual*/libCZI::AttachmentStatistics CCziReaderWriter::GetAttachmentStatistics()
+/*virtual*/libCZI::AttachmentStatistics CCziReaderWriter::GetAttachmentStatistics() const
 {
     this->ThrowIfNotOperational();
     AttachmentStatistics statistics;

--- a/Src/libCZI/CziReaderWriter.cpp
+++ b/Src/libCZI/CziReaderWriter.cpp
@@ -834,6 +834,14 @@ void CCziReaderWriter::WriteToOutputStream(std::uint64_t offset, const void* pv,
     return this->ReadAttachment(entry);
 }
 
+/*virtual*/libCZI::AttachmentStatistics CCziReaderWriter::GetAttachmentStatistics()
+{
+    this->ThrowIfNotOperational();
+    AttachmentStatistics statistics;
+    statistics.attachmentsCount = static_cast<int>(this->attachmentDirectory.GetEntryCnt());
+    return statistics;
+}
+
 /*virtual*/void CCziReaderWriter::ReplaceAttachment(int attchmntId, const libCZI::AddAttachmentInfo& addAttachmentInfo)
 {
     this->ThrowIfNotOperational();

--- a/Src/libCZI/CziReaderWriter.h
+++ b/Src/libCZI/CziReaderWriter.h
@@ -60,6 +60,7 @@ namespace libCZI
             void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
+            libCZI::AttachmentStatistics GetAttachmentStatistics() override;
 
         private:
             void Finish();

--- a/Src/libCZI/CziReaderWriter.h
+++ b/Src/libCZI/CziReaderWriter.h
@@ -60,7 +60,7 @@ namespace libCZI
             void EnumerateAttachments(const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             void EnumerateSubset(const char* contentFileType, const char* name, const std::function<bool(int index, const libCZI::AttachmentInfo& info)>& funcEnum) override;
             std::shared_ptr<libCZI::IAttachment> ReadAttachment(int index) override;
-            libCZI::AttachmentStatistics GetAttachmentStatistics() override;
+            libCZI::AttachmentStatistics GetAttachmentStatistics() const override;
 
         private:
             void Finish();

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -594,6 +594,13 @@ namespace libCZI
         std::map<int, std::vector<PyramidLayerStatistics>> scenePyramidStatistics;
     };
 
+    /// Statistics about the attachments in the CZI-document;
+    struct AttachmentStatistics
+    {
+        /// The total number of attachments.
+        int attachmentsCount;
+    };
+
     /// Interface for sub-block repository. This interface is used to access the sub-blocks in a CZI-file.
     class LIBCZI_API ISubBlockRepository
     {
@@ -742,6 +749,10 @@ namespace libCZI
         /// \param index Index of the attachment (as reported by the Enumerate-methods).
         /// \return If successful, the attachment object; otherwise an empty shared_ptr.
         virtual std::shared_ptr<IAttachment> ReadAttachment(int index) = 0;
+
+        /// Gets statistics about the attachments in the document.
+        /// \returns The attachment statistics.
+        virtual AttachmentStatistics GetAttachmentStatistics() = 0;
 
         virtual ~IAttachmentRepository() = default;
     };

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -147,7 +147,7 @@ namespace libCZI
     /// \returns    The newly allocated bitmap containing the image from the sub-block.
     LIBCZI_API std::shared_ptr<IBitmapData>  CreateBitmapFromSubBlock(ISubBlock* subBlk, const CreateBitmapOptions* options = nullptr);
 
-    /// Creates a bitmap from raw compressed data, bypassing the need for an ISubBlock object.
+    /// Creates a bitmap from raw sub-block payload data, bypassing the need for an ISubBlock object.
     /// This is the low-level counterpart of CreateBitmapFromSubBlock, intended for cases where
     /// the compressed data and its associated metadata are already available separately.
     /// \param  compression_mode    The compression mode identifying the codec of the data pointed to by \p pv.
@@ -752,7 +752,7 @@ namespace libCZI
 
         /// Gets statistics about the attachments in the document.
         /// \returns The attachment statistics.
-        virtual AttachmentStatistics GetAttachmentStatistics() = 0;
+        virtual AttachmentStatistics GetAttachmentStatistics() const = 0;
 
         virtual ~IAttachmentRepository() = default;
     };

--- a/Src/libCZI/libCZI.h
+++ b/Src/libCZI/libCZI.h
@@ -147,6 +147,21 @@ namespace libCZI
     /// \returns    The newly allocated bitmap containing the image from the sub-block.
     LIBCZI_API std::shared_ptr<IBitmapData>  CreateBitmapFromSubBlock(ISubBlock* subBlk, const CreateBitmapOptions* options = nullptr);
 
+    /// Creates a bitmap from raw compressed data, bypassing the need for an ISubBlock object.
+    /// This is the low-level counterpart of CreateBitmapFromSubBlock, intended for cases where
+    /// the compressed data and its associated metadata are already available separately.
+    /// \param  compression_mode    The compression mode identifying the codec of the data pointed to by \p pv.
+    /// \param  pv                  Pointer to the compressed data; must not be null.
+    /// \param  size                The size of the compressed data in bytes.
+    /// \param  pixelType           The pixel type of the bitmap to be decoded.
+    /// \param  width               The width of the expected bitmap in pixels.
+    /// \param  height              The height of the expected bitmap in pixels.
+    /// \param  options             (Optional) Options for controlling the operation. This controls how discrepancies
+    ///                             between the actual pixel data and the specified dimensions are handled. This argument
+    ///                             may be null, in which case the resolution protocol is applied for all discrepancy types.
+    /// \returns    The newly allocated bitmap containing the decoded image data.
+    LIBCZI_API std::shared_ptr<IBitmapData> CreateBitmapFromSubBlockData(libCZI::CompressionMode compression_mode, const void* pv, size_t size, libCZI::PixelType pixelType, std::uint32_t width, std::uint32_t height, const CreateBitmapOptions* options = nullptr);
+
     /// Creates metadata-object from a metadata segment.
     /// \param [in] metadataSegment The metadata segment object.
     /// \return The newly created metadata object.

--- a/Src/libCZIAPI_UnitTests/CMakeLists.txt
+++ b/Src/libCZIAPI_UnitTests/CMakeLists.txt
@@ -24,4 +24,10 @@ TARGET_LINK_LIBRARIES(libCZIAPI_UnitTests PRIVATE libCZIAPIStatic GTest::gtest G
 target_compile_definitions(libCZIAPI_UnitTests PRIVATE _LIBCZISTATICLIB _LIBCZIAPISTATICLIB)
 target_include_directories(libCZIAPI_UnitTests PRIVATE ../libCZIAPI/inc ../libCZI "${RAPIDJSON_INCLUDE_DIRS}")
 
-add_test(NAME libCZIAPI_UnitTests COMMAND libCZIAPI_UnitTests)
+include(GoogleTest)
+
+if(CMAKE_CROSSCOMPILING)
+    add_test(NAME libCZIAPI_UnitTests COMMAND libCZIAPI_UnitTests)
+else()
+    gtest_discover_tests(libCZIAPI_UnitTests)
+endif()

--- a/Src/libCZI_UnitTests/CMakeLists.txt
+++ b/Src/libCZI_UnitTests/CMakeLists.txt
@@ -57,4 +57,10 @@ set_target_properties(libCZI_UnitTests PROPERTIES CXX_STANDARD 14)
 
 target_compile_definitions(libCZI_UnitTests PRIVATE _LIBCZISTATICLIB)
 
-add_test(NAME libCZI_UnitTests COMMAND libCZI_UnitTests)
+include(GoogleTest)
+
+if(CMAKE_CROSSCOMPILING)
+    add_test(NAME libCZI_UnitTests COMMAND libCZI_UnitTests)
+else()
+    gtest_discover_tests(libCZI_UnitTests)
+endif()

--- a/Src/libCZI_UnitTests/test_reader.cpp
+++ b/Src/libCZI_UnitTests/test_reader.cpp
@@ -1452,3 +1452,159 @@ TEST(CziReader, ReadSubBlockWithZstd1CompressionWithHiLoBytePackTooLargeDisableR
     options.handle_zstd_data_size_mismatch = false;
     EXPECT_THROW(sub_block->CreateBitmap(&options), exception);
 }
+
+TEST(CziReader, CreateBitmapFromSubBlockDataUncompressedMatchesCreateBitmapFromSubBlock)
+{
+    // arrange
+    const auto test_czi = CreateCziDocumentOneSubblock4x4Gray8();
+    const auto input_stream = CreateStreamFromMemory(get<0>(test_czi), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    const auto sub_block = reader->ReadSubBlock(0);
+    const auto& sub_block_info = sub_block->GetSubBlockInfo();
+
+    size_t data_size = 0;
+    const auto raw_data = sub_block->GetRawData(ISubBlock::MemBlkType::Data, &data_size);
+
+    // act
+    const auto bitmap_from_sub_block = sub_block->CreateBitmap();
+    const auto bitmap_from_data = CreateBitmapFromSubBlockData(
+        sub_block_info.GetCompressionMode(),
+        raw_data.get(),
+        data_size,
+        sub_block_info.pixelType,
+        sub_block_info.physicalSize.w,
+        sub_block_info.physicalSize.h);
+
+    // assert
+    EXPECT_TRUE(AreBitmapDataEqual(bitmap_from_sub_block, bitmap_from_data));
+}
+
+TEST(CziReader, CreateBitmapFromSubBlockDataUncompressedTooShortEnableResolutionAndCheckZeroFill)
+{
+    // arrange
+    const auto test_czi = CreateCziDocumentContainingOneSubblockWhichIsTooShort();
+    const auto input_stream = CreateStreamFromMemory(get<0>(test_czi), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    const auto sub_block = reader->ReadSubBlock(0);
+    const auto& sub_block_info = sub_block->GetSubBlockInfo();
+
+    size_t data_size = 0;
+    const auto raw_data = sub_block->GetRawData(ISubBlock::MemBlkType::Data, &data_size);
+
+    CreateBitmapOptions options;
+    options.handle_uncompressed_data_size_mismatch = true;
+
+    // act
+    const auto bitmap = CreateBitmapFromSubBlockData(
+        sub_block_info.GetCompressionMode(),
+        raw_data.get(),
+        data_size,
+        sub_block_info.pixelType,
+        sub_block_info.physicalSize.w,
+        sub_block_info.physicalSize.h,
+        &options);
+
+    // assert
+    ASSERT_EQ(bitmap->GetWidth(), 4);
+    ASSERT_EQ(bitmap->GetHeight(), 4);
+    ASSERT_EQ(bitmap->GetPixelType(), PixelType::Gray8);
+
+    ScopedBitmapLockerSP locked_bitmap{ bitmap };
+    const uint8_t* bitmap_pointer = static_cast<const uint8_t*>(locked_bitmap.ptrDataRoi);
+
+    for (int y = 0; y < 4; ++y)
+    {
+        for (int x = 0; x < 4; ++x)
+        {
+            const int linear_index = x + y * 4;
+            const uint8_t expected_value = linear_index <= 10 ? static_cast<uint8_t>(linear_index) : 0;
+            EXPECT_EQ(bitmap_pointer[x + static_cast<size_t>(y) * locked_bitmap.stride], expected_value);
+        }
+    }
+}
+
+TEST(CziReader, CreateBitmapFromSubBlockDataUncompressedTooShortDisableResolutionAndCheckException)
+{
+    // arrange
+    const auto test_czi = CreateCziDocumentContainingOneSubblockWhichIsTooShort();
+    const auto input_stream = CreateStreamFromMemory(get<0>(test_czi), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    const auto sub_block = reader->ReadSubBlock(0);
+    const auto& sub_block_info = sub_block->GetSubBlockInfo();
+
+    size_t data_size = 0;
+    const auto raw_data = sub_block->GetRawData(ISubBlock::MemBlkType::Data, &data_size);
+
+    CreateBitmapOptions options;
+    options.handle_uncompressed_data_size_mismatch = false;
+
+    // act/assert
+    EXPECT_THROW(
+        CreateBitmapFromSubBlockData(
+            sub_block_info.GetCompressionMode(),
+            raw_data.get(),
+            data_size,
+            sub_block_info.pixelType,
+            sub_block_info.physicalSize.w,
+            sub_block_info.physicalSize.h,
+            &options),
+        logic_error);
+}
+
+TEST(CziReader, CreateBitmapFromSubBlockDataZstd0TooSmallEnableResolutionAndCheckZeroFill)
+{
+    // arrange
+    const auto test_czi = CreateCziDocumentContainingOneSubblockZstd0CompressedWhichIsTooSmall();
+    const auto input_stream = CreateStreamFromMemory(get<0>(test_czi), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    const auto sub_block = reader->ReadSubBlock(0);
+    const auto& sub_block_info = sub_block->GetSubBlockInfo();
+
+    size_t data_size = 0;
+    const auto raw_data = sub_block->GetRawData(ISubBlock::MemBlkType::Data, &data_size);
+
+    CreateBitmapOptions options;
+    options.handle_zstd_data_size_mismatch = true;
+
+    // act
+    const auto bitmap = CreateBitmapFromSubBlockData(
+        sub_block_info.GetCompressionMode(),
+        raw_data.get(),
+        data_size,
+        sub_block_info.pixelType,
+        sub_block_info.physicalSize.w,
+        sub_block_info.physicalSize.h,
+        &options);
+
+    // assert
+    ASSERT_EQ(bitmap->GetWidth(), 4);
+    ASSERT_EQ(bitmap->GetHeight(), 4);
+    ASSERT_EQ(bitmap->GetPixelType(), PixelType::Gray8);
+
+    ScopedBitmapLockerSP locked_bitmap{ bitmap };
+    const uint8_t* bitmap_pointer = static_cast<const uint8_t*>(locked_bitmap.ptrDataRoi);
+
+    EXPECT_EQ(bitmap_pointer[0 + 0 * locked_bitmap.stride], 1);
+    EXPECT_EQ(bitmap_pointer[1 + 0 * locked_bitmap.stride], 2);
+    EXPECT_EQ(bitmap_pointer[2 + 0 * locked_bitmap.stride], 3);
+    EXPECT_EQ(bitmap_pointer[3 + 0 * locked_bitmap.stride], 4);
+    EXPECT_EQ(bitmap_pointer[0 + 1 * locked_bitmap.stride], 5);
+    EXPECT_EQ(bitmap_pointer[1 + 1 * locked_bitmap.stride], 6);
+
+    for (int y = 1; y < 4; ++y)
+    {
+        bitmap_pointer = static_cast<const uint8_t*>(locked_bitmap.ptrDataRoi) + static_cast<size_t>(y) * locked_bitmap.stride;
+        for (int x = y == 1 ? 2 : 0; x < 4; ++x)
+        {
+            EXPECT_EQ(bitmap_pointer[x], 0);
+        }
+    }
+}

--- a/Src/libCZI_UnitTests/test_readerwriter.cpp
+++ b/Src/libCZI_UnitTests/test_readerwriter.cpp
@@ -1548,6 +1548,7 @@ TEST(CziReaderWriter, TryGetSubBlockInfoOfArbitrarySubBlockInChannel)
     b = reader_writer->TryGetSubBlockInfoOfArbitrarySubBlockInChannel(1, sub_block_info);
     EXPECT_FALSE(b);
 }
+
 TEST(CziReaderWriter, AttachmentStatisticsEmptyDocument)
 {
     // arrange

--- a/Src/libCZI_UnitTests/test_readerwriter.cpp
+++ b/Src/libCZI_UnitTests/test_readerwriter.cpp
@@ -1548,3 +1548,36 @@ TEST(CziReaderWriter, TryGetSubBlockInfoOfArbitrarySubBlockInChannel)
     b = reader_writer->TryGetSubBlockInfoOfArbitrarySubBlockInChannel(1, sub_block_info);
     EXPECT_FALSE(b);
 }
+TEST(CziReaderWriter, AttachmentStatisticsEmptyDocument)
+{
+    // arrange
+    const auto test_czi = CreateTestCzi();
+
+    const auto input_stream = make_shared<CMemInputOutputStream>(get<0>(test_czi).get(), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    // act
+    const auto statistics = reader->GetAttachmentStatistics();
+
+    // assert
+    EXPECT_EQ(statistics.attachmentsCount, 0);
+    EXPECT_EQ(reader->GetAttachmentCount(), 0);
+}
+
+TEST(CziReaderWriter, AttachmentStatisticsOneAttachment)
+{
+    // arrange
+    const auto test_czi = CreateTestCzi2();
+
+    const auto input_stream = make_shared<CMemInputOutputStream>(get<0>(test_czi).get(), get<1>(test_czi));
+    const auto reader = CreateCZIReader();
+    reader->Open(input_stream);
+
+    // act
+    const auto statistics = reader->GetAttachmentStatistics();
+
+    // assert
+    EXPECT_EQ(statistics.attachmentsCount, 1);
+    EXPECT_EQ(reader->GetAttachmentCount(), 1);
+}

--- a/Src/libCZI_UnitTests/test_readerwriter.cpp
+++ b/Src/libCZI_UnitTests/test_readerwriter.cpp
@@ -1003,6 +1003,7 @@ TEST(CziReaderWriter, ReaderWriter12)
     EXPECT_TRUE(CheckNotOperationalException([&]()->void {rw->GetPyramidStatistics(); })) << "incorrect behavior";
 
     EXPECT_TRUE(CheckNotOperationalException([&]()->void {rw->ReadAttachment(0); })) << "incorrect behavior";
+    EXPECT_TRUE(CheckNotOperationalException([&]()->void { rw->GetAttachmentStatistics(); })) << "incorrect behavior";
 }
 
 TEST(CziReaderWriter, ReaderWriterUpdateGuid1)
@@ -1547,6 +1548,20 @@ TEST(CziReaderWriter, TryGetSubBlockInfoOfArbitrarySubBlockInChannel)
 
     b = reader_writer->TryGetSubBlockInfoOfArbitrarySubBlockInChannel(1, sub_block_info);
     EXPECT_FALSE(b);
+}
+
+TEST(CziReaderWriter, AttachmentStatisticsReaderWriterOneAttachment)
+{
+    const auto test_czi = CreateTestCzi2();
+
+    const auto input_stream = make_shared<CMemInputOutputStream>(get<0>(test_czi).get(), get<1>(test_czi));
+    const auto reader_writer = CreateCZIReaderWriter();
+    reader_writer->Create(input_stream);
+
+    const auto statistics = reader_writer->GetAttachmentStatistics();
+
+    EXPECT_EQ(statistics.attachmentsCount, 1);
+    EXPECT_EQ(reader_writer->GetAttachmentCount(), 1);
 }
 
 TEST(CziReaderWriter, AttachmentStatisticsEmptyDocument)

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -55,3 +55,4 @@ Version history
  0.67.4             | [159](https://github.com/ZEISS/libczi/pull/159)      | remove version requirement for external eigen3 package
  0.67.5             | [168](https://github.com/ZEISS/libczi/pull/168)      | fix bug with zstd1-decoding in case of pixeltype BGR48
  0.67.6             | [169](https://github.com/ZEISS/libczi/pull/169)      | fix CI/CD build
+ 0.68.0             | [170](https://github.com/ZEISS/libczi/pull/170)      | improve CMake packaging and downstream build integration; add small API additions

--- a/docs/source/pages/version_history.md
+++ b/docs/source/pages/version_history.md
@@ -55,4 +55,4 @@ Version history
  0.67.4             | [159](https://github.com/ZEISS/libczi/pull/159)      | remove version requirement for external eigen3 package
  0.67.5             | [168](https://github.com/ZEISS/libczi/pull/168)      | fix bug with zstd1-decoding in case of pixeltype BGR48
  0.67.6             | [169](https://github.com/ZEISS/libczi/pull/169)      | fix CI/CD build
- 0.68.0             | [170](https://github.com/ZEISS/libczi/pull/170)      | improve CMake packaging and downstream build integration; add small API additions
+ 0.68.0             | [171](https://github.com/ZEISS/libczi/pull/171)      | add bitmap creation from compressed subblock data and attachment statistics APIs; improve test integration and CI workflow


### PR DESCRIPTION
## Description

This PR contains preparatory changes and small API additions that are independent of the planned experimental chunked-compression work.

Summary of changes:

- Add `CreateBitmapFromSubBlockData`, a low-level helper for creating a bitmap directly from compressed subblock payload data and the required bitmap metadata.
- Refactor bitmap creation internals so decoding from an `ISubBlock` and decoding from raw subblock data can share the same implementation.
- Add `AttachmentStatistics` and `GetAttachmentStatistics()` support for attachment repositories.
- Improve unit-test registration for cross-compiling by using `gtest_discover_tests()` only when tests can be discovered by executing the test binary.
- Fix the Codecov workflow flag variable casing from `matrix.OS` to `matrix.os`.
- Switch CLI11 usage to the single-header include.
- Bump libCZI version to `0.68.0` and update the version history.
 
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

* locally
* CI/CD

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
