### PR TITLE
Enable chunked extensible compression mode in CZIcmd

### DIFF
--- a/Src/CZICmd/executeCreateCzi.cpp
+++ b/Src/CZICmd/executeCreateCzi.cpp
@@ -150,6 +150,31 @@ private:
                 addInfo.SetCompressionMode(CompressionMode::Zstd0);
                 writer->SyncAddSubBlock(addInfo);
             }
+#if LIBCZI_EXPERIMENTAL_CHUNKED_COMPRESSION_AVAILABLE
+            else if (options.GetCompressionMode() == CompressionMode::ChunkedExtensible)
+            {
+                auto memblk = ChunkedCompress::CompressToMemoryBlock(bm->GetWidth(), bm->GetHeight(), locker.stride, bm->GetPixelType(), locker.ptrDataRoi, options.GetCompressionParameters().get());
+
+                AddSubBlockInfoMemPtr addInfo;
+                addInfo.Clear();
+                addInfo.coordinate = coord;
+                addInfo.mIndexValid = true;
+                addInfo.mIndex = m;
+                addInfo.x = x;
+                addInfo.y = y;
+                addInfo.logicalWidth = bm->GetWidth();
+                addInfo.logicalHeight = bm->GetHeight();
+                addInfo.physicalWidth = bm->GetWidth();
+                addInfo.physicalHeight = bm->GetHeight();
+                addInfo.PixelType = bm->GetPixelType();
+                addInfo.ptrData = memblk->GetPtr();
+                addInfo.dataSize = memblk->GetSizeOfData();
+                addInfo.ptrSbBlkMetadata = sbBlkMetadata;
+                addInfo.sbBlkMetadataSize = sbBlkMetadataSize;
+                addInfo.SetCompressionMode(CompressionMode::ChunkedExtensible);
+                writer->SyncAddSubBlock(addInfo);
+            }
+#endif
         }
     }
 }


### PR DESCRIPTION
# STOP - Read this First!
Reporting a security vulnerability?  
Check out the project's [security policy](https://github.com/zeiss/libczi/security/policy).

## Description

Enable chunked extensible compression mode in `CZIcmd`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`CZIcmd.exe -c CreateCZI -o test_chunked_lz4 --compressionopts "chunked:ChunkedMaxChunkSize=32768;ChunkedCodec=lz4;PreProcess=HiLoByteUnpack"`

## Checklist:

- [ ] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of libCZI following [Versioning of libCZI](https://zeiss.github.io/libczi/index.html#autotoc_md0) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
